### PR TITLE
chore(cleanup): some cleanup which is needed

### DIFF
--- a/cmd/open-sspm/connectors.go
+++ b/cmd/open-sspm/connectors.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"github.com/open-sspm/open-sspm/internal/config"
+	"github.com/open-sspm/open-sspm/internal/connectors/aws"
+	"github.com/open-sspm/open-sspm/internal/connectors/datadog"
+	"github.com/open-sspm/open-sspm/internal/connectors/entra"
+	"github.com/open-sspm/open-sspm/internal/connectors/github"
+	"github.com/open-sspm/open-sspm/internal/connectors/okta"
+	"github.com/open-sspm/open-sspm/internal/connectors/registry"
+	"github.com/open-sspm/open-sspm/internal/connectors/vault"
+)
+
+func buildConnectorRegistry(cfg config.Config) (*registry.ConnectorRegistry, error) {
+	reg := registry.NewRegistry()
+	if err := reg.Register(okta.NewDefinition(cfg.SyncOktaWorkers)); err != nil {
+		return nil, err
+	}
+	if err := reg.Register(&entra.Definition{}); err != nil {
+		return nil, err
+	}
+	if err := reg.Register(github.NewDefinition(cfg.SyncGitHubWorkers)); err != nil {
+		return nil, err
+	}
+	if err := reg.Register(datadog.NewDefinition(cfg.SyncDatadogWorkers)); err != nil {
+		return nil, err
+	}
+	if err := reg.Register(&aws.Definition{}); err != nil {
+		return nil, err
+	}
+	if err := reg.Register(&vault.Definition{}); err != nil {
+		return nil, err
+	}
+	return reg, nil
+}

--- a/cmd/open-sspm/serve.go
+++ b/cmd/open-sspm/serve.go
@@ -14,13 +14,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/open-sspm/open-sspm/internal/auth"
 	"github.com/open-sspm/open-sspm/internal/config"
-	"github.com/open-sspm/open-sspm/internal/connectors/aws"
-	"github.com/open-sspm/open-sspm/internal/connectors/datadog"
-	"github.com/open-sspm/open-sspm/internal/connectors/entra"
-	"github.com/open-sspm/open-sspm/internal/connectors/github"
-	"github.com/open-sspm/open-sspm/internal/connectors/okta"
-	"github.com/open-sspm/open-sspm/internal/connectors/registry"
-	"github.com/open-sspm/open-sspm/internal/connectors/vault"
 	"github.com/open-sspm/open-sspm/internal/db/gen"
 	httpapp "github.com/open-sspm/open-sspm/internal/http"
 	"github.com/open-sspm/open-sspm/internal/http/handlers"
@@ -61,23 +54,8 @@ func runServe() error {
 		}
 	}
 
-	reg := registry.NewRegistry()
-	if err := reg.Register(okta.NewDefinition(cfg.SyncOktaWorkers)); err != nil {
-		return err
-	}
-	if err := reg.Register(&entra.Definition{}); err != nil {
-		return err
-	}
-	if err := reg.Register(github.NewDefinition(cfg.SyncGitHubWorkers)); err != nil {
-		return err
-	}
-	if err := reg.Register(datadog.NewDefinition(cfg.SyncDatadogWorkers)); err != nil {
-		return err
-	}
-	if err := reg.Register(&aws.Definition{}); err != nil {
-		return err
-	}
-	if err := reg.Register(&vault.Definition{}); err != nil {
+	reg, err := buildConnectorRegistry(cfg)
+	if err != nil {
 		return err
 	}
 

--- a/cmd/open-sspm/sync.go
+++ b/cmd/open-sspm/sync.go
@@ -9,13 +9,6 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/open-sspm/open-sspm/internal/config"
-	"github.com/open-sspm/open-sspm/internal/connectors/aws"
-	"github.com/open-sspm/open-sspm/internal/connectors/datadog"
-	"github.com/open-sspm/open-sspm/internal/connectors/entra"
-	"github.com/open-sspm/open-sspm/internal/connectors/github"
-	"github.com/open-sspm/open-sspm/internal/connectors/okta"
-	"github.com/open-sspm/open-sspm/internal/connectors/registry"
-	"github.com/open-sspm/open-sspm/internal/connectors/vault"
 	"github.com/open-sspm/open-sspm/internal/sync"
 	"github.com/spf13/cobra"
 )
@@ -44,23 +37,8 @@ func runSync() error {
 	}
 	defer pool.Close()
 
-	reg := registry.NewRegistry()
-	if err := reg.Register(okta.NewDefinition(cfg.SyncOktaWorkers)); err != nil {
-		return err
-	}
-	if err := reg.Register(&entra.Definition{}); err != nil {
-		return err
-	}
-	if err := reg.Register(github.NewDefinition(cfg.SyncGitHubWorkers)); err != nil {
-		return err
-	}
-	if err := reg.Register(datadog.NewDefinition(cfg.SyncDatadogWorkers)); err != nil {
-		return err
-	}
-	if err := reg.Register(&aws.Definition{}); err != nil {
-		return err
-	}
-	if err := reg.Register(&vault.Definition{}); err != nil {
+	reg, err := buildConnectorRegistry(cfg)
+	if err != nil {
 		return err
 	}
 

--- a/cmd/open-sspm/worker.go
+++ b/cmd/open-sspm/worker.go
@@ -11,13 +11,6 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/open-sspm/open-sspm/internal/config"
-	"github.com/open-sspm/open-sspm/internal/connectors/aws"
-	"github.com/open-sspm/open-sspm/internal/connectors/datadog"
-	"github.com/open-sspm/open-sspm/internal/connectors/entra"
-	"github.com/open-sspm/open-sspm/internal/connectors/github"
-	"github.com/open-sspm/open-sspm/internal/connectors/okta"
-	"github.com/open-sspm/open-sspm/internal/connectors/registry"
-	"github.com/open-sspm/open-sspm/internal/connectors/vault"
 	"github.com/open-sspm/open-sspm/internal/metrics"
 	"github.com/open-sspm/open-sspm/internal/sync"
 	"github.com/spf13/cobra"
@@ -50,23 +43,8 @@ func runWorker() error {
 	}
 	defer pool.Close()
 
-	reg := registry.NewRegistry()
-	if err := reg.Register(okta.NewDefinition(cfg.SyncOktaWorkers)); err != nil {
-		return err
-	}
-	if err := reg.Register(&entra.Definition{}); err != nil {
-		return err
-	}
-	if err := reg.Register(github.NewDefinition(cfg.SyncGitHubWorkers)); err != nil {
-		return err
-	}
-	if err := reg.Register(datadog.NewDefinition(cfg.SyncDatadogWorkers)); err != nil {
-		return err
-	}
-	if err := reg.Register(&aws.Definition{}); err != nil {
-		return err
-	}
-	if err := reg.Register(&vault.Definition{}); err != nil {
+	reg, err := buildConnectorRegistry(cfg)
+	if err != nil {
 		return err
 	}
 

--- a/internal/http/handlers/dashboard.go
+++ b/internal/http/handlers/dashboard.go
@@ -13,11 +13,7 @@ import (
 // HandleDashboard renders the dashboard page.
 func (h *Handlers) HandleDashboard(c echo.Context) error {
 	ctx := c.Request().Context()
-	layout, snap, err := h.LayoutData(ctx, c, "Dashboard")
-	if err != nil {
-		return h.RenderError(c, err)
-	}
-	oktaCount, err := h.Q.CountIdPUsers(ctx)
+	layout, _, err := h.LayoutData(ctx, c, "Dashboard")
 	if err != nil {
 		return h.RenderError(c, err)
 	}
@@ -35,33 +31,6 @@ func (h *Handlers) HandleDashboard(c echo.Context) error {
 	connectedAppCount, err := h.Q.CountConnectedOktaApps(ctx)
 	if err != nil {
 		return h.RenderError(c, err)
-	}
-
-	var ghCount int64
-	var ddCount int64
-	var matched int64
-	var unmatched int64
-
-	if snap.GitHubEnabled && snap.GitHubConfigured {
-		ghCount, err = h.Q.CountAppUsersBySource(ctx, gen.CountAppUsersBySourceParams{SourceKind: "github", SourceName: snap.GitHub.Org})
-		if err != nil {
-			return h.RenderError(c, err)
-		}
-		matched, err = h.Q.CountMatchedAppUsersBySource(ctx, gen.CountMatchedAppUsersBySourceParams{SourceKind: "github", SourceName: snap.GitHub.Org})
-		if err != nil {
-			return h.RenderError(c, err)
-		}
-		unmatched, err = h.Q.CountUnmatchedAppUsersBySource(ctx, gen.CountUnmatchedAppUsersBySourceParams{SourceKind: "github", SourceName: snap.GitHub.Org})
-		if err != nil {
-			return h.RenderError(c, err)
-		}
-	}
-
-	if snap.DatadogEnabled && snap.DatadogConfigured {
-		ddCount, err = h.Q.CountAppUsersBySource(ctx, gen.CountAppUsersBySourceParams{SourceKind: "datadog", SourceName: snap.Datadog.Site})
-		if err != nil {
-			return h.RenderError(c, err)
-		}
 	}
 
 	sourceNameByKind := map[string]string{}
@@ -160,11 +129,6 @@ func (h *Handlers) HandleDashboard(c echo.Context) error {
 		ActiveUserCount:   activeUserCount,
 		AppCount:          appCount,
 		ConnectedAppCount: connectedAppCount,
-		OktaCount:         oktaCount,
-		GitHubCount:       ghCount,
-		DatadogCount:      ddCount,
-		MatchedCount:      matched,
-		UnmatchedCount:    unmatched,
 		FrameworkPosture:  frameworkPosture,
 	}
 

--- a/internal/http/viewmodels/dashboard.go
+++ b/internal/http/viewmodels/dashboard.go
@@ -5,11 +5,6 @@ type DashboardViewData struct {
 	ActiveUserCount   int64
 	AppCount          int64
 	ConnectedAppCount int64
-	OktaCount         int64
-	GitHubCount       int64
-	DatadogCount      int64
-	MatchedCount      int64
-	UnmatchedCount    int64
 	FrameworkPosture  []DashboardFrameworkPostureItem
 }
 

--- a/internal/http/viewmodels/findings.go
+++ b/internal/http/viewmodels/findings.go
@@ -15,7 +15,6 @@ type FindingsRulesetItem struct {
 	Status        string
 	Source        string
 	SourceVersion string
-	RuleCount     int
 	Href          string
 }
 
@@ -25,7 +24,6 @@ type FindingsRuleItem struct {
 	Title            string
 	Summary          string
 	MonitoringStatus string
-	MonitoringReason string
 	Status           string
 	EvaluatedAt      string
 	EvidenceSummary  string
@@ -43,16 +41,7 @@ type FindingsFrameworkMappingItem struct {
 	Framework        string
 	FrameworkVersion string
 	Control          string
-	Enhancement      string
-	ControlTitle     string
 	Coverage         string
-	Notes            string
-}
-
-type FindingsDataContractItem struct {
-	Dataset     string
-	Version     int
-	Description string
 }
 
 type FindingsAlert struct {

--- a/internal/http/viewmodels/findings_rule.go
+++ b/internal/http/viewmodels/findings_rule.go
@@ -10,22 +10,14 @@ type FindingsRuleViewData struct {
 	RuleKey         string
 	RuleTitle       string
 	RuleSummary     string
-	RuleDescription string
-	RuleCategory    string
 	RuleSeverity    string
 
 	MonitoringStatus string
 	MonitoringReason string
 
-	Tags              []string
-	References        []FindingsReferenceItem
-	FrameworkMappings []FindingsFrameworkMappingItem
-
 	RemediationInstructions string
 	RemediationRisks        string
 	RemediationEffort       string
-
-	RequiredData []string
 
 	CurrentStatus      string
 	CurrentEvaluatedAt string
@@ -33,7 +25,6 @@ type FindingsRuleViewData struct {
 	EvidenceSummary    string
 	Evidence           FindingsEvidenceViewData
 
-	RulesetOverrideExists  bool
 	RulesetOverrideEnabled bool
 
 	RuleOverride FindingsRuleOverrideViewData
@@ -52,14 +43,8 @@ type FindingsEvidenceViewData struct {
 
 	ParamsPretty string
 
-	ResultStatus    string
-	ResultErrorKind string
-
 	SelectionTotal    int
 	SelectionSelected int
-
-	JoinUnmatchedLeft   int
-	JoinOnUnmatchedLeft string
 
 	Violations          []FindingsEvidenceViolation
 	ViolationsTruncated bool
@@ -69,7 +54,6 @@ type FindingsEvidenceViewData struct {
 
 type FindingsJoinSideViewData struct {
 	Dataset string
-	KeyPath string
 }
 
 type FindingsEvidenceViolation struct {
@@ -78,7 +62,6 @@ type FindingsEvidenceViolation struct {
 }
 
 type FindingsRuleOverrideViewData struct {
-	Exists  bool
 	Enabled bool
 
 	HasSchema bool
@@ -97,7 +80,6 @@ type FindingsParamField struct {
 }
 
 type FindingsRuleAttestationViewData struct {
-	Exists    bool
 	Status    string
 	Notes     string
 	ExpiresAt string

--- a/internal/http/viewmodels/findings_ruleset.go
+++ b/internal/http/viewmodels/findings_ruleset.go
@@ -11,13 +11,7 @@ type FindingsRulesetViewData struct {
 	Tags              []string
 	References        []FindingsReferenceItem
 	FrameworkMappings []FindingsFrameworkMappingItem
-	DataContracts     []FindingsDataContractItem
 	HasMetadata       bool
-
-	RequirementsAPIScopes   []string
-	RequirementsPermissions []string
-	RequirementsNotes       string
-	HasRequirements         bool
 
 	OverrideExists  bool
 	OverrideEnabled bool


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Refactored connector registry initialization and removed unused view model fields across the codebase.

**Key Changes:**
- Extracted duplicate connector registry setup code into a shared `buildConnectorRegistry` function in `cmd/open-sspm/connectors.go`
- Removed unused dashboard statistics fields (`OktaCount`, `GitHubCount`, `DatadogCount`, `MatchedCount`, `UnmatchedCount`) and their associated database queries
- Cleaned up findings view models by removing unused metadata fields that were being parsed but never displayed
- Removed unused evidence fields from rule evaluation display structures

**Impact:**
- Reduced code duplication across serve, sync, and worker commands
- Simplified maintenance by centralizing connector registration logic
- Reduced database query overhead by removing unused count queries
- Cleaner view models with only fields actually used in templates

<h3>Confidence Score: 5/5</h3>


- Safe to merge - well-executed refactoring with no functional changes
- The changes are purely structural improvements. The connector registry refactoring follows DRY principles correctly, and the removed fields were verified to be unused in templates and display logic. No behavioral changes or new features were introduced.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/open-sspm/connectors.go | Extracted connector registry initialization into a reusable function |
| cmd/open-sspm/serve.go | Replaced duplicated connector registration code with `buildConnectorRegistry` function call |
| cmd/open-sspm/sync.go | Replaced duplicated connector registration code with `buildConnectorRegistry` function call |
| cmd/open-sspm/worker.go | Replaced duplicated connector registration code with `buildConnectorRegistry` function call |
| internal/http/handlers/dashboard.go | Removed unused database queries and fields that were not displayed in dashboard view |
| internal/http/handlers/findings.go | Removed unused metadata fields and simplified evidence parsing by removing unused fields |
| internal/http/viewmodels/dashboard.go | Removed unused count fields that were not being displayed |
| internal/http/viewmodels/findings.go | Removed unused metadata fields from structs |
| internal/http/viewmodels/findings_rule.go | Removed unused fields from rule and evidence view data structures |
| internal/http/viewmodels/findings_ruleset.go | Removed unused requirements-related fields from ruleset view data |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Main as main()
    participant Serve as runServe()
    participant Sync as runSync()
    participant Worker as runWorker()
    participant Build as buildConnectorRegistry()
    participant Registry as ConnectorRegistry

    Note over Main,Registry: Before: Duplicated registration in each command

    alt serve command
        Main->>Serve: execute
        Serve->>Build: buildConnectorRegistry(cfg)
        Build->>Registry: NewRegistry()
        Build->>Registry: Register(okta, entra, github, datadog, aws, vault)
        Registry-->>Build: registry
        Build-->>Serve: registry
        Note over Serve: Uses registry for HTTP handlers
    end

    alt sync command
        Main->>Sync: execute
        Sync->>Build: buildConnectorRegistry(cfg)
        Build->>Registry: NewRegistry()
        Build->>Registry: Register(okta, entra, github, datadog, aws, vault)
        Registry-->>Build: registry
        Build-->>Sync: registry
        Note over Sync: Uses registry for one-off sync
    end

    alt worker command
        Main->>Worker: execute
        Worker->>Build: buildConnectorRegistry(cfg)
        Build->>Registry: NewRegistry()
        Build->>Registry: Register(okta, entra, github, datadog, aws, vault)
        Registry-->>Build: registry
        Build-->>Worker: registry
        Note over Worker: Uses registry for periodic sync
    end

    Note over Main,Registry: After: Centralized registration function
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->