### PR TITLE
fix(helm): Added sidecar.istio.io/inject: false to the three hook Job…

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -13,6 +13,7 @@ Deploys:
   - `open-sspm migrate` as a pre-install/pre-upgrade Job
   - `open-sspm seed-rules` as a pre-install Job (optionally also pre-upgrade)
   - `open-sspm users bootstrap-admin` as a pre-install Job (optionally also pre-upgrade; disabled by default)
+  - Hook Jobs disable Istio sidecar injection to avoid hangs in Istio-injection-enabled namespaces.
 
 This chart assumes a **managed Postgres** (RDS, Cloud SQL, etc). It does **not** deploy Postgres.
 

--- a/helm/open-sspm/templates/job-bootstrap-admin.yaml
+++ b/helm/open-sspm/templates/job-bootstrap-admin.yaml
@@ -24,6 +24,8 @@ spec:
       labels:
         {{- include "open-sspm.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: bootstrap-admin
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       restartPolicy: Never
       {{- if or (not .Values.serviceAccount.create) (not .Release.IsInstall) }}

--- a/helm/open-sspm/templates/job-migrate.yaml
+++ b/helm/open-sspm/templates/job-migrate.yaml
@@ -20,6 +20,8 @@ spec:
       labels:
         {{- include "open-sspm.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: migrate
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       restartPolicy: Never
       {{- if or (not .Values.serviceAccount.create) (not .Release.IsInstall) }}

--- a/helm/open-sspm/templates/job-seed-rules.yaml
+++ b/helm/open-sspm/templates/job-seed-rules.yaml
@@ -24,6 +24,8 @@ spec:
       labels:
         {{- include "open-sspm.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: seed-rules
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       restartPolicy: Never
       {{- if or (not .Values.serviceAccount.create) (not .Release.IsInstall) }}


### PR DESCRIPTION
… pod templates

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added `sidecar.istio.io/inject: "false"` annotation to all three Helm hook Job pod templates (`job-migrate.yaml`, `job-seed-rules.yaml`, `job-bootstrap-admin.yaml`) to prevent Jobs from hanging when deployed in Istio service mesh-enabled namespaces.

- Prevents Istio sidecar proxy injection into short-lived hook Jobs
- Ensures Jobs can complete and exit cleanly without waiting for sidecar termination
- Documentation updated in `helm/README.md` to explain the behavior
- Standard best practice for Kubernetes Jobs in Istio environments

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The changes follow Kubernetes and Istio best practices for Jobs. The annotation syntax is correct, placement is appropriate, and the change is well-documented. No logical or security issues introduced.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| helm/open-sspm/templates/job-migrate.yaml | Added Istio sidecar injection annotation to prevent hook Job hangs |
| helm/open-sspm/templates/job-seed-rules.yaml | Added Istio sidecar injection annotation to prevent hook Job hangs |
| helm/open-sspm/templates/job-bootstrap-admin.yaml | Added Istio sidecar injection annotation to prevent hook Job hangs |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Helm
    participant K8s as Kubernetes API
    participant Istio as Istio Control Plane
    participant MigrateJob as Migrate Job Pod
    participant SeedJob as Seed-Rules Job Pod
    participant BootstrapJob as Bootstrap-Admin Job Pod
    participant DB as Postgres Database

    Note over Helm,DB: Helm Install/Upgrade initiated

    Helm->>K8s: Create Job: migrate (hook-weight: 0)
    Note over MigrateJob: Pod annotation:<br/>sidecar.istio.io/inject: "false"
    K8s->>MigrateJob: Start migrate pod
    Note over Istio,MigrateJob: Istio skips sidecar injection
    MigrateJob->>DB: Run database migrations
    DB-->>MigrateJob: Migrations complete
    MigrateJob->>K8s: Pod exits successfully

    Helm->>K8s: Create Job: seed-rules (hook-weight: 1)
    Note over SeedJob: Pod annotation:<br/>sidecar.istio.io/inject: "false"
    K8s->>SeedJob: Start seed-rules pod
    Note over Istio,SeedJob: Istio skips sidecar injection
    SeedJob->>DB: Upsert benchmark rules
    DB-->>SeedJob: Rules seeded
    SeedJob->>K8s: Pod exits successfully

    Helm->>K8s: Create Job: bootstrap-admin (hook-weight: 2, if enabled)
    Note over BootstrapJob: Pod annotation:<br/>sidecar.istio.io/inject: "false"
    K8s->>BootstrapJob: Start bootstrap-admin pod
    Note over Istio,BootstrapJob: Istio skips sidecar injection
    BootstrapJob->>DB: Create admin user (idempotent)
    DB-->>BootstrapJob: Admin user created/exists
    BootstrapJob->>K8s: Pod exits successfully

    Note over Helm,DB: All hooks succeeded, proceed with main deployment
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->