### PR TITLE
feat: smtp for emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,18 @@ GLOBAL_EVAL_MODE=best_effort
 # CONNECTOR_SECRET_KEY=
 # CONNECTOR_SECRET_KEY_FILE=/path/to/connector-secret-key
 
+# SMTP (optional)
+# Set SMTP_ENABLED=1 to enable outbound email via an SMTP relay.
+# SMTP_ENABLED=0
+# SMTP_HOST=smtp.example.com
+# SMTP_PORT=587
+# SMTP_TLS_MODE=starttls
+# SMTP_FROM_ADDRESS=noreply@example.com
+# SMTP_FROM_NAME=Open SSPM
+# Optional: set both values when your SMTP relay requires authentication.
+# SMTP_USERNAME=
+# SMTP_PASSWORD=
+
 # Sync
 SYNC_INTERVAL=15m
 SYNC_DISCOVERY_INTERVAL=15m

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -12,21 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title
-        uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          types: |
-            feat
-            fix
-            perf
-            refactor
-            docs
-            test
-            build
-            ci
-            chore
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          pattern='^(feat|fix|docs|chore|ci|refactor|perf): .+'
 
-          requireScope: false
-          scopes: |
-            .*
+          if [[ ! "${PR_TITLE}" =~ ${pattern} ]]; then
+            echo "PR title must match '<type>: <summary>'." >&2
+            echo "Allowed types: feat, fix, docs, chore, ci, refactor, perf." >&2
+            echo "Example: feat: add SMTP adapter" >&2
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,23 +10,18 @@ Thanks for helping improve Open-SSPM!
 
 ## PR title format (required)
 
-PR titles must follow Conventional Commits (scope is optional):
+PR titles must use this format:
 
-- `type(scope): summary`
 - `type: summary`
-- `type(scope)!: summary` for breaking changes
-- `type!: summary` for breaking changes
 
 Allowed `type` values:
-- `feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `build`, `ci`, `chore`
-
-Suggested `scope` values (optional):
-- `okta`, `github`, `datadog`, `aws`, `rules`, `sync`, `http`, `db`, `ui`, `helm`, `docker`
+- `feat`, `fix`, `docs`, `chore`, `ci`, `refactor`, `perf`
 
 Examples:
-- `feat(sync): add incremental GitHub sync`
-- `fix(helm): run seed-rules as pre-install hook`
-- `docs(readme): clarify managed Postgres requirement`
-- `feat(api)!: change findings JSON output`
-
-If you use `!` (breaking change), include migration notes in the PR description.
+- `feat: add incremental GitHub sync`
+- `fix: run seed-rules as pre-install hook`
+- `docs: clarify managed Postgres requirement`
+- `chore: update demo deployment docs`
+- `ci: tighten Helm validation job`
+- `refactor: simplify SMTP config loading`
+- `perf: reduce sync query overhead`

--- a/cmd/open-sspm/runtime.go
+++ b/cmd/open-sspm/runtime.go
@@ -7,11 +7,13 @@ import (
 	"github.com/open-sspm/open-sspm/internal/config"
 	"github.com/open-sspm/open-sspm/internal/connectors/configstore"
 	"github.com/open-sspm/open-sspm/internal/db/gen"
+	"github.com/open-sspm/open-sspm/internal/mailer"
 )
 
 type runtimeDependencies struct {
 	pool    *pgxpool.Pool
 	queries *gen.Queries
+	mailer  mailer.Mailer
 }
 
 func openRuntimeDependencies(ctx context.Context, cfg config.Config) (*runtimeDependencies, error) {
@@ -25,8 +27,29 @@ func openRuntimeDependencies(ctx context.Context, cfg config.Config) (*runtimeDe
 		pool.Close()
 		return nil, err
 	}
+	mailAdapter, err := openMailer(cfg)
+	if err != nil {
+		pool.Close()
+		return nil, err
+	}
 	return &runtimeDependencies{
 		pool:    pool,
 		queries: queries,
+		mailer:  mailAdapter,
 	}, nil
+}
+
+func openMailer(cfg config.Config) (mailer.Mailer, error) {
+	if !cfg.SMTP.Enabled {
+		return mailer.NewNoop(), nil
+	}
+	return mailer.NewSMTP(mailer.SMTPConfig{
+		Host:        cfg.SMTP.Host,
+		Port:        cfg.SMTP.Port,
+		Username:    cfg.SMTP.Username,
+		Password:    cfg.SMTP.Password,
+		FromAddress: cfg.SMTP.FromAddress,
+		FromName:    cfg.SMTP.FromName,
+		TLSMode:     cfg.SMTP.TLSMode,
+	})
 }

--- a/cmd/open-sspm/serve.go
+++ b/cmd/open-sspm/serve.go
@@ -108,7 +108,7 @@ func runServe() error {
 		syncer = nil
 	}
 
-	srv, err := httpapp.NewEchoServer(cfg, runtimeDeps.pool, queries, syncer, reg)
+	srv, err := httpapp.NewEchoServer(cfg, runtimeDeps.pool, queries, syncer, reg, runtimeDeps.mailer)
 	if err != nil {
 		return err
 	}

--- a/docs/config/authentication.md
+++ b/docs/config/authentication.md
@@ -138,4 +138,4 @@ Preferred recovery paths:
 1. Sign in as another admin and reset the password in **Settings → Users**
 2. If no admin can sign in, recover directly in Postgres against the `auth_users` table, then sign in again
 
-There is no built-in email-based password reset flow in the current application.
+There is no built-in email-based password reset flow in the current application, even if SMTP is configured.

--- a/docs/config/environment-variables.md
+++ b/docs/config/environment-variables.md
@@ -131,6 +131,79 @@ Development-only helper that creates `admin@admin.com` / `admin` if no auth user
 DEV_SEED_ADMIN=1
 ```
 
+## SMTP
+
+Open-SSPM can be configured to send email through an SMTP relay. SMTP is disabled by default.
+
+::: info
+The current release adds SMTP transport configuration only. There is not yet a built-in password reset, invitation, or email verification flow.
+:::
+
+### SMTP_ENABLED
+
+- **Values:** `0`, `1`
+- **Default:** `0`
+
+```bash
+SMTP_ENABLED=1
+```
+
+### SMTP_HOST
+
+SMTP server hostname. Required when `SMTP_ENABLED=1`.
+
+```bash
+SMTP_HOST=smtp.example.com
+```
+
+### SMTP_PORT
+
+- **Default:** `587`
+
+```bash
+SMTP_PORT=587
+```
+
+### SMTP_TLS_MODE
+
+- **Values:** `starttls`, `tls`, `plain`
+- **Default:** `starttls`
+
+```bash
+SMTP_TLS_MODE=starttls
+```
+
+Use `tls` for implicit TLS (commonly port `465`). Use `plain` only for trusted relays without authentication, or for localhost SMTP testing.
+
+### SMTP_FROM_ADDRESS
+
+Sender email address. Required when `SMTP_ENABLED=1`.
+
+```bash
+SMTP_FROM_ADDRESS=noreply@example.com
+```
+
+Use a bare email address here. Put any display name in `SMTP_FROM_NAME`.
+
+### SMTP_FROM_NAME
+
+Optional sender display name.
+
+```bash
+SMTP_FROM_NAME="Open SSPM"
+```
+
+### SMTP_USERNAME / SMTP_PASSWORD
+
+Optional SMTP authentication credentials. Set both or leave both empty.
+
+```bash
+SMTP_USERNAME=mailer
+SMTP_PASSWORD=change-me
+```
+
+When `SMTP_TLS_MODE=plain`, authenticated SMTP is supported only for localhost relays.
+
 ## Sync
 
 ### SYNC_INTERVAL

--- a/docs/config/environment-variables.md
+++ b/docs/config/environment-variables.md
@@ -183,7 +183,7 @@ Sender email address. Required when `SMTP_ENABLED=1`.
 SMTP_FROM_ADDRESS=noreply@example.com
 ```
 
-Use a bare email address here. Put any display name in `SMTP_FROM_NAME`.
+Supports either a bare email address or a full mailbox such as `noreply@example.com` or `"Open SSPM <noreply@example.com>"`. Prefer setting any display name in `SMTP_FROM_NAME`; if `SMTP_FROM_NAME` is empty and a display name is included here, it will be used.
 
 ### SMTP_FROM_NAME
 

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -91,6 +91,16 @@ connectorSecret:
     name: open-sspm-app
     key: CONNECTOR_SECRET_KEY
 
+smtp:
+  enabled: true
+  host: smtp.example.com
+  port: 587
+  tlsMode: starttls
+  fromAddress: noreply@example.com
+  fromName: Open SSPM
+  existingSecret:
+    name: open-sspm-smtp
+
 config:
   syncInterval: 15m
   syncDiscoveryInterval: 15m
@@ -143,6 +153,32 @@ Install with a values file:
 ```bash
 helm upgrade --install open-sspm ./helm/open-sspm -f values.yaml
 ```
+
+### SMTP Relay
+
+If you want Open-SSPM to send email through an SMTP relay, create a Secret with the relay credentials and reference it from `smtp.existingSecret.name`.
+
+```bash
+kubectl create secret generic open-sspm-smtp \
+  --from-literal=SMTP_USERNAME='mailer' \
+  --from-literal=SMTP_PASSWORD='change-me'
+```
+
+Then configure the chart:
+
+```yaml
+smtp:
+  enabled: true
+  host: smtp.example.com
+  port: 587
+  tlsMode: starttls
+  fromAddress: noreply@example.com
+  fromName: Open SSPM
+  existingSecret:
+    name: open-sspm-smtp
+```
+
+SMTP credentials are optional; if your relay does not require authentication, leave `smtp.existingSecret.name` empty.
 
 ### Ingress
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -182,7 +182,7 @@ kubectl port-forward svc/<service-name> 8080:80
 
 - `smtp.enabled` controls `SMTP_ENABLED`
 - `smtp.host`, `smtp.port`, `smtp.tlsMode`, `smtp.fromAddress`, and `smtp.fromName` configure the relay
-- `smtp.existingSecret.name` injects optional `SMTP_USERNAME` / `SMTP_PASSWORD` credentials from a Secret
+- `smtp.existingSecret.name` injects `SMTP_USERNAME` / `SMTP_PASSWORD` credentials from a Secret when configured
 - The chart passes SMTP env vars to the Deployments and hook Jobs so `migrate`, `seed-rules`, and `bootstrap-admin` all see the same config contract
 
 ### Metrics service component selector

--- a/helm/README.md
+++ b/helm/README.md
@@ -56,6 +56,17 @@ kubectl create secret generic open-sspm-app \
   --from-literal=CONNECTOR_SECRET_KEY="$(openssl rand -base64 32)"
 ```
 
+### SMTP relay credentials (`SMTP_USERNAME` / `SMTP_PASSWORD`)
+
+If you want Open-SSPM to send email through an SMTP relay, configure the `smtp.*` values and optionally provide SMTP credentials via an existing Secret.
+
+Example:
+```bash
+kubectl create secret generic open-sspm-smtp \
+  --from-literal=SMTP_USERNAME='mailer' \
+  --from-literal=SMTP_PASSWORD='change-me'
+```
+
 ### Install / upgrade
 
 Minimal install:
@@ -65,6 +76,22 @@ helm upgrade --install open-sspm ./helm/open-sspm \
   --set image.tag=<tag> \
   --set database.existingSecret.name=open-sspm-db \
   --set connectorSecret.existingSecret.name=open-sspm-app
+```
+
+Example with SMTP enabled:
+```bash
+helm upgrade --install open-sspm ./helm/open-sspm \
+  --set image.repository=ghcr.io/<org>/<repo> \
+  --set image.tag=<tag> \
+  --set database.existingSecret.name=open-sspm-db \
+  --set connectorSecret.existingSecret.name=open-sspm-app \
+  --set smtp.enabled=true \
+  --set smtp.host=smtp.example.com \
+  --set smtp.port=587 \
+  --set smtp.tlsMode=starttls \
+  --set smtp.fromAddress=noreply@example.com \
+  --set smtp.fromName="Open SSPM" \
+  --set smtp.existingSecret.name=open-sspm-smtp
 ```
 
 ### Migrations (pre-install/pre-upgrade Job)
@@ -150,6 +177,13 @@ kubectl port-forward svc/<service-name> 8080:80
 - `config.logFormat` controls `LOG_FORMAT` (default: `json`; allowed: `json`, `text`)
 - `config.logLevel` controls `LOG_LEVEL` (default: `info`; allowed: `debug`, `info`, `warn`, `error`)
 - Invalid values fail fast during command startup.
+
+### SMTP
+
+- `smtp.enabled` controls `SMTP_ENABLED`
+- `smtp.host`, `smtp.port`, `smtp.tlsMode`, `smtp.fromAddress`, and `smtp.fromName` configure the relay
+- `smtp.existingSecret.name` injects optional `SMTP_USERNAME` / `SMTP_PASSWORD` credentials from a Secret
+- The chart passes SMTP env vars to the Deployments and hook Jobs so `migrate`, `seed-rules`, and `bootstrap-admin` all see the same config contract
 
 ### Metrics service component selector
 

--- a/helm/open-sspm/templates/_helpers.tpl
+++ b/helm/open-sspm/templates/_helpers.tpl
@@ -40,3 +40,34 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- default "default" .Values.serviceAccount.name -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "open-sspm.smtpEnv" -}}
+- name: SMTP_ENABLED
+  value: {{ ternary "1" "0" .Values.smtp.enabled | quote }}
+{{- if .Values.smtp.enabled }}
+- name: SMTP_HOST
+  value: {{ .Values.smtp.host | quote }}
+- name: SMTP_PORT
+  value: {{ .Values.smtp.port | quote }}
+- name: SMTP_TLS_MODE
+  value: {{ .Values.smtp.tlsMode | quote }}
+- name: SMTP_FROM_ADDRESS
+  value: {{ .Values.smtp.fromAddress | quote }}
+- name: SMTP_FROM_NAME
+  value: {{ .Values.smtp.fromName | quote }}
+{{- if .Values.smtp.existingSecret.name }}
+- name: SMTP_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.smtp.existingSecret.name }}
+      key: {{ .Values.smtp.existingSecret.usernameKey | quote }}
+      optional: true
+- name: SMTP_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.smtp.existingSecret.name }}
+      key: {{ .Values.smtp.existingSecret.passwordKey | quote }}
+      optional: true
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/helm/open-sspm/templates/_helpers.tpl
+++ b/helm/open-sspm/templates/_helpers.tpl
@@ -60,14 +60,14 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
   valueFrom:
     secretKeyRef:
       name: {{ .Values.smtp.existingSecret.name }}
-      key: {{ .Values.smtp.existingSecret.usernameKey | quote }}
-      optional: true
+      key: {{ required "smtp.existingSecret.usernameKey is required when smtp.existingSecret.name is set" .Values.smtp.existingSecret.usernameKey | quote }}
+      optional: false
 - name: SMTP_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ .Values.smtp.existingSecret.name }}
-      key: {{ .Values.smtp.existingSecret.passwordKey | quote }}
-      optional: true
+      key: {{ required "smtp.existingSecret.passwordKey is required when smtp.existingSecret.name is set" .Values.smtp.existingSecret.passwordKey | quote }}
+      optional: false
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/helm/open-sspm/templates/deployment-serve.yaml
+++ b/helm/open-sspm/templates/deployment-serve.yaml
@@ -97,6 +97,7 @@ spec:
               value: {{ .Values.config.syncGithubWorkers | quote }}
             - name: SYNC_DATADOG_WORKERS
               value: {{ .Values.config.syncDatadogWorkers | quote }}
+            {{- include "open-sspm.smtpEnv" . | nindent 12 }}
             {{- with .Values.serve.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/helm/open-sspm/templates/deployment-worker-discovery.yaml
+++ b/helm/open-sspm/templates/deployment-worker-discovery.yaml
@@ -81,6 +81,7 @@ spec:
               value: {{ .Values.config.syncGithubWorkers | quote }}
             - name: SYNC_DATADOG_WORKERS
               value: {{ .Values.config.syncDatadogWorkers | quote }}
+            {{- include "open-sspm.smtpEnv" . | nindent 12 }}
             {{- with .Values.discoveryWorker.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/helm/open-sspm/templates/deployment-worker.yaml
+++ b/helm/open-sspm/templates/deployment-worker.yaml
@@ -86,6 +86,7 @@ spec:
               value: {{ .Values.config.syncGithubWorkers | quote }}
             - name: SYNC_DATADOG_WORKERS
               value: {{ .Values.config.syncDatadogWorkers | quote }}
+            {{- include "open-sspm.smtpEnv" . | nindent 12 }}
             {{- with .Values.worker.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/helm/open-sspm/templates/job-bootstrap-admin.yaml
+++ b/helm/open-sspm/templates/job-bootstrap-admin.yaml
@@ -64,6 +64,7 @@ spec:
                 secretKeyRef:
                   name: {{ required "database.existingSecret.name is required" .Values.database.existingSecret.name }}
                   key: {{ required "database.existingSecret.key is required" .Values.database.existingSecret.key }}
+            {{- include "open-sspm.smtpEnv" . | nindent 12 }}
             - name: ADMIN_EMAIL
               valueFrom:
                 secretKeyRef:

--- a/helm/open-sspm/templates/job-migrate.yaml
+++ b/helm/open-sspm/templates/job-migrate.yaml
@@ -48,6 +48,7 @@ spec:
                 secretKeyRef:
                   name: {{ required "database.existingSecret.name is required" .Values.database.existingSecret.name }}
                   key: {{ required "database.existingSecret.key is required" .Values.database.existingSecret.key }}
+            {{- include "open-sspm.smtpEnv" . | nindent 12 }}
             - name: LOG_FORMAT
               value: {{ .Values.config.logFormat | quote }}
             - name: LOG_LEVEL

--- a/helm/open-sspm/templates/job-seed-rules.yaml
+++ b/helm/open-sspm/templates/job-seed-rules.yaml
@@ -51,6 +51,7 @@ spec:
                 secretKeyRef:
                   name: {{ required "database.existingSecret.name is required" .Values.database.existingSecret.name }}
                   key: {{ required "database.existingSecret.key is required" .Values.database.existingSecret.key }}
+            {{- include "open-sspm.smtpEnv" . | nindent 12 }}
             - name: LOG_FORMAT
               value: {{ .Values.config.logFormat | quote }}
             - name: LOG_LEVEL

--- a/helm/open-sspm/values.yaml
+++ b/helm/open-sspm/values.yaml
@@ -24,6 +24,18 @@ connectorSecret:
     name: ""
     key: CONNECTOR_SECRET_KEY
 
+smtp:
+  enabled: false
+  host: ""
+  port: 587
+  tlsMode: "starttls"
+  fromAddress: ""
+  fromName: ""
+  existingSecret:
+    name: ""
+    usernameKey: SMTP_USERNAME
+    passwordKey: SMTP_PASSWORD
+
 config:
   httpAddr: ":8080"
   # Metrics listener (set to "off" to disable).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/mail"
 	"os"
 	"strconv"
 	"strings"
@@ -19,6 +20,8 @@ const (
 	defaultSyncInterval          = 15 * time.Minute
 	defaultSyncDiscoveryInterval = 15 * time.Minute
 	defaultStartupReadModelMode  = StartupReadModelRebuildAuto
+	defaultSMTPPort              = 587
+	defaultSMTPTLSMode           = SMTPTLSModeStartTLS
 
 	defaultSyncOktaWorkers    = 3
 	defaultSyncGitHubWorkers  = 6
@@ -33,11 +36,16 @@ const (
 const (
 	StartupReadModelRebuildAuto   = "auto"
 	StartupReadModelRebuildAlways = "always"
+
+	SMTPTLSModeStartTLS = "starttls"
+	SMTPTLSModeTLS      = "tls"
+	SMTPTLSModePlain    = "plain"
 )
 
 type Config struct {
 	DatabaseURL                 string
 	ConnectorSecretKey          []byte
+	SMTP                        SMTPConfig
 	HTTPAddr                    string
 	MetricsAddr                 string
 	StaticDir                   string
@@ -66,6 +74,17 @@ type Config struct {
 	SyncLockHeartbeatTimeout    time.Duration
 	SyncLockInstanceID          string
 	StartupReadModelRebuildMode string
+}
+
+type SMTPConfig struct {
+	Enabled     bool
+	Host        string
+	Port        int
+	Username    string
+	Password    string
+	FromAddress string
+	FromName    string
+	TLSMode     string
 }
 
 type LoadOptions struct {
@@ -109,6 +128,11 @@ func LoadWithOptions(opts LoadOptions) (Config, error) {
 		SyncLockHeartbeatTimeout:  defaultSyncLockHeartbeatTimeout,
 		SyncLockInstanceID:        strings.TrimSpace(os.Getenv("SYNC_LOCK_INSTANCE_ID")),
 	}
+	smtpConfig, err := loadSMTPConfig()
+	if err != nil {
+		return cfg, err
+	}
+	cfg.SMTP = smtpConfig
 
 	cfg.MetricsAddr = loadMetricsAddr(cfg.MetricsAddr)
 	if err := applyDurationEnvOverrides(&cfg); err != nil {
@@ -206,6 +230,75 @@ func validate(cfg Config, opts LoadOptions) error {
 	return nil
 }
 
+func loadSMTPConfig() (SMTPConfig, error) {
+	cfg := SMTPConfig{
+		Enabled: getenvBoolDefault("SMTP_ENABLED", false),
+		Port:    defaultSMTPPort,
+		TLSMode: defaultSMTPTLSMode,
+	}
+	if !cfg.Enabled {
+		return cfg, nil
+	}
+
+	cfg.Host = strings.TrimSpace(os.Getenv("SMTP_HOST"))
+	cfg.Username = strings.TrimSpace(os.Getenv("SMTP_USERNAME"))
+	cfg.Password = os.Getenv("SMTP_PASSWORD")
+	cfg.FromAddress = strings.TrimSpace(os.Getenv("SMTP_FROM_ADDRESS"))
+	cfg.FromName = strings.TrimSpace(os.Getenv("SMTP_FROM_NAME"))
+	cfg.TLSMode = strings.ToLower(strings.TrimSpace(getenvDefault("SMTP_TLS_MODE", defaultSMTPTLSMode)))
+
+	port, err := getenvRequiredPositiveIntDefault("SMTP_PORT", defaultSMTPPort)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.Port = port
+
+	if cfg.Host == "" {
+		return cfg, errors.New("SMTP_HOST is required when SMTP_ENABLED=1")
+	}
+	if cfg.FromAddress == "" {
+		return cfg, errors.New("SMTP_FROM_ADDRESS is required when SMTP_ENABLED=1")
+	}
+	if cfg.Port > 65535 {
+		return cfg, errors.New("SMTP_PORT must be between 1 and 65535")
+	}
+	switch cfg.TLSMode {
+	case SMTPTLSModeStartTLS, SMTPTLSModeTLS, SMTPTLSModePlain:
+	default:
+		return cfg, fmt.Errorf(
+			"SMTP_TLS_MODE must be one of: %s, %s, %s",
+			SMTPTLSModeStartTLS,
+			SMTPTLSModeTLS,
+			SMTPTLSModePlain,
+		)
+	}
+	addr, err := mail.ParseAddress(cfg.FromAddress)
+	if err != nil {
+		return cfg, fmt.Errorf("SMTP_FROM_ADDRESS must be a valid email address: %w", err)
+	}
+	cfg.FromAddress = addr.Address
+	if cfg.FromName == "" && strings.TrimSpace(addr.Name) != "" {
+		cfg.FromName = addr.Name
+	}
+	if (cfg.Username == "") != (cfg.Password == "") {
+		return cfg, errors.New("SMTP_USERNAME and SMTP_PASSWORD must either both be set or both be empty")
+	}
+	if cfg.Username != "" && cfg.TLSMode == SMTPTLSModePlain && !smtpPlainAuthAllowsInsecureHost(cfg.Host) {
+		return cfg, errors.New("SMTP_TLS_MODE=plain only supports SMTP authentication on localhost")
+	}
+
+	return cfg, nil
+}
+
+func smtpPlainAuthAllowsInsecureHost(host string) bool {
+	switch host {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	default:
+		return false
+	}
+}
+
 func loadConnectorSecretKey() ([]byte, error) {
 	raw := strings.TrimSpace(os.Getenv("CONNECTOR_SECRET_KEY"))
 	path := strings.TrimSpace(os.Getenv("CONNECTOR_SECRET_KEY_FILE"))
@@ -249,6 +342,21 @@ func getenvIntDefault(key string, def int) int {
 		return def
 	}
 	return n
+}
+
+func getenvRequiredPositiveIntDefault(key string, def int) (int, error) {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def, nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be a whole number", key)
+	}
+	if n < 1 {
+		return 0, fmt.Errorf("%s must be greater than zero", key)
+	}
+	return n, nil
 }
 
 func getenvBoolDefault(key string, def bool) bool {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -280,6 +280,9 @@ func loadSMTPConfig() (SMTPConfig, error) {
 	if cfg.FromName == "" && strings.TrimSpace(addr.Name) != "" {
 		cfg.FromName = addr.Name
 	}
+	if strings.ContainsAny(cfg.FromName, "\r\n") {
+		return cfg, errors.New("SMTP_FROM_NAME must not contain carriage returns or line feeds")
+	}
 	if (cfg.Username == "") != (cfg.Password == "") {
 		return cfg, errors.New("SMTP_USERNAME and SMTP_PASSWORD must either both be set or both be empty")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -178,3 +178,148 @@ func TestLoadWithOptions_RejectsInvalidStartupReadModelRebuildMode(t *testing.T)
 		t.Fatalf("expected invalid startup read model rebuild mode error")
 	}
 }
+
+func TestLoadWithOptions_SMTPDisabledByDefault(t *testing.T) {
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("SMTP_ENABLED", "")
+
+	cfg, err := LoadWithOptions(LoadOptions{RequireDatabaseURL: false})
+	if err != nil {
+		t.Fatalf("LoadWithOptions() error = %v", err)
+	}
+	if cfg.SMTP.Enabled {
+		t.Fatalf("SMTP.Enabled = true, want false")
+	}
+}
+
+func TestLoadWithOptions_LoadsSMTPConfig(t *testing.T) {
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("SMTP_ENABLED", "1")
+	t.Setenv("SMTP_HOST", "smtp.example.com")
+	t.Setenv("SMTP_FROM_ADDRESS", "noreply@example.com")
+	t.Setenv("SMTP_FROM_NAME", "Open SSPM")
+	t.Setenv("SMTP_USERNAME", "mailer")
+	t.Setenv("SMTP_PASSWORD", "secret")
+	t.Setenv("SMTP_PORT", "2525")
+	t.Setenv("SMTP_TLS_MODE", SMTPTLSModeTLS)
+
+	cfg, err := LoadWithOptions(LoadOptions{RequireDatabaseURL: false})
+	if err != nil {
+		t.Fatalf("LoadWithOptions() error = %v", err)
+	}
+	if !cfg.SMTP.Enabled {
+		t.Fatalf("SMTP.Enabled = false, want true")
+	}
+	if got, want := cfg.SMTP.Host, "smtp.example.com"; got != want {
+		t.Fatalf("SMTP.Host = %q, want %q", got, want)
+	}
+	if got, want := cfg.SMTP.Port, 2525; got != want {
+		t.Fatalf("SMTP.Port = %d, want %d", got, want)
+	}
+	if got, want := cfg.SMTP.TLSMode, SMTPTLSModeTLS; got != want {
+		t.Fatalf("SMTP.TLSMode = %q, want %q", got, want)
+	}
+	if got, want := cfg.SMTP.FromAddress, "noreply@example.com"; got != want {
+		t.Fatalf("SMTP.FromAddress = %q, want %q", got, want)
+	}
+	if got, want := cfg.SMTP.FromName, "Open SSPM"; got != want {
+		t.Fatalf("SMTP.FromName = %q, want %q", got, want)
+	}
+	if got, want := cfg.SMTP.Username, "mailer"; got != want {
+		t.Fatalf("SMTP.Username = %q, want %q", got, want)
+	}
+	if got, want := cfg.SMTP.Password, "secret"; got != want {
+		t.Fatalf("SMTP.Password = %q, want %q", got, want)
+	}
+}
+
+func TestLoadWithOptions_NormalizesSMTPFromAddress(t *testing.T) {
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("SMTP_ENABLED", "1")
+	t.Setenv("SMTP_HOST", "smtp.example.com")
+	t.Setenv("SMTP_FROM_ADDRESS", "Open SSPM <noreply@example.com>")
+	t.Setenv("SMTP_FROM_NAME", "")
+
+	cfg, err := LoadWithOptions(LoadOptions{RequireDatabaseURL: false})
+	if err != nil {
+		t.Fatalf("LoadWithOptions() error = %v", err)
+	}
+	if got, want := cfg.SMTP.FromAddress, "noreply@example.com"; got != want {
+		t.Fatalf("SMTP.FromAddress = %q, want %q", got, want)
+	}
+	if got, want := cfg.SMTP.FromName, "Open SSPM"; got != want {
+		t.Fatalf("SMTP.FromName = %q, want %q", got, want)
+	}
+}
+
+func TestLoadWithOptions_SMTPEnabledRequiresHost(t *testing.T) {
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("SMTP_ENABLED", "1")
+	t.Setenv("SMTP_HOST", "")
+	t.Setenv("SMTP_FROM_ADDRESS", "noreply@example.com")
+
+	_, err := LoadWithOptions(LoadOptions{RequireDatabaseURL: false})
+	if err == nil {
+		t.Fatalf("expected SMTP host validation error")
+	}
+}
+
+func TestLoadWithOptions_SMTPEnabledRejectsInvalidTLSMode(t *testing.T) {
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("SMTP_ENABLED", "1")
+	t.Setenv("SMTP_HOST", "smtp.example.com")
+	t.Setenv("SMTP_FROM_ADDRESS", "noreply@example.com")
+	t.Setenv("SMTP_TLS_MODE", "invalid")
+
+	_, err := LoadWithOptions(LoadOptions{RequireDatabaseURL: false})
+	if err == nil {
+		t.Fatalf("expected SMTP TLS mode validation error")
+	}
+}
+
+func TestLoadWithOptions_SMTPEnabledRejectsPartialAuth(t *testing.T) {
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("SMTP_ENABLED", "1")
+	t.Setenv("SMTP_HOST", "smtp.example.com")
+	t.Setenv("SMTP_FROM_ADDRESS", "noreply@example.com")
+	t.Setenv("SMTP_USERNAME", "mailer")
+	t.Setenv("SMTP_PASSWORD", "")
+
+	_, err := LoadWithOptions(LoadOptions{RequireDatabaseURL: false})
+	if err == nil {
+		t.Fatalf("expected SMTP auth validation error")
+	}
+}
+
+func TestLoadWithOptions_SMTPEnabledRejectsPlainAuthForRemoteHost(t *testing.T) {
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("SMTP_ENABLED", "1")
+	t.Setenv("SMTP_HOST", "smtp.example.com")
+	t.Setenv("SMTP_FROM_ADDRESS", "noreply@example.com")
+	t.Setenv("SMTP_USERNAME", "mailer")
+	t.Setenv("SMTP_PASSWORD", "secret")
+	t.Setenv("SMTP_TLS_MODE", SMTPTLSModePlain)
+
+	_, err := LoadWithOptions(LoadOptions{RequireDatabaseURL: false})
+	if err == nil {
+		t.Fatalf("expected plain SMTP auth validation error")
+	}
+}
+
+func TestLoadWithOptions_SMTPEnabledAllowsPlainAuthOnLocalhost(t *testing.T) {
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("SMTP_ENABLED", "1")
+	t.Setenv("SMTP_HOST", "localhost")
+	t.Setenv("SMTP_FROM_ADDRESS", "noreply@example.com")
+	t.Setenv("SMTP_USERNAME", "mailer")
+	t.Setenv("SMTP_PASSWORD", "secret")
+	t.Setenv("SMTP_TLS_MODE", SMTPTLSModePlain)
+
+	cfg, err := LoadWithOptions(LoadOptions{RequireDatabaseURL: false})
+	if err != nil {
+		t.Fatalf("LoadWithOptions() error = %v", err)
+	}
+	if got, want := cfg.SMTP.TLSMode, SMTPTLSModePlain; got != want {
+		t.Fatalf("SMTP.TLSMode = %q, want %q", got, want)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -252,6 +252,36 @@ func TestLoadWithOptions_NormalizesSMTPFromAddress(t *testing.T) {
 	}
 }
 
+func TestLoadWithOptions_RejectsSMTPFromNameWithHeaderBreak(t *testing.T) {
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("SMTP_ENABLED", "1")
+	t.Setenv("SMTP_HOST", "smtp.example.com")
+	t.Setenv("SMTP_FROM_ADDRESS", "noreply@example.com")
+	t.Setenv("SMTP_FROM_NAME", "Open\r\nSSPM")
+
+	_, err := LoadWithOptions(LoadOptions{RequireDatabaseURL: false})
+	if err == nil {
+		t.Fatalf("expected SMTP from name validation error")
+	}
+}
+
+func TestLoadWithOptions_PreservesSMTPPasswordBytes(t *testing.T) {
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("SMTP_ENABLED", "1")
+	t.Setenv("SMTP_HOST", "smtp.example.com")
+	t.Setenv("SMTP_FROM_ADDRESS", "noreply@example.com")
+	t.Setenv("SMTP_USERNAME", "mailer")
+	t.Setenv("SMTP_PASSWORD", "secret\r\n")
+
+	cfg, err := LoadWithOptions(LoadOptions{RequireDatabaseURL: false})
+	if err != nil {
+		t.Fatalf("LoadWithOptions() error = %v", err)
+	}
+	if got, want := cfg.SMTP.Password, "secret\r\n"; got != want {
+		t.Fatalf("SMTP.Password = %q, want %q", got, want)
+	}
+}
+
 func TestLoadWithOptions_SMTPEnabledRequiresHost(t *testing.T) {
 	t.Setenv("DATABASE_URL", "")
 	t.Setenv("SMTP_ENABLED", "1")

--- a/internal/http/handlers/base.go
+++ b/internal/http/handlers/base.go
@@ -20,6 +20,7 @@ import (
 	"github.com/open-sspm/open-sspm/internal/db/gen"
 	"github.com/open-sspm/open-sspm/internal/http/authn"
 	"github.com/open-sspm/open-sspm/internal/http/viewmodels"
+	"github.com/open-sspm/open-sspm/internal/mailer"
 )
 
 const (
@@ -43,6 +44,7 @@ type Handlers struct {
 	Sessions *scs.SessionManager
 	Syncer   SyncRunner
 	Registry *registry.ConnectorRegistry
+	Mailer   mailer.Mailer
 
 	oktaAppStatusesCache oktaAppStatusesCache
 }

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/open-sspm/open-sspm/internal/db/gen"
 	"github.com/open-sspm/open-sspm/internal/http/authn"
 	"github.com/open-sspm/open-sspm/internal/http/handlers"
+	"github.com/open-sspm/open-sspm/internal/mailer"
 )
 
 // EchoServer is the HTTP server wrapper.
@@ -37,7 +38,14 @@ type EchoServer struct {
 }
 
 // NewEchoServer creates a new HTTP server.
-func NewEchoServer(cfg config.Config, pool *pgxpool.Pool, q *gen.Queries, syncer handlers.SyncRunner, reg *registry.ConnectorRegistry) (*EchoServer, error) {
+func NewEchoServer(
+	cfg config.Config,
+	pool *pgxpool.Pool,
+	q *gen.Queries,
+	syncer handlers.SyncRunner,
+	reg *registry.ConnectorRegistry,
+	mailAdapter mailer.Mailer,
+) (*EchoServer, error) {
 	sessions := scs.New()
 	sessions.Store = pgxstore.New(pool)
 	sessions.HashTokenInStore = true
@@ -49,7 +57,15 @@ func NewEchoServer(cfg config.Config, pool *pgxpool.Pool, q *gen.Queries, syncer
 	sessions.Cookie.SameSite = http.SameSiteLaxMode
 	sessions.Cookie.Secure = cfg.AuthCookieSecure
 
-	h := &handlers.Handlers{Cfg: cfg, Q: q, Pool: pool, Syncer: syncer, Registry: reg, Sessions: sessions}
+	h := &handlers.Handlers{
+		Cfg:      cfg,
+		Q:        q,
+		Pool:     pool,
+		Sessions: sessions,
+		Syncer:   syncer,
+		Registry: reg,
+		Mailer:   mailAdapter,
+	}
 	es := &EchoServer{h: h, e: newEcho(cfg)}
 	es.e.Use(middleware.RequestIDWithConfig(middleware.RequestIDConfig{
 		RequestIDHandler: func(c *echo.Context, id string) {

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -1,0 +1,30 @@
+package mailer
+
+import "context"
+
+// Mailer sends plain-text transactional email messages.
+type Mailer interface {
+	Send(context.Context, Message) error
+}
+
+type Message struct {
+	To       []string
+	Subject  string
+	TextBody string
+}
+
+type SMTPConfig struct {
+	Host        string
+	Port        int
+	Username    string
+	Password    string
+	FromAddress string
+	FromName    string
+	TLSMode     string
+}
+
+const (
+	TLSModeStartTLS = "starttls"
+	TLSModeTLS      = "tls"
+	TLSModePlain    = "plain"
+)

--- a/internal/mailer/noop.go
+++ b/internal/mailer/noop.go
@@ -1,0 +1,13 @@
+package mailer
+
+import "context"
+
+type noopMailer struct{}
+
+func NewNoop() Mailer {
+	return noopMailer{}
+}
+
+func (noopMailer) Send(context.Context, Message) error {
+	return nil
+}

--- a/internal/mailer/smtp.go
+++ b/internal/mailer/smtp.go
@@ -1,0 +1,278 @@
+package mailer
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"mime/quotedprintable"
+	"net"
+	"net/mail"
+	"net/smtp"
+	"strings"
+	"time"
+)
+
+type smtpMailer struct {
+	config SMTPConfig
+}
+
+func NewSMTP(cfg SMTPConfig) (Mailer, error) {
+	normalized, err := normalizeSMTPConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &smtpMailer{config: normalized}, nil
+}
+
+func (m *smtpMailer) Send(ctx context.Context, msg Message) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	payload, recipients, err := buildMessage(m.config, msg)
+	if err != nil {
+		return err
+	}
+
+	client, err := m.connect(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = client.Close()
+	}()
+
+	if m.config.Username != "" {
+		auth := smtp.PlainAuth("", m.config.Username, m.config.Password, m.config.Host)
+		if err := client.Auth(auth); err != nil {
+			return fmt.Errorf("smtp auth: %w", err)
+		}
+	}
+
+	if err := client.Mail(m.config.FromAddress); err != nil {
+		return fmt.Errorf("smtp from: %w", err)
+	}
+	for _, recipient := range recipients {
+		if err := client.Rcpt(recipient); err != nil {
+			return fmt.Errorf("smtp recipient %q: %w", recipient, err)
+		}
+	}
+
+	writer, err := client.Data()
+	if err != nil {
+		return fmt.Errorf("smtp data: %w", err)
+	}
+	if _, err := writer.Write(payload); err != nil {
+		_ = writer.Close()
+		return fmt.Errorf("smtp write: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("smtp finalize: %w", err)
+	}
+
+	if err := client.Quit(); err != nil {
+		return fmt.Errorf("smtp quit: %w", err)
+	}
+	return nil
+}
+
+func (m *smtpMailer) connect(ctx context.Context) (*smtp.Client, error) {
+	hostPort := net.JoinHostPort(m.config.Host, fmt.Sprintf("%d", m.config.Port))
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		ServerName: m.config.Host,
+	}
+
+	var (
+		conn net.Conn
+		err  error
+	)
+
+	switch m.config.TLSMode {
+	case TLSModeTLS:
+		dialer := &tls.Dialer{
+			Config:    tlsConfig,
+			NetDialer: &net.Dialer{},
+		}
+		conn, err = dialer.DialContext(ctx, "tcp", hostPort)
+	case TLSModeStartTLS, TLSModePlain:
+		dialer := &net.Dialer{}
+		conn, err = dialer.DialContext(ctx, "tcp", hostPort)
+	default:
+		return nil, fmt.Errorf("unsupported SMTP TLS mode %q", m.config.TLSMode)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("smtp dial: %w", err)
+	}
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	}
+
+	client, err := smtp.NewClient(conn, m.config.Host)
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("smtp client: %w", err)
+	}
+
+	if m.config.TLSMode == TLSModeStartTLS {
+		if ok, _ := client.Extension("STARTTLS"); !ok {
+			_ = client.Close()
+			return nil, errors.New("smtp server does not advertise STARTTLS")
+		}
+		if err := client.StartTLS(tlsConfig); err != nil {
+			_ = client.Close()
+			return nil, fmt.Errorf("smtp starttls: %w", err)
+		}
+	}
+
+	return client, nil
+}
+
+func validateSMTPConfig(cfg SMTPConfig) error {
+	if strings.TrimSpace(cfg.Host) == "" {
+		return errors.New("smtp host is required")
+	}
+	if cfg.Port < 1 || cfg.Port > 65535 {
+		return errors.New("smtp port must be between 1 and 65535")
+	}
+	if strings.TrimSpace(cfg.FromAddress) == "" {
+		return errors.New("smtp from address is required")
+	}
+	if _, err := mail.ParseAddress(cfg.FromAddress); err != nil {
+		return fmt.Errorf("smtp from address: %w", err)
+	}
+	switch strings.ToLower(strings.TrimSpace(cfg.TLSMode)) {
+	case TLSModeStartTLS, TLSModeTLS, TLSModePlain:
+	default:
+		return fmt.Errorf("unsupported SMTP TLS mode %q", cfg.TLSMode)
+	}
+	if (strings.TrimSpace(cfg.Username) == "") != (cfg.Password == "") {
+		return errors.New("smtp username and password must either both be set or both be empty")
+	}
+	if cfg.Username != "" && cfg.TLSMode == TLSModePlain && !plainAuthAllowsInsecureHost(cfg.Host) {
+		return errors.New("smtp plain auth requires TLS or localhost")
+	}
+	if containsHeaderBreak(cfg.FromName) {
+		return errors.New("smtp from name must not contain line breaks")
+	}
+	return nil
+}
+
+func normalizeSMTPConfig(cfg SMTPConfig) (SMTPConfig, error) {
+	cfg.Host = strings.TrimSpace(cfg.Host)
+	cfg.Username = strings.TrimSpace(cfg.Username)
+	cfg.FromAddress = strings.TrimSpace(cfg.FromAddress)
+	cfg.FromName = strings.TrimSpace(cfg.FromName)
+	cfg.TLSMode = strings.ToLower(strings.TrimSpace(cfg.TLSMode))
+
+	addr, err := mail.ParseAddress(cfg.FromAddress)
+	if err != nil {
+		return cfg, fmt.Errorf("smtp from address: %w", err)
+	}
+	cfg.FromAddress = addr.Address
+	if cfg.FromName == "" && strings.TrimSpace(addr.Name) != "" {
+		cfg.FromName = addr.Name
+	}
+
+	if err := validateSMTPConfig(cfg); err != nil {
+		return cfg, err
+	}
+	return cfg, nil
+}
+
+func buildMessage(cfg SMTPConfig, msg Message) ([]byte, []string, error) {
+	recipients, toHeader, err := normalizeRecipients(msg.To)
+	if err != nil {
+		return nil, nil, err
+	}
+	if containsHeaderBreak(msg.Subject) {
+		return nil, nil, errors.New("email subject must not contain line breaks")
+	}
+
+	var buf bytes.Buffer
+	if _, err := fmt.Fprintf(&buf, "Date: %s\r\n", time.Now().UTC().Format(time.RFC1123Z)); err != nil {
+		return nil, nil, err
+	}
+	if _, err := fmt.Fprintf(&buf, "From: %s\r\n", (&mail.Address{
+		Name:    cfg.FromName,
+		Address: cfg.FromAddress,
+	}).String()); err != nil {
+		return nil, nil, err
+	}
+	if _, err := fmt.Fprintf(&buf, "To: %s\r\n", strings.Join(toHeader, ", ")); err != nil {
+		return nil, nil, err
+	}
+	if subject := strings.TrimSpace(msg.Subject); subject != "" {
+		if _, err := fmt.Fprintf(&buf, "Subject: %s\r\n", mime.QEncoding.Encode("utf-8", subject)); err != nil {
+			return nil, nil, err
+		}
+	}
+	if _, err := io.WriteString(&buf, "MIME-Version: 1.0\r\n"); err != nil {
+		return nil, nil, err
+	}
+	if _, err := io.WriteString(&buf, "Content-Type: text/plain; charset=UTF-8\r\n"); err != nil {
+		return nil, nil, err
+	}
+	if _, err := io.WriteString(&buf, "Content-Transfer-Encoding: quoted-printable\r\n\r\n"); err != nil {
+		return nil, nil, err
+	}
+
+	qp := quotedprintable.NewWriter(&buf)
+	if _, err := io.WriteString(qp, normalizeBody(msg.TextBody)); err != nil {
+		_ = qp.Close()
+		return nil, nil, err
+	}
+	if err := qp.Close(); err != nil {
+		return nil, nil, err
+	}
+
+	return buf.Bytes(), recipients, nil
+}
+
+func normalizeRecipients(values []string) ([]string, []string, error) {
+	if len(values) == 0 {
+		return nil, nil, errors.New("email must include at least one recipient")
+	}
+
+	recipients := make([]string, 0, len(values))
+	headers := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		addr, err := mail.ParseAddress(value)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid recipient address %q: %w", value, err)
+		}
+		recipients = append(recipients, addr.Address)
+		headers = append(headers, addr.String())
+	}
+	if len(recipients) == 0 {
+		return nil, nil, errors.New("email must include at least one recipient")
+	}
+	return recipients, headers, nil
+}
+
+func normalizeBody(body string) string {
+	body = strings.ReplaceAll(body, "\r\n", "\n")
+	body = strings.ReplaceAll(body, "\r", "\n")
+	return strings.ReplaceAll(body, "\n", "\r\n")
+}
+
+func containsHeaderBreak(value string) bool {
+	return strings.ContainsAny(value, "\r\n")
+}
+
+func plainAuthAllowsInsecureHost(host string) bool {
+	switch host {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/mailer/smtp_test.go
+++ b/internal/mailer/smtp_test.go
@@ -1,0 +1,106 @@
+package mailer
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestNewSMTPRejectsInvalidConfig(t *testing.T) {
+	_, err := NewSMTP(SMTPConfig{
+		Host:        "",
+		Port:        587,
+		FromAddress: "noreply@example.com",
+		TLSMode:     TLSModeStartTLS,
+	})
+	if err == nil {
+		t.Fatalf("expected invalid SMTP config error")
+	}
+}
+
+func TestNewSMTPRejectsPlainAuthWithoutTLSForRemoteHost(t *testing.T) {
+	_, err := NewSMTP(SMTPConfig{
+		Host:        "smtp.example.com",
+		Port:        587,
+		Username:    "mailer",
+		Password:    "secret",
+		FromAddress: "noreply@example.com",
+		TLSMode:     TLSModePlain,
+	})
+	if err == nil {
+		t.Fatalf("expected invalid SMTP auth config error")
+	}
+}
+
+func TestNewSMTPNormalizesFromMailbox(t *testing.T) {
+	m, err := NewSMTP(SMTPConfig{
+		Host:        "smtp.example.com",
+		Port:        587,
+		FromAddress: "Open SSPM <noreply@example.com>",
+		TLSMode:     TLSModeStartTLS,
+	})
+	if err != nil {
+		t.Fatalf("NewSMTP() error = %v", err)
+	}
+
+	smtpMailer, ok := m.(*smtpMailer)
+	if !ok {
+		t.Fatalf("NewSMTP() returned %T, want *smtpMailer", m)
+	}
+	if got, want := smtpMailer.config.FromAddress, "noreply@example.com"; got != want {
+		t.Fatalf("FromAddress = %q, want %q", got, want)
+	}
+	if got, want := smtpMailer.config.FromName, "Open SSPM"; got != want {
+		t.Fatalf("FromName = %q, want %q", got, want)
+	}
+}
+
+func TestBuildMessageFormatsHeadersAndRecipients(t *testing.T) {
+	payload, recipients, err := buildMessage(SMTPConfig{
+		Host:        "smtp.example.com",
+		Port:        587,
+		FromAddress: "noreply@example.com",
+		FromName:    "Open SSPM",
+		TLSMode:     TLSModeStartTLS,
+	}, Message{
+		To:       []string{"Alice <alice@example.com>", "bob@example.com"},
+		Subject:  "Hello",
+		TextBody: "Line one\nLine two",
+	})
+	if err != nil {
+		t.Fatalf("buildMessage() error = %v", err)
+	}
+
+	if got, want := len(recipients), 2; got != want {
+		t.Fatalf("len(recipients) = %d, want %d", got, want)
+	}
+	if got, want := recipients[0], "alice@example.com"; got != want {
+		t.Fatalf("recipients[0] = %q, want %q", got, want)
+	}
+	if got, want := recipients[1], "bob@example.com"; got != want {
+		t.Fatalf("recipients[1] = %q, want %q", got, want)
+	}
+
+	rendered := string(payload)
+	for _, expected := range []string{
+		"From: \"Open SSPM\" <noreply@example.com>\r\n",
+		"To: \"Alice\" <alice@example.com>, <bob@example.com>\r\n",
+		"Subject: Hello\r\n",
+		"Content-Type: text/plain; charset=UTF-8\r\n",
+		"Line one\r\nLine two",
+	} {
+		if !strings.Contains(rendered, expected) {
+			t.Fatalf("rendered message missing %q\n%s", expected, rendered)
+		}
+	}
+}
+
+func TestNoopMailerSend(t *testing.T) {
+	if err := NewNoop().Send(context.Background(), Message{
+		To:       []string{"user@example.com"},
+		Subject:  "ignored",
+		TextBody: "ignored",
+	}); err != nil {
+		t.Fatalf("NewNoop().Send() error = %v", err)
+	}
+}

--- a/internal/mailer/smtp_test.go
+++ b/internal/mailer/smtp_test.go
@@ -55,6 +55,28 @@ func TestNewSMTPNormalizesFromMailbox(t *testing.T) {
 	}
 }
 
+func TestNewSMTPPreservesPasswordBytes(t *testing.T) {
+	m, err := NewSMTP(SMTPConfig{
+		Host:        "smtp.example.com",
+		Port:        587,
+		Username:    "mailer",
+		Password:    "secret\r\n",
+		FromAddress: "noreply@example.com",
+		TLSMode:     TLSModeStartTLS,
+	})
+	if err != nil {
+		t.Fatalf("NewSMTP() error = %v", err)
+	}
+
+	smtpMailer, ok := m.(*smtpMailer)
+	if !ok {
+		t.Fatalf("NewSMTP() returned %T, want *smtpMailer", m)
+	}
+	if got, want := smtpMailer.config.Password, "secret\r\n"; got != want {
+		t.Fatalf("Password = %q, want %q", got, want)
+	}
+}
+
 func TestBuildMessageFormatsHeadersAndRecipients(t *testing.T) {
 	payload, recipients, err := buildMessage(SMTPConfig{
 		Host:        "smtp.example.com",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds optional outbound email via SMTP, introducing a `mailer` package with a `Mailer` interface, a production SMTP adapter (STARTTLS/TLS/plain modes with `PlainAuth`), and a no-op fallback when SMTP is disabled. Config is loaded from environment variables with validation at both the `config` and `mailer` layers, and Helm support is added via a shared `smtpEnv` helper template.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are P2 style/hardening suggestions that do not affect correctness.

The SMTP implementation is well-structured: proper TLS configuration, context-aware dialing, correct PlainAuth usage, CRLF-injection guards, and thorough tests at both the mailer and config layers. The two P2 findings (optional secret refs in Helm; missing FromName header-injection guard in loadSMTPConfig) are non-blocking because the mailer validation catches them before any email is sent.

helm/open-sspm/templates/_helpers.tpl (optional: true on secret refs) and internal/config/config.go (missing FromName line-break check at load time)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/mailer/smtp.go | Core SMTP client: solid TLS/STARTTLS handling, proper PlainAuth hostname checks, context-deadline propagation, and quoted-printable encoding — no issues found. |
| internal/config/config.go | Loads and validates SMTP config from environment; missing the FromName header-injection guard that exists in the mailer layer (P2). |
| helm/open-sspm/templates/_helpers.tpl | New smtpEnv helper correctly renders SMTP env vars; SMTP_USERNAME/PASSWORD secretKeyRefs marked optional: true which can hide misconfigured secrets (P2). |
| cmd/open-sspm/runtime.go | Wires the mailer into runtimeDependencies via openMailer; correctly falls back to noop when SMTP is disabled. |
| internal/mailer/smtp_test.go | Good unit test coverage: invalid config, PlainAuth-without-TLS rejection, address normalization, message header formatting, and noop path. |
| internal/config/config_test.go | New SMTP config tests cover all validation paths: missing host, invalid TLS mode, partial auth, plain-auth-on-remote rejection, and localhost allowance. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant ENV as Environment
    participant CFG as config.loadSMTPConfig
    participant RT as openMailer (runtime.go)
    participant SM as mailer.NewSMTP
    participant SV as EchoServer / Handlers
    participant SMTP as SMTP Relay

    ENV->>CFG: SMTP_* env vars
    CFG->>RT: SMTPConfig (validated)
    alt SMTP_ENABLED=1
        RT->>SM: mailer.SMTPConfig (mapped fields)
        SM->>SM: normalizeSMTPConfig + validateSMTPConfig
        SM-->>RT: *smtpMailer
    else SMTP_ENABLED=0
        RT-->>RT: noopMailer
    end
    RT->>SV: inject Mailer into Handlers
    SV->>SM: Send(ctx, Message)
    SM->>SMTP: Dial (TLS / STARTTLS / plain)
    SM->>SMTP: AUTH PLAIN
    SM->>SMTP: MAIL FROM / RCPT TO / DATA
    SMTP-->>SM: 250 OK
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: helm/open-sspm/templates/_helpers.tpl
Line: 55-64

Comment:
**`optional: true` may silently hide missing SMTP secrets**

Both `SMTP_USERNAME` and `SMTP_PASSWORD` are sourced from a `secretKeyRef` with `optional: true`. If the secret named in `smtp.existingSecret.name` is not yet created (e.g. an operator forgets to create it), Kubernetes will start the pod with both env vars unset — which is a valid "no-auth" config — rather than refusing to start. The misconfiguration is only discovered at runtime when authenticated sends fail. Consider removing `optional: true` so a missing secret causes the pod to enter `CreateContainerConfigError` immediately.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/config/config.go
Line: 247-248

Comment:
**`FromName` not checked for header-injection in `loadSMTPConfig`**

`mailer.validateSMTPConfig` calls `containsHeaderBreak(cfg.FromName)` to guard against CRLF header injection, but `loadSMTPConfig` loads `SMTP_FROM_NAME` from the environment without the same check. In the current call chain this is caught before any email is sent (because `mailer.NewSMTP` runs full validation), but the two validation layers are diverging: if the config is ever consumed without going through `NewSMTP`, the injection check would be silently skipped. Adding the check here keeps both layers in sync.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: smtp for emails"](https://github.com/open-sspm/open-sspm/commit/93b79b693296ab36b9964830d821114972a25d58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28866318)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->