### PR TITLE
feat(log): log to slog, closes #11

### DIFF
--- a/cmd/open-sspm/migrate.go
+++ b/cmd/open-sspm/migrate.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"errors"
-	"log"
+	"log/slog"
 
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
@@ -30,13 +30,13 @@ var migrateCmd = &cobra.Command{
 
 		if err := m.Up(); err != nil {
 			if errors.Is(err, migrate.ErrNoChange) {
-				log.Println("No changes to apply")
+				slog.Info("no changes to apply")
 				return nil
 			}
 			return err
 		}
 
-		log.Println("Migrations applied successfully")
+		slog.Info("migrations applied successfully")
 		return nil
 	},
 }

--- a/cmd/open-sspm/seed_rules.go
+++ b/cmd/open-sspm/seed_rules.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -63,7 +63,7 @@ func runSeedRules(ctx context.Context) error {
 		return err
 	}
 
-	log.Printf("seeded %d rulesets", len(loaded))
+	slog.Info("seeded rulesets", "count", len(loaded))
 	return nil
 }
 
@@ -260,7 +260,7 @@ func seedRuleset(ctx context.Context, q *gen.Queries, ls LoadedRuleset) error {
 		return fmt.Errorf("deactivate missing rules for ruleset %s: %w", def.Key, err)
 	}
 
-	log.Printf("seeded ruleset %s (%d rules)", def.Key, len(ls.Rules))
+	slog.Info("seeded ruleset", "key", def.Key, "rules", len(ls.Rules))
 	return nil
 }
 

--- a/cmd/open-sspm/serve.go
+++ b/cmd/open-sspm/serve.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"errors"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -91,7 +91,7 @@ func runServe() error {
 
 	errCh := make(chan error, 1)
 	go func() {
-		log.Printf("listening on %s", cfg.HTTPAddr)
+		slog.Info("listening", "addr", cfg.HTTPAddr)
 		errCh <- srv.StartServer(httpServer)
 	}()
 

--- a/cmd/open-sspm/worker.go
+++ b/cmd/open-sspm/worker.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"errors"
-	"log"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -71,7 +71,7 @@ func runWorker() error {
 	runner := sync.NewDBRunner(pool, reg)
 	runner.SetReporter(&sync.LogReporter{})
 
-	log.Printf("sync worker started (interval=%s)", cfg.SyncInterval.String())
+	slog.Info("sync worker started", "interval", cfg.SyncInterval)
 	scheduler := sync.Scheduler{Runner: runner, Interval: cfg.SyncInterval}
 	scheduler.Run(ctx)
 	return nil

--- a/internal/connectors/aws/integration.go
+++ b/internal/connectors/aws/integration.go
@@ -3,7 +3,7 @@ package aws
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -41,7 +41,7 @@ func (i *AWSIntegration) InitEvents() []registry.Event {
 
 func (i *AWSIntegration) Run(ctx context.Context, deps registry.IntegrationDeps) error {
 	started := time.Now()
-	log.Println("Syncing AWS Identity Center")
+	slog.Info("syncing AWS Identity Center")
 
 	runID, err := deps.Q.CreateSyncRun(ctx, gen.CreateSyncRunParams{
 		SourceKind: "aws",
@@ -190,7 +190,7 @@ func (i *AWSIntegration) Run(ctx context.Context, deps registry.IntegrationDeps)
 		registry.FailSyncRun(ctx, deps.Q, runID, err, registry.SyncErrorKindDB)
 		return err
 	}
-	log.Printf("aws sync complete: %d users", len(users))
+	slog.Info("aws sync complete", "users", len(users))
 	return nil
 }
 

--- a/internal/connectors/datadog/datadog.go
+++ b/internal/connectors/datadog/datadog.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -324,13 +324,13 @@ func mapUser(raw json.RawMessage) (User, error) {
 	}
 	lastLoginAt, err := parseOptionalRFC3339Time(payload.Attributes.LastLoginAt)
 	if err != nil {
-		log.Printf("datadog: user %s: last_login_at parse failed: %v", strings.TrimSpace(payload.ID), err)
+		slog.Warn("datadog user last_login_at parse failed", "user_id", strings.TrimSpace(payload.ID), "err", err)
 		lastLoginAt = nil
 	}
 	if lastLoginAt == nil {
 		lastLoginAt, err = parseOptionalRFC3339Time(payload.Attributes.LastLogin)
 		if err != nil {
-			log.Printf("datadog: user %s: last_login parse failed: %v", strings.TrimSpace(payload.ID), err)
+			slog.Warn("datadog user last_login parse failed", "user_id", strings.TrimSpace(payload.ID), "err", err)
 			lastLoginAt = nil
 		}
 	}

--- a/internal/connectors/datadog/integration.go
+++ b/internal/connectors/datadog/integration.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 	gosync "sync"
 	"sync/atomic"
@@ -49,7 +49,7 @@ func (i *DatadogIntegration) InitEvents() []registry.Event {
 
 func (i *DatadogIntegration) Run(ctx context.Context, deps registry.IntegrationDeps) error {
 	started := time.Now()
-	log.Println("Syncing Datadog")
+	slog.Info("syncing Datadog")
 
 	runID, err := deps.Q.CreateSyncRun(ctx, gen.CreateSyncRunParams{
 		SourceKind: "datadog",
@@ -292,7 +292,7 @@ func (i *DatadogIntegration) Run(ctx context.Context, deps registry.IntegrationD
 		registry.FailSyncRun(ctx, deps.Q, runID, err, registry.SyncErrorKindDB)
 		return err
 	}
-	log.Printf("datadog sync complete: %d users", len(users))
+	slog.Info("datadog sync complete", "users", len(users))
 	return nil
 }
 

--- a/internal/connectors/entra/integration.go
+++ b/internal/connectors/entra/integration.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -40,7 +40,7 @@ func (i *EntraIntegration) InitEvents() []registry.Event {
 
 func (i *EntraIntegration) Run(ctx context.Context, deps registry.IntegrationDeps) error {
 	started := time.Now()
-	log.Println("Syncing Microsoft Entra ID")
+	slog.Info("syncing Microsoft Entra ID")
 
 	runID, err := deps.Q.CreateSyncRun(ctx, gen.CreateSyncRunParams{
 		SourceKind: "entra",
@@ -148,7 +148,7 @@ func (i *EntraIntegration) Run(ctx context.Context, deps registry.IntegrationDep
 		registry.FailSyncRun(ctx, deps.Q, runID, err, registry.SyncErrorKindDB)
 		return err
 	}
-	log.Printf("entra sync complete: %d users", len(externalIDs))
+	slog.Info("entra sync complete", "users", len(externalIDs))
 	return nil
 }
 

--- a/internal/connectors/okta/integration.go
+++ b/internal/connectors/okta/integration.go
@@ -3,7 +3,7 @@ package okta
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -103,7 +103,7 @@ func (i *OktaIntegration) Run(ctx context.Context, deps registry.IntegrationDeps
 		return err
 	}
 
-	log.Printf("okta sync complete: %d users", len(users))
+	slog.Info("okta sync complete", "users", len(users))
 	return nil
 }
 
@@ -141,7 +141,7 @@ func (i *OktaIntegration) EvaluateCompliance(ctx context.Context, deps registry.
 		EvaluatedAt: time.Now(),
 	}); err != nil {
 		err = fmt.Errorf("okta v1 ruleset evaluations: %w", err)
-		log.Println(err)
+		slog.Error("okta ruleset evaluations failed", "err", err)
 		deps.Report(registry.Event{Source: "okta", Stage: "evaluate-rules", Current: 1, Total: 1, Message: err.Error(), Err: err})
 		return nil
 	}

--- a/internal/http/handlers/users.go
+++ b/internal/http/handlers/users.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path"
@@ -1396,7 +1396,7 @@ func datadogUserStatus(appUserID int64, externalID string, rawJSON []byte) strin
 		Status string `json:"status"`
 	}
 	if err := json.Unmarshal(rawJSON, &payload); err != nil {
-		log.Printf("datadog: app_user_id=%d external_id=%s: unable to parse user raw_json: %v", appUserID, strings.TrimSpace(externalID), err)
+		slog.Warn("datadog user raw_json parse failed", "app_user_id", appUserID, "external_id", strings.TrimSpace(externalID), "err", err)
 		return ""
 	}
 	return strings.TrimSpace(payload.Status)

--- a/internal/sync/db_runner.go
+++ b/internal/sync/db_runner.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -70,7 +70,7 @@ func (r *DBRunner) RunOnce(ctx context.Context) error {
 
 		def, ok := r.registry.Get(kind)
 		if !ok {
-			log.Printf("unknown connector kind %q skipped", kind)
+			slog.Warn("unknown connector kind skipped", "kind", kind)
 			skippedKinds = append(skippedKinds, kind)
 			continue
 		}

--- a/internal/sync/log_reporter.go
+++ b/internal/sync/log_reporter.go
@@ -1,20 +1,25 @@
 package sync
 
 import (
-	"log"
+	"log/slog"
 
 	"github.com/open-sspm/open-sspm/internal/connectors/registry"
 )
 
-// LogReporter is a simple reporter that logs events to the standard logger.
+// LogReporter is a simple reporter that logs events to the default slog logger.
 type LogReporter struct{}
 
 func (r *LogReporter) Report(e registry.Event) {
 	if e.Message != "" {
+		attrs := []any{"source", e.Source}
+		if e.Stage != "" {
+			attrs = append(attrs, "stage", e.Stage)
+		}
 		if e.Err != nil {
-			log.Printf("[%s] %s: %v", e.Source, e.Message, e.Err)
+			attrs = append(attrs, "err", e.Err)
+			slog.Error(e.Message, attrs...)
 		} else {
-			log.Printf("[%s] %s", e.Source, e.Message)
+			slog.Info(e.Message, attrs...)
 		}
 	}
 }

--- a/internal/sync/scheduler.go
+++ b/internal/sync/scheduler.go
@@ -2,7 +2,7 @@ package sync
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"time"
 )
 
@@ -18,7 +18,7 @@ func (s *Scheduler) Run(ctx context.Context) {
 
 	// Run immediately at startup.
 	if err := s.Runner.RunOnce(ctx); err != nil {
-		log.Println("initial sync failed:", err)
+		slog.Error("initial sync failed", "err", err)
 	}
 
 	ticker := time.NewTicker(s.Interval)
@@ -29,7 +29,7 @@ func (s *Scheduler) Run(ctx context.Context) {
 			return
 		case <-ticker.C:
 			if err := s.Runner.RunOnce(ctx); err != nil {
-				log.Println("scheduled sync failed:", err)
+				slog.Error("scheduled sync failed", "err", err)
 			}
 		}
 	}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR successfully migrates the logging infrastructure from Go's standard `log` package to the structured logging package `log/slog` (introduced in Go 1.21). The migration is comprehensive and consistent across the codebase.

## Key Changes
- **Structured logging**: All log statements now use key-value pairs for context (e.g., `slog.Info("message", "key", value)`) instead of printf-style formatting
- **Consistent log levels**: Appropriately uses `slog.Info`, `slog.Warn`, and `slog.Error` based on severity
- **Better observability**: Structured attributes make logs more machine-readable and easier to query in logging systems
- **Code quality**: Some long log statements in `internal/connectors/github/integration.go` were reformatted across multiple lines for better readability

## Scope
The migration touches 15 files across:
- CLI commands (`cmd/open-sspm/*`)
- Sync orchestration (`internal/sync/*`)
- All connector integrations (`internal/connectors/*`)
- HTTP handlers (`internal/http/handlers/users.go`)

The changes are purely mechanical refactoring with no functional changes to business logic.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no identified issues
- This is a clean, mechanical refactoring that migrates from `log` to `log/slog` with no changes to business logic. All changes follow consistent patterns, use appropriate log levels, and maintain the same information content. The structured logging approach is a best practice that improves observability.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/sync/log_reporter.go | Migrated from `log` to `log/slog` with structured logging using key-value attributes for source, stage, and errors |
| internal/sync/orchestrator.go | Replaced all `log.Printf` calls with `slog.Info` and `slog.Error` using structured attributes |
| internal/connectors/github/integration.go | Migrated from `log.Printf` to `slog` with structured logging, improved formatting by splitting long log statements across multiple lines |
| internal/connectors/datadog/datadog.go | Replaced `log.Printf` with `slog.Warn` for parsing errors, using structured attributes |
| cmd/open-sspm/migrate.go | Updated to use `slog.Info` for migration status messages |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application Entry Point
    participant Logger as log/slog Logger
    participant Reporter as LogReporter
    participant Orch as Orchestrator
    participant Integ as Integrations
    
    App->>Logger: Import log/slog
    App->>Logger: slog.Info("starting...")
    
    Note over App,Integ: Sync Operation Flow
    
    App->>Reporter: SetReporter(&LogReporter{})
    Reporter->>Logger: Uses slog for output
    
    App->>Orch: RunOnce(ctx)
    Orch->>Logger: slog.Info("matching auto-linking...")
    
    loop For each integration
        Orch->>Integ: Run(ctx, deps)
        Integ->>Logger: slog.Info("syncing [connector]")
        Integ->>Reporter: Report(Event{...})
        Reporter->>Logger: slog.Info/Error with structured attrs
        Integ->>Logger: slog.Info("sync complete")
    end
    
    Orch->>Logger: slog.Error("sync failed") on error
    Orch->>Logger: slog.Info("sync complete") on success
    
    Note over Logger: All logs use structured<br/>key-value attributes
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->