### PR TITLE
fix(edge): fix edge cases

### DIFF
--- a/db/migrations/000047_sync_runs_success_latest_by_source_index_excludes_discovery.down.sql
+++ b/db/migrations/000047_sync_runs_success_latest_by_source_index_excludes_discovery.down.sql
@@ -1,0 +1,17 @@
+DROP INDEX IF EXISTS idx_sync_runs_success_latest_by_source;
+
+CREATE INDEX IF NOT EXISTS idx_sync_runs_success_latest_by_source
+  ON sync_runs (
+    (
+      CASE lower(trim(source_kind))
+        WHEN 'okta_discovery' THEN 'okta'
+        WHEN 'entra_discovery' THEN 'entra'
+        WHEN 'google_workspace_discovery' THEN 'google_workspace'
+        WHEN 'aws_identity_center' THEN 'aws'
+        ELSE lower(trim(source_kind))
+      END
+    ),
+    (trim(source_name)),
+    finished_at DESC
+  )
+  WHERE status = 'success' AND finished_at IS NOT NULL;

--- a/db/migrations/000047_sync_runs_success_latest_by_source_index_excludes_discovery.up.sql
+++ b/db/migrations/000047_sync_runs_success_latest_by_source_index_excludes_discovery.up.sql
@@ -1,0 +1,16 @@
+DROP INDEX IF EXISTS idx_sync_runs_success_latest_by_source;
+
+CREATE INDEX IF NOT EXISTS idx_sync_runs_success_latest_by_source
+  ON sync_runs (
+    (
+      CASE lower(trim(source_kind))
+        WHEN 'aws_identity_center' THEN 'aws'
+        ELSE lower(trim(source_kind))
+      END
+    ),
+    (trim(source_name)),
+    finished_at DESC
+  )
+  WHERE status = 'success'
+    AND finished_at IS NOT NULL
+    AND lower(trim(source_kind)) NOT IN ('okta_discovery', 'entra_discovery', 'google_workspace_discovery');

--- a/db/queries/read_models.sql
+++ b/db/queries/read_models.sql
@@ -34,9 +34,6 @@ ON CONFLICT (source_kind, source_name) DO UPDATE SET
 WITH normalized AS (
   SELECT
     CASE lower(trim(r.source_kind))
-      WHEN 'okta_discovery' THEN 'okta'
-      WHEN 'entra_discovery' THEN 'entra'
-      WHEN 'google_workspace_discovery' THEN 'google_workspace'
       WHEN 'aws_identity_center' THEN 'aws'
       ELSE lower(trim(r.source_kind))
     END::text AS source_kind,
@@ -45,6 +42,7 @@ WITH normalized AS (
   FROM sync_runs r
   WHERE r.status = 'success'
     AND r.finished_at IS NOT NULL
+    AND lower(trim(r.source_kind)) NOT IN ('okta_discovery', 'entra_discovery', 'google_workspace_discovery')
 )
 SELECT source_kind, source_name, finished_at::timestamptz AS last_success_at
 FROM (

--- a/db/queries/source_accounts.sql
+++ b/db/queries/source_accounts.sql
@@ -70,7 +70,7 @@ SELECT
   now()
 FROM dedup input
 ON CONFLICT (source_kind, source_name, external_id) DO UPDATE SET
-  email = EXCLUDED.email,
+  email = COALESCE(NULLIF(EXCLUDED.email, ''), accounts.email),
   display_name = EXCLUDED.display_name,
   account_kind = EXCLUDED.account_kind,
   entity_category = EXCLUDED.entity_category,

--- a/internal/db/gen/read_models.sql.go
+++ b/internal/db/gen/read_models.sql.go
@@ -24,9 +24,6 @@ const listLatestSuccessfulSyncRunsBySource = `-- name: ListLatestSuccessfulSyncR
 WITH normalized AS (
   SELECT
     CASE lower(trim(r.source_kind))
-      WHEN 'okta_discovery' THEN 'okta'
-      WHEN 'entra_discovery' THEN 'entra'
-      WHEN 'google_workspace_discovery' THEN 'google_workspace'
       WHEN 'aws_identity_center' THEN 'aws'
       ELSE lower(trim(r.source_kind))
     END::text AS source_kind,
@@ -35,6 +32,7 @@ WITH normalized AS (
   FROM sync_runs r
   WHERE r.status = 'success'
     AND r.finished_at IS NOT NULL
+    AND lower(trim(r.source_kind)) NOT IN ('okta_discovery', 'entra_discovery', 'google_workspace_discovery')
 )
 SELECT source_kind, source_name, finished_at::timestamptz AS last_success_at
 FROM (

--- a/internal/db/gen/source_accounts.sql.go
+++ b/internal/db/gen/source_accounts.sql.go
@@ -1091,7 +1091,7 @@ SELECT
   now()
 FROM dedup input
 ON CONFLICT (source_kind, source_name, external_id) DO UPDATE SET
-  email = EXCLUDED.email,
+  email = COALESCE(NULLIF(EXCLUDED.email, ''), accounts.email),
   display_name = EXCLUDED.display_name,
   account_kind = EXCLUDED.account_kind,
   entity_category = EXCLUDED.entity_category,

--- a/internal/db/gen/source_accounts_integration_test.go
+++ b/internal/db/gen/source_accounts_integration_test.go
@@ -1,0 +1,154 @@
+package gen
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestUpsertSourceAccountsBulkBySourcePreservesExistingEmailWhenIncomingEmailMissing(t *testing.T) {
+	t.Parallel()
+
+	withEntityCategoryTestDatabase(t, func(ctx context.Context, pool *pgxpool.Pool, q *Queries, migrator *migrate.Migrate) {
+		migrateUp(t, migrator)
+
+		sourceKind := "github"
+		sourceName := "acme"
+		externalID := "user-1"
+
+		initialRunID := insertSyncRun(t, ctx, pool, sourceKind, sourceName)
+		upsertSourceAccountForTest(t, ctx, pool, q, initialRunID, sourceKind, sourceName, externalID, stringPtr("known@example.com"))
+
+		cases := []struct {
+			name  string
+			email *string
+		}{
+			{name: "blank", email: stringPtr("   ")},
+			{name: "null", email: nil},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				updateRunID := insertSyncRun(t, ctx, pool, sourceKind, sourceName)
+				upsertSourceAccountForTest(t, ctx, pool, q, updateRunID, sourceKind, sourceName, externalID, tc.email)
+
+				if got := fetchSourceAccountEmail(t, ctx, pool, sourceKind, sourceName, externalID); got != "known@example.com" {
+					t.Fatalf("email = %q, want %q", got, "known@example.com")
+				}
+			})
+		}
+	})
+}
+
+func TestUpsertSourceAccountsBulkBySourcePopulatesBlankEmailWhenIncomingEmailPresent(t *testing.T) {
+	t.Parallel()
+
+	withEntityCategoryTestDatabase(t, func(ctx context.Context, pool *pgxpool.Pool, q *Queries, migrator *migrate.Migrate) {
+		migrateUp(t, migrator)
+
+		sourceKind := "github"
+		sourceName := "acme"
+		externalID := "user-2"
+
+		initialRunID := insertSyncRun(t, ctx, pool, sourceKind, sourceName)
+		upsertSourceAccountForTest(t, ctx, pool, q, initialRunID, sourceKind, sourceName, externalID, stringPtr(""))
+
+		updateRunID := insertSyncRun(t, ctx, pool, sourceKind, sourceName)
+		upsertSourceAccountForTest(t, ctx, pool, q, updateRunID, sourceKind, sourceName, externalID, stringPtr("filled@example.com"))
+
+		if got := fetchSourceAccountEmail(t, ctx, pool, sourceKind, sourceName, externalID); got != "filled@example.com" {
+			t.Fatalf("email = %q, want %q", got, "filled@example.com")
+		}
+	})
+}
+
+func TestUpsertSourceAccountsBulkBySourceOverwritesExistingEmailWhenIncomingEmailPresent(t *testing.T) {
+	t.Parallel()
+
+	withEntityCategoryTestDatabase(t, func(ctx context.Context, pool *pgxpool.Pool, q *Queries, migrator *migrate.Migrate) {
+		migrateUp(t, migrator)
+
+		sourceKind := "github"
+		sourceName := "acme"
+		externalID := "user-3"
+
+		initialRunID := insertSyncRun(t, ctx, pool, sourceKind, sourceName)
+		upsertSourceAccountForTest(t, ctx, pool, q, initialRunID, sourceKind, sourceName, externalID, stringPtr("old@example.com"))
+
+		updateRunID := insertSyncRun(t, ctx, pool, sourceKind, sourceName)
+		upsertSourceAccountForTest(t, ctx, pool, q, updateRunID, sourceKind, sourceName, externalID, stringPtr("new@example.com"))
+
+		if got := fetchSourceAccountEmail(t, ctx, pool, sourceKind, sourceName, externalID); got != "new@example.com" {
+			t.Fatalf("email = %q, want %q", got, "new@example.com")
+		}
+	})
+}
+
+func upsertSourceAccountForTest(t *testing.T, ctx context.Context, pool *pgxpool.Pool, q *Queries, runID int64, sourceKind, sourceName, externalID string, email *string) {
+	t.Helper()
+
+	rawJSON := [][]byte{[]byte(`{"status":"active"}`)}
+	lastLoginAts := []pgtype.Timestamptz{{}}
+	lastLoginIps := []string{""}
+	lastLoginRegions := []string{""}
+
+	if email == nil {
+		if _, err := pool.Exec(ctx, upsertSourceAccountsBulkBySource,
+			sourceKind,
+			sourceName,
+			runID,
+			[]string{externalID},
+			[]*string{nil},
+			[]string{"Example User"},
+			[]string{"human"},
+			[]string{"user"},
+			rawJSON,
+			lastLoginAts,
+			lastLoginIps,
+			lastLoginRegions,
+		); err != nil {
+			t.Fatalf("pool.Exec(upsertSourceAccountsBulkBySource): %v", err)
+		}
+		return
+	}
+
+	if _, err := q.UpsertSourceAccountsBulkBySource(ctx, UpsertSourceAccountsBulkBySourceParams{
+		SourceKind:       sourceKind,
+		SourceName:       sourceName,
+		SeenInRunID:      runID,
+		ExternalIds:      []string{externalID},
+		Emails:           []string{*email},
+		DisplayNames:     []string{"Example User"},
+		AccountKinds:     []string{"human"},
+		EntityCategories: []string{"user"},
+		RawJsons:         rawJSON,
+		LastLoginAts:     lastLoginAts,
+		LastLoginIps:     lastLoginIps,
+		LastLoginRegions: lastLoginRegions,
+	}); err != nil {
+		t.Fatalf("UpsertSourceAccountsBulkBySource(): %v", err)
+	}
+}
+
+func fetchSourceAccountEmail(t *testing.T, ctx context.Context, pool *pgxpool.Pool, sourceKind, sourceName, externalID string) string {
+	t.Helper()
+
+	var email string
+	if err := pool.QueryRow(ctx, `
+		SELECT email
+		FROM accounts
+		WHERE source_kind = $1
+		  AND source_name = $2
+		  AND external_id = $3
+	`, sourceKind, sourceName, externalID).Scan(&email); err != nil {
+		t.Fatalf("select account email: %v", err)
+	}
+	return email
+}
+
+func stringPtr(s string) *string {
+	return &s
+}

--- a/internal/readmodels/projector_integration_test.go
+++ b/internal/readmodels/projector_integration_test.go
@@ -1,0 +1,329 @@
+package readmodels
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/open-sspm/open-sspm/internal/connectors/configstore"
+	"github.com/open-sspm/open-sspm/internal/db/gen"
+)
+
+const readModelsTestConnectorSecretKey = "0123456789abcdef0123456789abcdef"
+
+func TestProjectorRefreshConnectorSourceStateUsesLatestFullRunForFreshness(t *testing.T) {
+	t.Parallel()
+
+	withReadModelsTestDatabase(t, func(ctx context.Context, pool *pgxpool.Pool, q *gen.Queries, migrator *migrate.Migrate) {
+		migrateUpReadModels(t, migrator)
+
+		insertReadModelsConnectorConfig(t, ctx, pool, configstore.KindEntra, true, configstore.EntraConfig{
+			TenantID:         "11111111-1111-1111-1111-111111111111",
+			ClientID:         "22222222-2222-2222-2222-222222222222",
+			ClientSecret:     "secret",
+			DiscoveryEnabled: true,
+		})
+
+		now := time.Now().UTC().Truncate(time.Second)
+		fullFinishedAt := now.Add(-4 * time.Hour)
+		discoveryFinishedAt := now.Add(-5 * time.Minute)
+
+		insertReadModelsSyncRun(t, ctx, pool, "entra", "11111111-1111-1111-1111-111111111111", fullFinishedAt)
+		insertReadModelsSyncRun(t, ctx, pool, "entra_discovery", "11111111-1111-1111-1111-111111111111", discoveryFinishedAt)
+
+		projector := NewProjector(pool, nil, RefreshConfig{SyncEntraInterval: time.Hour})
+		if err := projector.RefreshConnectorSourceState(ctx); err != nil {
+			t.Fatalf("RefreshConnectorSourceState(): %v", err)
+		}
+
+		lastSuccessAt, freshUntilAt := fetchConnectorSourceStateTimes(t, ctx, pool, "entra", "11111111-1111-1111-1111-111111111111")
+		if !lastSuccessAt.Equal(fullFinishedAt) {
+			t.Fatalf("last_success_at = %s, want %s", lastSuccessAt, fullFinishedAt)
+		}
+
+		wantFreshUntil := fullFinishedAt.Add(2 * time.Hour)
+		if !freshUntilAt.Equal(wantFreshUntil) {
+			t.Fatalf("fresh_until_at = %s, want %s", freshUntilAt, wantFreshUntil)
+		}
+	})
+}
+
+func TestProjectorRefreshConnectorSourceStateKeepsCurrentFullRunCurrent(t *testing.T) {
+	t.Parallel()
+
+	withReadModelsTestDatabase(t, func(ctx context.Context, pool *pgxpool.Pool, q *gen.Queries, migrator *migrate.Migrate) {
+		migrateUpReadModels(t, migrator)
+
+		insertReadModelsConnectorConfig(t, ctx, pool, configstore.KindEntra, true, configstore.EntraConfig{
+			TenantID:         "11111111-1111-1111-1111-111111111111",
+			ClientID:         "22222222-2222-2222-2222-222222222222",
+			ClientSecret:     "secret",
+			DiscoveryEnabled: true,
+		})
+
+		now := time.Now().UTC().Truncate(time.Second)
+		fullFinishedAt := now.Add(-30 * time.Minute)
+		discoveryFinishedAt := now.Add(-5 * time.Minute)
+
+		insertReadModelsSyncRun(t, ctx, pool, "entra", "11111111-1111-1111-1111-111111111111", fullFinishedAt)
+		insertReadModelsSyncRun(t, ctx, pool, "entra_discovery", "11111111-1111-1111-1111-111111111111", discoveryFinishedAt)
+
+		projector := NewProjector(pool, nil, RefreshConfig{SyncEntraInterval: time.Hour})
+		if err := projector.RefreshConnectorSourceState(ctx); err != nil {
+			t.Fatalf("RefreshConnectorSourceState(): %v", err)
+		}
+
+		lastSuccessAt, freshUntilAt := fetchConnectorSourceStateTimes(t, ctx, pool, "entra", "11111111-1111-1111-1111-111111111111")
+		if !lastSuccessAt.Equal(fullFinishedAt) {
+			t.Fatalf("last_success_at = %s, want %s", lastSuccessAt, fullFinishedAt)
+		}
+		if !freshUntilAt.After(now) {
+			t.Fatalf("fresh_until_at = %s, want a current freshness window after %s", freshUntilAt, now)
+		}
+	})
+}
+
+func TestProjectorRefreshConnectorSourceStateDoesNotLetDiscoveryFreshnessKeepNonHumanCurrent(t *testing.T) {
+	t.Parallel()
+
+	withReadModelsTestDatabase(t, func(ctx context.Context, pool *pgxpool.Pool, q *gen.Queries, migrator *migrate.Migrate) {
+		migrateUpReadModels(t, migrator)
+
+		sourceName := "11111111-1111-1111-1111-111111111111"
+		insertReadModelsConnectorConfig(t, ctx, pool, configstore.KindEntra, true, configstore.EntraConfig{
+			TenantID:         sourceName,
+			ClientID:         "22222222-2222-2222-2222-222222222222",
+			ClientSecret:     "secret",
+			DiscoveryEnabled: true,
+		})
+
+		now := time.Now().UTC().Truncate(time.Second)
+		fullFinishedAt := now.Add(-4 * time.Hour)
+		discoveryFinishedAt := now.Add(-5 * time.Minute)
+		fullRunID := insertReadModelsSyncRun(t, ctx, pool, "entra", sourceName, fullFinishedAt)
+		insertReadModelsSyncRun(t, ctx, pool, "entra_discovery", sourceName, discoveryFinishedAt)
+
+		appAssetID := upsertReadModelsAppAsset(t, ctx, q, fullRunID, "entra", sourceName, "entra_service_principal", "svc-123", "Azure Service Principal")
+
+		if _, err := q.RefreshAllAppAssetReadModels(ctx); err != nil {
+			t.Fatalf("RefreshAllAppAssetReadModels(): %v", err)
+		}
+
+		projector := NewProjector(pool, nil, RefreshConfig{SyncEntraInterval: time.Hour})
+		if err := projector.RefreshConnectorSourceState(ctx); err != nil {
+			t.Fatalf("RefreshConnectorSourceState(): %v", err)
+		}
+
+		if _, err := q.RefreshAllNonHumanPrincipalReadModelsSafely(ctx); err != nil {
+			t.Fatalf("RefreshAllNonHumanPrincipalReadModelsSafely(): %v", err)
+		}
+
+		principal, err := q.GetNonHumanPrincipalByRef(ctx, "app-asset-"+int64String(appAssetID))
+		if err != nil {
+			t.Fatalf("GetNonHumanPrincipalByRef(): %v", err)
+		}
+		if principal.FreshnessState != "stale" {
+			t.Fatalf("freshness_state = %q, want %q", principal.FreshnessState, "stale")
+		}
+		if !principal.HasStaleEvidence {
+			t.Fatalf("has_stale_evidence = false, want true")
+		}
+	})
+}
+
+func withReadModelsTestDatabase(t *testing.T, fn func(context.Context, *pgxpool.Pool, *gen.Queries, *migrate.Migrate)) {
+	t.Helper()
+
+	baseURL := strings.TrimSpace(os.Getenv("OPENSSPM_TEST_DATABASE_URL"))
+	if baseURL == "" {
+		t.Skip("OPENSSPM_TEST_DATABASE_URL is not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	adminURL, err := testDatabaseAdminURL(baseURL)
+	if err != nil {
+		t.Fatalf("testDatabaseAdminURL() err = %v", err)
+	}
+
+	adminConn, err := pgx.Connect(ctx, adminURL)
+	if err != nil {
+		t.Fatalf("pgx.Connect(admin) err = %v", err)
+	}
+	defer adminConn.Close(ctx)
+
+	dbName := "opensspm_readmodels_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	if _, err := adminConn.Exec(ctx, "CREATE DATABASE "+pgx.Identifier{dbName}.Sanitize()); err != nil {
+		t.Fatalf("CREATE DATABASE err = %v", err)
+	}
+	defer func() {
+		dropCtx, dropCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer dropCancel()
+		_, _ = adminConn.Exec(dropCtx, "DROP DATABASE IF EXISTS "+pgx.Identifier{dbName}.Sanitize()+" WITH (FORCE)")
+	}()
+
+	testURL, err := testDatabaseURLWithName(baseURL, dbName)
+	if err != nil {
+		t.Fatalf("testDatabaseURLWithName() err = %v", err)
+	}
+
+	migrator, err := migrate.New("file://"+readModelsMigrationsDir(t), testURL)
+	if err != nil {
+		t.Fatalf("migrate.New() err = %v", err)
+	}
+	defer func() {
+		_, _ = migrator.Close()
+	}()
+
+	pool, err := pgxpool.New(ctx, testURL)
+	if err != nil {
+		t.Fatalf("pgxpool.New() err = %v", err)
+	}
+	defer pool.Close()
+
+	fn(ctx, pool, gen.New(pool), migrator)
+}
+
+func migrateUpReadModels(t *testing.T, migrator *migrate.Migrate) {
+	t.Helper()
+
+	if err := migrator.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		t.Fatalf("migrate up: %v", err)
+	}
+}
+
+func insertReadModelsConnectorConfig(t *testing.T, ctx context.Context, pool *pgxpool.Pool, kind string, enabled bool, cfg any) {
+	t.Helper()
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin connector config tx %s: %v", kind, err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	qtx := gen.New(pool).WithTx(tx)
+	if _, err := qtx.UpdateConnectorConfigEnabled(ctx, gen.UpdateConnectorConfigEnabledParams{
+		Kind:    kind,
+		Enabled: enabled,
+	}); err != nil {
+		t.Fatalf("UpdateConnectorConfigEnabled(%s): %v", kind, err)
+	}
+
+	store := configstore.NewStore(nil, qtx, []byte(readModelsTestConnectorSecretKey))
+	if err := store.SaveConnectorConfigTx(ctx, qtx, kind, cfg); err != nil {
+		t.Fatalf("SaveConnectorConfigTx(%s): %v", kind, err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit connector config %s: %v", kind, err)
+	}
+}
+
+func insertReadModelsSyncRun(t *testing.T, ctx context.Context, pool *pgxpool.Pool, sourceKind, sourceName string, finishedAt time.Time) int64 {
+	t.Helper()
+
+	var id int64
+	err := pool.QueryRow(ctx, `
+		INSERT INTO sync_runs (source_kind, source_name, status, started_at, finished_at, message)
+		VALUES ($1, $2, 'success', $3, $4, '')
+		RETURNING id
+	`, sourceKind, sourceName, finishedAt.Add(-time.Minute), finishedAt).Scan(&id)
+	if err != nil {
+		t.Fatalf("insert sync run %s/%s: %v", sourceKind, sourceName, err)
+	}
+	return id
+}
+
+func upsertReadModelsAppAsset(t *testing.T, ctx context.Context, q *gen.Queries, runID int64, sourceKind, sourceName, assetKind, externalID, displayName string) int64 {
+	t.Helper()
+
+	now := pgtype.Timestamptz{Time: time.Now().UTC(), Valid: true}
+	if _, err := q.UpsertAppAssetsBulkBySource(ctx, gen.UpsertAppAssetsBulkBySourceParams{
+		SourceKind:        sourceKind,
+		SourceName:        sourceName,
+		SeenInRunID:       runID,
+		AssetKinds:        []string{assetKind},
+		ExternalIds:       []string{externalID},
+		ParentExternalIds: []string{""},
+		DisplayNames:      []string{displayName},
+		Statuses:          []string{"active"},
+		CreatedAtSources:  []pgtype.Timestamptz{now},
+		UpdatedAtSources:  []pgtype.Timestamptz{now},
+		RawJsons:          [][]byte{[]byte(`{}`)},
+	}); err != nil {
+		t.Fatalf("UpsertAppAssetsBulkBySource(): %v", err)
+	}
+
+	appAsset, err := q.GetAppAssetBySourceAndKindAndExternalID(ctx, gen.GetAppAssetBySourceAndKindAndExternalIDParams{
+		SourceKind: sourceKind,
+		SourceName: sourceName,
+		AssetKind:  assetKind,
+		ExternalID: externalID,
+	})
+	if err != nil {
+		t.Fatalf("GetAppAssetBySourceAndKindAndExternalID(): %v", err)
+	}
+	return appAsset.ID
+}
+
+func fetchConnectorSourceStateTimes(t *testing.T, ctx context.Context, pool *pgxpool.Pool, sourceKind, sourceName string) (time.Time, time.Time) {
+	t.Helper()
+
+	var lastSuccessAt, freshUntilAt time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT last_success_at, fresh_until_at
+		FROM connector_source_state
+		WHERE source_kind = $1
+		  AND source_name = $2
+	`, sourceKind, sourceName).Scan(&lastSuccessAt, &freshUntilAt); err != nil {
+		t.Fatalf("select connector_source_state: %v", err)
+	}
+	return lastSuccessAt.UTC(), freshUntilAt.UTC()
+}
+
+func int64String(v int64) string {
+	return strconv.FormatInt(v, 10)
+}
+
+func readModelsMigrationsDir(t *testing.T) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "db", "migrations"))
+}
+
+func testDatabaseAdminURL(baseURL string) (string, error) {
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return "", err
+	}
+	parsed.Path = "/postgres"
+	return parsed.String(), nil
+}
+
+func testDatabaseURLWithName(baseURL, dbName string) (string, error) {
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return "", err
+	}
+	parsed.Path = "/" + dbName
+	return parsed.String(), nil
+}

--- a/internal/sync/orchestrator.go
+++ b/internal/sync/orchestrator.go
@@ -288,10 +288,10 @@ func (o *Orchestrator) RunOnce(ctx context.Context) error {
 
 	// Evaluate global-scope rulesets (normalized datasets) after connector syncs and
 	// per-integration compliance evaluations have completed.
-	anySyncErrors := false
+	hasPrerequisiteErrors := resolveErr != nil
 	for _, err := range runErrByKey {
 		if err != nil {
-			anySyncErrors = true
+			hasPrerequisiteErrors = true
 			break
 		}
 	}
@@ -300,7 +300,7 @@ func (o *Orchestrator) RunOnce(ctx context.Context) error {
 	if globalEvalFn == nil {
 		globalEvalFn = runGlobalComplianceEvaluations
 	}
-	if err := globalEvalFn(ctx, o.q, o.globalEvalMode, anySyncErrors, o.report); err != nil {
+	if err := globalEvalFn(ctx, o.q, o.globalEvalMode, hasPrerequisiteErrors, o.report); err != nil {
 		wrapped := fmt.Errorf("global compliance: %w", err)
 		slog.Error("global compliance evaluation failed", "err", err)
 		errs = append(errs, wrapped)
@@ -311,11 +311,11 @@ func (o *Orchestrator) RunOnce(ctx context.Context) error {
 	return err
 }
 
-func runGlobalComplianceEvaluations(ctx context.Context, q *gen.Queries, mode string, anySyncErrors bool, report func(registry.Event)) error {
-	if mode == globalEvalModeStrict && anySyncErrors {
-		slog.Info("skipping global compliance evaluation due to integration errors")
+func runGlobalComplianceEvaluations(ctx context.Context, q *gen.Queries, mode string, hasPrerequisiteErrors bool, report func(registry.Event)) error {
+	if mode == globalEvalModeStrict && hasPrerequisiteErrors {
+		slog.Info("skipping global compliance evaluation due to prerequisite errors")
 		if report != nil {
-			report(registry.Event{Source: "rules", Stage: "global", Message: "skipping global compliance evaluation due to integration errors"})
+			report(registry.Event{Source: "rules", Stage: "global", Message: "skipping global compliance evaluation due to prerequisite errors"})
 		}
 		return nil
 	}

--- a/internal/sync/orchestrator_mode_test.go
+++ b/internal/sync/orchestrator_mode_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -181,5 +182,93 @@ func TestOrchestrator_PassesReadModelConfigThroughIntegrationContext(t *testing.
 
 	if err := orch.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce() error = %v", err)
+	}
+}
+
+func TestOrchestrator_StrictModeSkipsGlobalComplianceWhenIdentityResolutionFails(t *testing.T) {
+	t.Parallel()
+
+	orch := NewOrchestrator(&pgxpool.Pool{}, nil)
+	orch.SetLockManager(orchestratorTestLockManager{})
+	orch.SetRunMode(registry.RunModeFull)
+	orch.SetGlobalEvalMode(globalEvalModeStrict)
+
+	identityErr := errors.New("identity exploded")
+	orch.identityFn = func(context.Context, *gen.Queries) (identity.Stats, error) {
+		return identity.Stats{}, identityErr
+	}
+
+	var globalRan bool
+	var globalSkipped bool
+	orch.globalEvalFn = func(_ context.Context, _ *gen.Queries, mode string, hasPrerequisiteErrors bool, _ func(registry.Event)) error {
+		if mode == globalEvalModeStrict && hasPrerequisiteErrors {
+			globalSkipped = true
+			return nil
+		}
+		globalRan = true
+		return nil
+	}
+
+	integration := &orchestratorCountingIntegration{}
+	if err := orch.AddIntegration(integration); err != nil {
+		t.Fatalf("AddIntegration() error = %v", err)
+	}
+
+	err := orch.RunOnce(context.Background())
+	if err == nil {
+		t.Fatalf("RunOnce() error = nil, want identity error")
+	}
+	if integration.complianceCount != 1 {
+		t.Fatalf("complianceCount = %d, want 1", integration.complianceCount)
+	}
+	if globalRan {
+		t.Fatalf("global evaluator ran, want skipped")
+	}
+	if !globalSkipped {
+		t.Fatalf("global evaluator skip flag = false, want true")
+	}
+}
+
+func TestOrchestrator_BestEffortModeRunsGlobalComplianceWhenIdentityResolutionFails(t *testing.T) {
+	t.Parallel()
+
+	orch := NewOrchestrator(&pgxpool.Pool{}, nil)
+	orch.SetLockManager(orchestratorTestLockManager{})
+	orch.SetRunMode(registry.RunModeFull)
+	orch.SetGlobalEvalMode(globalEvalModeBestEffort)
+
+	identityErr := errors.New("identity exploded")
+	orch.identityFn = func(context.Context, *gen.Queries) (identity.Stats, error) {
+		return identity.Stats{}, identityErr
+	}
+
+	var globalRan bool
+	var receivedPrereqErrors bool
+	orch.globalEvalFn = func(_ context.Context, _ *gen.Queries, mode string, hasPrerequisiteErrors bool, _ func(registry.Event)) error {
+		if mode != globalEvalModeBestEffort {
+			t.Fatalf("mode = %q, want %q", mode, globalEvalModeBestEffort)
+		}
+		receivedPrereqErrors = hasPrerequisiteErrors
+		globalRan = true
+		return nil
+	}
+
+	integration := &orchestratorCountingIntegration{}
+	if err := orch.AddIntegration(integration); err != nil {
+		t.Fatalf("AddIntegration() error = %v", err)
+	}
+
+	err := orch.RunOnce(context.Background())
+	if err == nil {
+		t.Fatalf("RunOnce() error = nil, want identity error")
+	}
+	if integration.complianceCount != 1 {
+		t.Fatalf("complianceCount = %d, want 1", integration.complianceCount)
+	}
+	if !globalRan {
+		t.Fatalf("global evaluator did not run in best-effort mode")
+	}
+	if !receivedPrereqErrors {
+		t.Fatalf("hasPrerequisiteErrors = false, want true")
 	}
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three independent edge cases: (1) discovery-kind sync runs (`okta_discovery`, `entra_discovery`, `google_workspace_discovery`) are now excluded from the `ListLatestSuccessfulSyncRunsBySource` read model instead of being silently folded into their parent kinds; (2) an empty incoming email no longer overwrites a stored account email on upsert conflict; (3) an identity-resolution failure now correctly sets `hasPrerequisiteErrors`, so strict-mode global compliance evaluation is properly skipped even when all integration syncs succeed. New tests cover the last fix for both strict and best-effort modes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three fixes are narrow, well-tested, and align with the documented product invariants.

No P0 or P1 issues found. The SQL changes are straightforward and guarded by SQLC regeneration; the orchestrator fix is covered by two new tests; and the email COALESCE guard is a purely defensive improvement.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| db/queries/read_models.sql | Removes CASE-based normalization of *_discovery source kinds from the read model query, replacing them with a NOT IN filter that excludes those rows entirely; aws_identity_center → aws mapping is preserved. |
| db/queries/source_accounts.sql | ON CONFLICT update now uses COALESCE(NULLIF(EXCLUDED.email, ''), accounts.email) so an empty incoming email no longer overwrites a stored value. |
| internal/db/gen/read_models.sql.go | Regenerated SQLC file matching the updated read_models.sql query; no hand-edits detected. |
| internal/db/gen/source_accounts.sql.go | Regenerated SQLC file reflecting the COALESCE email guard; no hand-edits detected. |
| internal/sync/orchestrator.go | hasPrerequisiteErrors now seeds from resolveErr != nil before iterating runErrByKey, so an identity-resolution failure alone is sufficient to suppress strict-mode global compliance evaluation. |
| internal/sync/orchestrator_mode_test.go | Adds two new focused tests covering strict-mode skip and best-effort pass-through when identity resolution returns an error. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[RunOnce] --> B[Run integration syncs]
    B --> C{mode == Discovery?}
    C -- Yes --> D[Return join of sync errors]
    C -- No --> E[identity.Resolve]
    E --> F{resolveErr != nil?}
    F -- Yes --> G[hasPrerequisiteErrors = true\nappend resolveErr to errs]
    F -- No --> H[hasPrerequisiteErrors = false]
    G --> I[Run per-integration compliance\nexcept for failed integrations]
    H --> I
    I --> J{any runErrByKey != nil?}
    J -- Yes --> K[hasPrerequisiteErrors = true]
    J -- No --> L[hasPrerequisiteErrors unchanged]
    K --> M[globalEvalFn]
    L --> M
    M --> N{mode == strict AND\nhasPrerequisiteErrors?}
    N -- Yes --> O[Skip global compliance\nlog prerequisite errors]
    N -- No --> P[Run global compliance engine]
    O --> Q[Return errors.Join]
    P --> Q
```

<sub>Reviews (1): Last reviewed commit: ["fix(edge): fix edge cases"](https://github.com/open-sspm/open-sspm/commit/c97db525eb0bc76ed8b3d0abfdc41f07a9b80d0a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28860380)</sub>

<!-- /greptile_comment -->