### PR TITLE
fix(entra): use direct group members for app role expansion

### DIFF
--- a/internal/connectors/entra/entitlements.go
+++ b/internal/connectors/entra/entitlements.go
@@ -246,7 +246,7 @@ func (i *EntraIntegration) collectEntraAppRoleEntitlements(ctx context.Context, 
 		Stage:   "list-entitlements",
 		Current: 0,
 		Total:   int64(len(groupIDs)),
-		Message: fmt.Sprintf("listing transitive members for %d granting groups", len(groupIDs)),
+		Message: fmt.Sprintf("listing direct members for %d granting groups", len(groupIDs)),
 	})
 	if len(groupIDs) == 0 {
 		return buildEntraAppEntitlementRows(appEntitlements), nil
@@ -272,7 +272,7 @@ func (i *EntraIntegration) collectEntraAppRoleEntitlements(ctx context.Context, 
 				if groupCtx.Err() != nil {
 					return
 				}
-				users, err := i.client.ListGroupTransitiveUserMembers(groupCtx, groupID)
+				users, err := i.client.ListGroupUserMembers(groupCtx, groupID)
 				if err != nil {
 					groupResults <- entraGroupMembersResult{
 						GroupID: groupID,

--- a/internal/connectors/entra/entitlements_test.go
+++ b/internal/connectors/entra/entitlements_test.go
@@ -21,10 +21,11 @@ const (
 )
 
 type entitlementsTestClient struct {
-	assignmentsBySP          map[string][]ServicePrincipalAppRoleAssignment
-	groupMembersByID         map[string][]User
-	directoryRoles           []DirectoryRole
-	directoryRoleAssignments []DirectoryRoleAssignment
+	assignmentsBySP            map[string][]ServicePrincipalAppRoleAssignment
+	groupMembersByID           map[string][]User
+	transitiveGroupMembersByID map[string][]User
+	directoryRoles             []DirectoryRole
+	directoryRoleAssignments   []DirectoryRoleAssignment
 }
 
 func (c entitlementsTestClient) ListApplications(context.Context) ([]Application, error) {
@@ -59,7 +60,14 @@ func (c entitlementsTestClient) ListGroups(context.Context) ([]Group, error) {
 	panic("unexpected call")
 }
 
+func (c entitlementsTestClient) ListGroupUserMembers(_ context.Context, groupID string) ([]User, error) {
+	return c.groupMembersByID[groupID], nil
+}
+
 func (c entitlementsTestClient) ListGroupTransitiveUserMembers(_ context.Context, groupID string) ([]User, error) {
+	if c.transitiveGroupMembersByID != nil {
+		return c.transitiveGroupMembersByID[groupID], nil
+	}
 	return c.groupMembersByID[groupID], nil
 }
 
@@ -258,6 +266,38 @@ func TestCollectEntraAppRoleEntitlementsKeepsDistinctRolesWithSharedName(t *test
 	}
 	if _, ok := seenRoleIDs[duplicateRoleID2]; !ok {
 		t.Fatalf("missing app role id %q", duplicateRoleID2)
+	}
+}
+
+func TestCollectEntraAppRoleEntitlementsSkipsNestedGroupMembers(t *testing.T) {
+	t.Parallel()
+
+	integration := &EntraIntegration{
+		client: entitlementsTestClient{
+			assignmentsBySP: map[string][]ServicePrincipalAppRoleAssignment{
+				appRoleSPID: {
+					mustParseAppRoleAssignment(t, `{"id":"assign-nested-1","principalId":"`+appRoleGroup1+`","principalType":"Group","principalDisplayName":"Engineering","resourceId":"`+appRoleSPID+`","resourceDisplayName":"Zendesk","appRoleId":"`+appRoleID+`"}`),
+				},
+			},
+			groupMembersByID: map[string][]User{
+				appRoleGroup1: nil,
+			},
+			transitiveGroupMembersByID: map[string][]User{
+				appRoleGroup1: {
+					mustParseUser(t, `{"id":"`+appRoleUser3ID+`"}`),
+				},
+			},
+		},
+	}
+
+	rows, err := integration.collectEntraAppRoleEntitlements(context.Background(), func(registry.Event) {}, []ServicePrincipal{
+		mustParseServicePrincipal(t, `{"id":"`+appRoleSPID+`","displayName":"Zendesk","appRoles":[{"id":"`+appRoleID+`","displayName":"Agent","value":"agent"}]}`),
+	})
+	if err != nil {
+		t.Fatalf("collectEntraAppRoleEntitlements() error = %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("len(rows)=%d want 0", len(rows))
 	}
 }
 

--- a/internal/connectors/entra/full_sync_integration_test.go
+++ b/internal/connectors/entra/full_sync_integration_test.go
@@ -72,6 +72,10 @@ func (c fullSyncTestClient) ListGroups(context.Context) ([]Group, error) {
 	return c.groups, nil
 }
 
+func (c fullSyncTestClient) ListGroupUserMembers(_ context.Context, groupID string) ([]User, error) {
+	return c.groupMembersByID[groupID], nil
+}
+
 func (c fullSyncTestClient) ListGroupTransitiveUserMembers(_ context.Context, groupID string) ([]User, error) {
 	return c.groupMembersByID[groupID], nil
 }

--- a/internal/connectors/entra/graph.go
+++ b/internal/connectors/entra/graph.go
@@ -262,6 +262,7 @@ func (c *Client) ListGroupUserMembers(ctx context.Context, groupID string) ([]Us
 	result, err := c.graph.Groups().ByGroupId(groupID).Members().GraphUser().Get(ctx, &groups.ItemMembersGraphUserRequestBuilderGetRequestConfiguration{
 		QueryParameters: &groups.ItemMembersGraphUserRequestBuilderGetQueryParameters{
 			Select: []string{"id", "displayName", "mail", "userPrincipalName", "otherMails", "proxyAddresses", "userType", "accountEnabled", "createdDateTime"},
+			Top:    int32Ptr(defaultPageSize),
 		},
 	})
 	if err != nil {

--- a/internal/connectors/entra/graph.go
+++ b/internal/connectors/entra/graph.go
@@ -253,6 +253,23 @@ func (c *Client) ListGroups(ctx context.Context) ([]Group, error) {
 	return collectPagedItems[Group](ctx, result, c.graph.GetAdapter(), msgraphmodels.CreateGroupCollectionResponseFromDiscriminatorValue)
 }
 
+func (c *Client) ListGroupUserMembers(ctx context.Context, groupID string) ([]User, error) {
+	groupID = strings.TrimSpace(groupID)
+	if groupID == "" {
+		return nil, errors.New("group id is required")
+	}
+
+	result, err := c.graph.Groups().ByGroupId(groupID).Members().GraphUser().Get(ctx, &groups.ItemMembersGraphUserRequestBuilderGetRequestConfiguration{
+		QueryParameters: &groups.ItemMembersGraphUserRequestBuilderGetQueryParameters{
+			Select: []string{"id", "displayName", "mail", "userPrincipalName", "otherMails", "proxyAddresses", "userType", "accountEnabled", "createdDateTime"},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list entra group members %s: %w", groupID, err)
+	}
+	return collectPagedItems[User](ctx, result, c.graph.GetAdapter(), msgraphmodels.CreateUserCollectionResponseFromDiscriminatorValue)
+}
+
 func (c *Client) ListGroupTransitiveUserMembers(ctx context.Context, groupID string) ([]User, error) {
 	groupID = strings.TrimSpace(groupID)
 	if groupID == "" {

--- a/internal/connectors/entra/graph_test.go
+++ b/internal/connectors/entra/graph_test.go
@@ -699,9 +699,10 @@ func TestListServicePrincipalAssignedToPaging(t *testing.T) {
 	}
 }
 
-func TestListGroupTransitiveMembersAndDirectoryRoleAssignments(t *testing.T) {
+func TestListGroupMembersTransitiveMembersAndDirectoryRoleAssignments(t *testing.T) {
 	t.Parallel()
 
+	var directGroupMemberRequests int
 	var groupMemberRequests int
 	var directoryRoleRequests int
 	var directoryRoleAssignmentRequests int
@@ -711,6 +712,16 @@ func TestListGroupTransitiveMembersAndDirectoryRoleAssignments(t *testing.T) {
 		assertTestBearer(t, r)
 
 		switch {
+		case strings.Contains(r.URL.Path, "/groups/group-1/members/"):
+			directGroupMemberRequests++
+			w.Header().Set("Content-Type", "application/json")
+			if r.URL.Query().Get("page") == "2" {
+				_, _ = w.Write([]byte(`{"value":[{"id":"user-2","displayName":"Bob","userPrincipalName":"bob@example.com"}]}`))
+				return
+			}
+			next := srv.URL + "/graph/v1.0/groups/group-1/members/graph.user?page=2"
+			_, _ = w.Write([]byte(`{"value":[{"id":"user-1","displayName":"Alice","mail":"alice@example.com","userPrincipalName":"alice@example.com"}],"@odata.nextLink":"` + next + `"}`))
+			return
 		case strings.Contains(r.URL.Path, "/groups/group-1/transitiveMembers/"):
 			groupMemberRequests++
 			if got := r.Header.Get("ConsistencyLevel"); got != "eventual" {
@@ -751,6 +762,17 @@ func TestListGroupTransitiveMembersAndDirectoryRoleAssignments(t *testing.T) {
 	defer srv.Close()
 
 	client := newGraphTestClient(t, srv)
+
+	directGroupMembers, err := client.ListGroupUserMembers(context.Background(), "group-1")
+	if err != nil {
+		t.Fatalf("ListGroupUserMembers() error = %v", err)
+	}
+	if len(directGroupMembers) != 2 {
+		t.Fatalf("len(directGroupMembers)=%d want 2", len(directGroupMembers))
+	}
+	if entityID(directGroupMembers[0]) != "user-1" || entityID(directGroupMembers[1]) != "user-2" {
+		t.Fatalf("unexpected direct group member ids [%q %q]", entityID(directGroupMembers[0]), entityID(directGroupMembers[1]))
+	}
 
 	groupMembers, err := client.ListGroupTransitiveUserMembers(context.Background(), "group-1")
 	if err != nil {
@@ -795,6 +817,9 @@ func TestListGroupTransitiveMembersAndDirectoryRoleAssignments(t *testing.T) {
 	}
 	if got := entraDirectoryObjectDisplayName(assignments[1].GetPrincipal()); got != "Privileged Ops" {
 		t.Fatalf("second principal displayName=%q want %q", got, "Privileged Ops")
+	}
+	if directGroupMemberRequests != 2 {
+		t.Fatalf("directGroupMemberRequests=%d want 2", directGroupMemberRequests)
 	}
 	if groupMemberRequests != 2 {
 		t.Fatalf("groupMemberRequests=%d want 2", groupMemberRequests)

--- a/internal/connectors/entra/integration.go
+++ b/internal/connectors/entra/integration.go
@@ -44,6 +44,7 @@ type entraClient interface {
 	ListDirectoryRoleAssignments(context.Context) ([]DirectoryRoleAssignment, error)
 	ListUsers(context.Context) ([]User, error)
 	ListGroups(context.Context) ([]Group, error)
+	ListGroupUserMembers(context.Context, string) ([]User, error)
 	ListGroupTransitiveUserMembers(context.Context, string) ([]User, error)
 	ListApplicationOwners(context.Context, string) ([]DirectoryOwner, error)
 	ListServicePrincipalOwners(context.Context, string) ([]DirectoryOwner, error)

--- a/internal/connectors/entra/integration_test.go
+++ b/internal/connectors/entra/integration_test.go
@@ -154,6 +154,10 @@ func (s stubEntraClient) ListGroups(context.Context) ([]Group, error) {
 	panic("unexpected call")
 }
 
+func (s stubEntraClient) ListGroupUserMembers(context.Context, string) ([]User, error) {
+	panic("unexpected call")
+}
+
 func (s stubEntraClient) ListGroupTransitiveUserMembers(context.Context, string) ([]User, error) {
 	panic("unexpected call")
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes app-role entitlement expansion from using transitive group membership (`/transitiveMembers/graph.user`) to direct group membership (`/members/graph.user`), intentionally excluding members of nested subgroups. The new `ListGroupUserMembers` method is added to the Graph client and `entraClient` interface, and a new test confirms nested group members are now skipped.

<h3>Confidence Score: 5/5</h3>

Safe to merge; only finding is a minor missing `Top` page-size param that doesn't affect correctness.

All findings are P2. The behavioral change is intentional and well-tested, the interface is consistently updated across all mock implementations, and pagination is exercised in the graph test. The sole note is a missing `Top` parameter that reduces pagination efficiency but does not break correctness.

`internal/connectors/entra/graph.go` — `ListGroupUserMembers` is missing `Top: int32Ptr(defaultPageSize)`.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/connectors/entra/graph.go | Adds `ListGroupUserMembers` using the non-transitive `/members/graph.user` endpoint; missing `Top` page-size param unlike all other list methods. |
| internal/connectors/entra/entitlements.go | Switches app-role group expansion from `ListGroupTransitiveUserMembers` to `ListGroupUserMembers`; progress message updated to match. |
| internal/connectors/entra/integration.go | Adds `ListGroupUserMembers` to the `entraClient` interface. |
| internal/connectors/entra/entitlements_test.go | Separates direct and transitive member maps in the test stub; adds `TestCollectEntraAppRoleEntitlementsSkipsNestedGroupMembers` proving nested members are excluded. |
| internal/connectors/entra/graph_test.go | Adds mock HTTP handler and assertions for the new `/members/graph.user` paged endpoint, including two-page pagination verification. |
| internal/connectors/entra/full_sync_integration_test.go | Adds `ListGroupUserMembers` stub to satisfy the updated interface; delegates to existing `groupMembersByID` map. |
| internal/connectors/entra/integration_test.go | Adds `ListGroupUserMembers` panic stub to `stubEntraClient` to implement the updated interface. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant E as EntraIntegration
    participant C as entraClient
    participant G as Microsoft Graph API

    E->>C: ListGroupUserMembers(ctx, groupID)
    C->>G: GET /groups/{id}/members/graph.user?$select=...
    G-->>C: page 1 + @odata.nextLink
    C->>G: GET nextLink (page 2...)
    G-->>C: final page
    C-->>E: []User (direct members only)
    Note over E: Nested subgroup members excluded
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/connectors/entra/graph.go
Line: 262-266

Comment:
**Missing `Top` page-size parameter**

Every other list method in this file sets `Top: int32Ptr(defaultPageSize)` (999). `ListGroupUserMembers` omits it, so Microsoft Graph will use its default page size (100 items). For large groups this means up to ~10× more round-trips compared to `ListGroupTransitiveUserMembers`, even though pagination still works correctly.

```suggestion
	result, err := c.graph.Groups().ByGroupId(groupID).Members().GraphUser().Get(ctx, &groups.ItemMembersGraphUserRequestBuilderGetRequestConfiguration{
		QueryParameters: &groups.ItemMembersGraphUserRequestBuilderGetQueryParameters{
			Select: []string{"id", "displayName", "mail", "userPrincipalName", "otherMails", "proxyAddresses", "userType", "accountEnabled", "createdDateTime"},
			Top:    int32Ptr(defaultPageSize),
		},
	})
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(entra): use direct group members for..."](https://github.com/open-sspm/open-sspm/commit/b8d8c2aa2bb35a7e09f4e6b15776be698d845468) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27755410)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->