### PR TITLE
fix(demo): fix demo deployment

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -126,9 +126,7 @@ jobs:
             exit 1
           fi
 
-          sudo -u postgres psql -v ON_ERROR_STOP=1 -d postgres -v db_name="${db_name}" -c \
-            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = :'db_name' AND pid <> pg_backend_pid();"
-          sudo -u postgres dropdb --if-exists "${db_name}"
+          sudo -u postgres dropdb --if-exists --force "${db_name}"
           sudo -u postgres createdb -O "${db_user}" "${db_name}"
 
           /usr/local/bin/open-sspm migrate


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Replaced manual database connection termination with `dropdb --force` flag for cleaner deployment script.

- Simplified database reset from two commands to one
- The `--force` flag automatically terminates active connections before dropping the database
- Functionally equivalent to the previous approach but more maintainable

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The change is a simple refactoring that uses a built-in PostgreSQL flag to achieve the same result as the previous manual approach, with no functional changes or risks
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-demo.yml | Simplified database drop logic by using `--force` flag instead of manual connection termination |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant SSH as SSH Session
    participant PG as PostgreSQL
    participant SYS as systemd

    GHA->>SSH: Deploy artifact & execute script
    SSH->>SYS: Stop open-sspm service
    SSH->>PG: dropdb --if-exists --force db_name
    Note over PG: Terminates active connections<br/>& drops database
    SSH->>PG: createdb -O db_user db_name
    SSH->>SSH: Run migrations & seed data
    SSH->>SYS: Restart open-sspm service
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->