### PR TITLE
fix(deploy): fix css

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ DATABASE_URL=postgres://postgres:postgres@localhost:5432/opensspm?sslmode=disabl
 
 # Server
 HTTP_ADDR=:8080
+# Optional: absolute path to the built static assets directory (e.g. /opt/open-sspm/web/static).
+# When unset, the server tries to locate web/static relative to the current working directory.
+# STATIC_DIR=
 AUTH_COOKIE_SECURE=0
 RESYNC_ENABLED=1
 RESYNC_MODE=inline

--- a/demo/infra/DEPLOYMENT.md
+++ b/demo/infra/DEPLOYMENT.md
@@ -5,9 +5,11 @@ Target:
 - `open-sspm` runs as a systemd service and serves HTTP on `127.0.0.1:8080`
 - nginx listens on `:80` and reverse-proxies to `open-sspm`
 
-This repo currently expects **runtime files** to exist next to the binary:
+This repo expects **runtime files** to exist on disk:
 - static assets: `web/static/` (CSS build output must be present)
 - migrations: `db/migrations/` (used by `open-sspm migrate`)
+
+By default the server serves static assets from `web/static` relative to its working directory, or you can set `STATIC_DIR` (recommended for systemd installs).
 
 The Ansible bootstrap creates an empty working directory at:
 - `/opt/open-sspm/web/static`

--- a/demo/infra/ansible/site.yml
+++ b/demo/infra/ansible/site.yml
@@ -86,6 +86,7 @@
         content: |
           DATABASE_URL=postgres://{{ opensspm_db_user }}:{{ opensspm_db_password }}@localhost:5432/{{ opensspm_db_name }}?sslmode=disable
           HTTP_ADDR=127.0.0.1:8080
+          STATIC_DIR=/opt/open-sspm/web/static
           SYNC_INTERVAL=0s
           RESYNC_ENABLED=0
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ const (
 type Config struct {
 	DatabaseURL           string
 	HTTPAddr              string
+	StaticDir             string
 	AuthCookieSecure      bool
 	DevSeedAdmin          bool
 	SyncInterval          time.Duration
@@ -62,6 +63,7 @@ func LoadWithOptions(opts LoadOptions) (Config, error) {
 	cfg := Config{
 		DatabaseURL:        os.Getenv("DATABASE_URL"),
 		HTTPAddr:           getenvDefault("HTTP_ADDR", defaultHTTPAddr),
+		StaticDir:          strings.TrimSpace(os.Getenv("STATIC_DIR")),
 		AuthCookieSecure:   getenvBoolDefault("AUTH_COOKIE_SECURE", false),
 		DevSeedAdmin:       getenvBoolDefault("DEV_SEED_ADMIN", false),
 		SyncInterval:       defaultSyncInterval,


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR adds support for configurable static assets directory via the `STATIC_DIR` environment variable to fix CSS loading issues in deployment scenarios.

## What Changed

The PR introduces a new optional `STATIC_DIR` configuration that allows operators to specify an absolute path to the static assets directory. This addresses deployment scenarios where the application binary and static assets are in different locations, particularly in systemd-managed installations.

**Key improvements:**
- **New config field**: Added `StaticDir` to the Config struct, loaded from the `STATIC_DIR` environment variable
- **Smart path resolution**: Implemented `resolveStaticDir()` function that searches multiple candidate locations in order:
  1. Explicitly configured `STATIC_DIR` (if set)
  2. `web/static` relative to current working directory
  3. `web/static` relative to executable location
  4. `web/static` in parent directory of executable
  5. `/opt/open-sspm/web/static` (common deployment location)
- **Improved logging**: Added info/warn logs to indicate whether static assets directory was found
- **Deployment updates**: Updated Ansible playbook to set `STATIC_DIR=/opt/open-sspm/web/static` in the systemd environment file
- **Documentation**: Updated `.env.example` and `DEPLOYMENT.md` to document the new configuration option

## How It Integrates

The change fits well with the existing codebase architecture:
- Follows the established pattern of environment-based configuration in `internal/config/config.go`
- Uses standard library functions (`filepath.Clean`, `os.Stat`) for path validation
- Maintains backward compatibility: when `STATIC_DIR` is unset, the server falls back to checking relative paths
- Consistent with the deployment model where systemd runs the binary from `/usr/local/bin/` but static assets are in `/opt/open-sspm/`

The implementation handles edge cases well (empty strings, whitespace, path normalization) and provides graceful degradation - even if the directory isn't found, the server starts and logs a warning rather than failing.

### Confidence Score: 5/5

- This PR is safe to merge with no identified issues
- After thorough analysis of all 5 changed files and extensive exploration of the codebase, I found no bugs, security vulnerabilities, or logic errors. The implementation properly handles edge cases (whitespace, empty strings, path traversal via filepath.Clean, relative vs absolute paths), maintains consistency across all deployment configurations (Ansible, Docker, GitHub Actions), and follows Go best practices. The fallback logic is well-designed with appropriate logging. All deployment paths are consistent (/opt/open-sspm/web/static for systemd, /home/appuser/web/static for Docker with relative path fallback).
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .env.example | 5/5 | Added documentation for new optional STATIC_DIR configuration variable |
| demo/infra/DEPLOYMENT.md | 5/5 | Updated documentation to clarify static assets location and STATIC_DIR usage for systemd installs |
| demo/infra/ansible/site.yml | 5/5 | Added STATIC_DIR=/opt/open-sspm/web/static to environment configuration for systemd service |
| internal/config/config.go | 5/5 | Added StaticDir field to Config struct and loaded from STATIC_DIR environment variable with trimming |
| internal/http/server.go | 5/5 | Implemented resolveStaticDir function with multi-path fallback logic and added logging for static asset directory resolution |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Systemd
    participant Config
    participant Server
    participant ResolveStatic
    participant FileSystem
    participant Echo

    User->>Systemd: systemctl start open-sspm
    Systemd->>Config: Load /etc/open-sspm.env
    Note over Config: STATIC_DIR=/opt/open-sspm/web/static
    
    Config->>Server: Initialize with Config.StaticDir
    Server->>ResolveStatic: resolveStaticDir(Config.StaticDir)
    
    alt STATIC_DIR is set
        ResolveStatic->>ResolveStatic: Add preferred path to candidates
    end
    
    ResolveStatic->>ResolveStatic: Add "web/static" to candidates
    ResolveStatic->>FileSystem: os.Executable()
    FileSystem-->>ResolveStatic: /usr/local/bin/open-sspm
    ResolveStatic->>ResolveStatic: Add exe-relative paths to candidates
    ResolveStatic->>ResolveStatic: Add /opt/open-sspm/web/static
    ResolveStatic->>ResolveStatic: Deduplicate with filepath.Clean
    
    loop For each candidate
        ResolveStatic->>FileSystem: os.Stat(candidate)
        alt Directory exists
            FileSystem-->>ResolveStatic: IsDir() = true
            ResolveStatic-->>Server: (path, ok=true)
            Server->>Server: slog.Info("serving static assets")
            Note over Server: Break loop on first match
        end
    end
    
    alt No directory found
        ResolveStatic-->>Server: (fallback_path, ok=false)
        Server->>Server: slog.Warn("directory not found")
    end
    
    Server->>Echo: Static("/static", staticDir)
    Note over Echo: Registers static file handler
    
    User->>Echo: GET /static/app.css
    Echo->>FileSystem: Read staticDir + "/app.css"
    FileSystem-->>Echo: File contents
    Echo-->>User: 200 OK with CSS
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->