### PR TITLE
chore(github): disable code quality for templ generated files, closes #32

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,5 +1,4 @@
 name: "Open-SSPM CodeQL config"
 paths-ignore:
   - "**/*_templ.go"
-  - "**/*.templ.go"
   - "internal/db/gen/**/*.go"


### PR DESCRIPTION
… #32

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR adds a CodeQL configuration file to exclude templ-generated files from code quality analysis, addressing issue #32. The configuration is placed in the standard location (`.github/codeql/codeql-config.yml`) and uses the `paths-ignore` directive to exclude generated template files.

## Key Changes
- Adds new CodeQL configuration file with two exclusion patterns for templ-generated Go files
- Excludes `**/*_templ.go` pattern (matches 29 files in `internal/http/views/`)
- Includes `**/*.templ.go` pattern (currently matches 0 files)

## Observations
1. **Pattern redundancy**: The `**/*.templ.go` pattern doesn't match any existing files. All templ-generated files in the codebase use underscore naming (`*_templ.go`), not dot notation.

2. **Missing similar exclusions**: The repository also contains SQLC-generated files in `internal/db/gen/` with "DO NOT EDIT" headers, which could benefit from similar exclusion treatment for consistency.

3. **Configuration usage**: Note that this configuration file will only be used if CodeQL is enabled via GitHub Advanced Security settings or through a GitHub Actions workflow (no workflow currently references this config).

The core functionality works correctly - the `**/*_templ.go` pattern will properly exclude the 29 templ-generated files from analysis.

### Confidence Score: 4/5

- This PR is safe to merge with minor optimization opportunities
- The PR successfully addresses its stated goal of excluding templ-generated files from CodeQL analysis. The main pattern works correctly and will exclude all 29 generated template files. The issues identified are minor: one redundant pattern that has no negative impact, and a suggestion to add SQLC exclusions for consistency. The configuration syntax is valid and follows CodeQL standards.
- No files require special attention - the configuration is straightforward and functional

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/codeql/codeql-config.yml | 3/5 | New CodeQL config excludes templ-generated files, but has redundant pattern and missing SQLC exclusions |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Templ as Templ Generator
    participant GH as GitHub
    participant CodeQL as CodeQL Scanner
    participant Config as codeql-config.yml

    Dev->>Templ: make templ (generate templates)
    Templ->>Templ: Read *.templ files
    Templ->>GH: Generate *_templ.go files (29 files)
    Note over Templ,GH: Generated files have<br/>"DO NOT EDIT" headers
    
    Dev->>GH: git push (commit changes)
    GH->>CodeQL: Trigger code scanning
    CodeQL->>Config: Load exclusion patterns
    Config-->>CodeQL: paths-ignore:<br/>- **/*_templ.go<br/>- **/*.templ.go
    
    CodeQL->>CodeQL: Match **/*_templ.go pattern
    Note over CodeQL: Excludes 29 generated<br/>template files
    
    CodeQL->>CodeQL: Match **/*.templ.go pattern
    Note over CodeQL: No files matched<br/>(redundant pattern)
    
    CodeQL->>GH: Analyze remaining Go files
    Note over CodeQL,GH: Templ-generated files<br/>excluded from analysis
    
    GH->>Dev: Report code quality results
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->