### PR TITLE
fix: Implemented the identity pagination clamp.

### DIFF
--- a/internal/http/handlers/identities.go
+++ b/internal/http/handlers/identities.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"sort"
@@ -113,25 +114,29 @@ func (h *Handlers) HandleIdentities(c *echo.Context) error {
 	if requestedPage < 1 {
 		requestedPage = 1
 	}
-	requestedOffset := int32((requestedPage - 1) * perPage)
+	requestedOffset, requestedOffsetOK := pageOffsetInt32(requestedPage, perPage)
 
-	rows, err := h.Q.ListIdentitiesInventoryPageByFilters(ctx, listParams(requestedOffset))
-	if err != nil {
-		return h.RenderError(c, err)
+	var rows []gen.ListIdentitiesInventoryPageByFiltersRow
+	if requestedOffsetOK {
+		rows, err = h.Q.ListIdentitiesInventoryPageByFilters(ctx, listParams(requestedOffset))
+		if err != nil {
+			return h.RenderError(c, err)
+		}
 	}
 
 	totalCount := int64(0)
 	switch {
 	case len(rows) > 0:
 		totalCount = rows[0].TotalCount
-	case requestedPage > 1:
+	case requestedPage > 1 || !requestedOffsetOK:
 		totalCount, err = h.Q.CountIdentitiesInventoryByFilters(ctx, countParams)
 		if err != nil {
 			return h.RenderError(c, err)
 		}
 		pagination = newPaginatedListState(totalCount, page, perPage)
-		if totalCount > 0 && pagination.Offset() != int(requestedOffset) {
-			rows, err = h.Q.ListIdentitiesInventoryPageByFilters(ctx, listParams(int32(pagination.Offset())))
+		clampedOffset, clampedOffsetOK := pageOffsetInt32(pagination.page, perPage)
+		if totalCount > 0 && clampedOffsetOK && (!requestedOffsetOK || clampedOffset != requestedOffset) {
+			rows, err = h.Q.ListIdentitiesInventoryPageByFilters(ctx, listParams(clampedOffset))
 			if err != nil {
 				return h.RenderError(c, err)
 			}
@@ -169,6 +174,22 @@ func (h *Handlers) HandleIdentities(c *echo.Context) error {
 	}
 
 	return renderIdentities()
+}
+
+func pageOffsetInt32(page, perPage int) (int32, bool) {
+	if page < 1 {
+		page = 1
+	}
+	if perPage < 1 {
+		perPage = 1
+	}
+	pageIndex := int64(page - 1)
+	perPage64 := int64(perPage)
+	if pageIndex > math.MaxInt32/perPage64 {
+		return 0, false
+	}
+	offset := pageIndex * perPage64
+	return int32(offset), true
 }
 
 func availableIdentitySourcePairs(stateView connectorStateView) []viewmodels.ProgrammaticSourceOption {

--- a/internal/http/handlers/identities_integration_test.go
+++ b/internal/http/handlers/identities_integration_test.go
@@ -32,24 +32,35 @@ func TestHandleIdentitiesClampsOutOfRangePage(t *testing.T) {
 		identityID := insertCommandSearchIdentity(t, ctx, pool, "human", "person@example.com", "Example Person")
 		insertCommandSearchIdentityAccountLink(t, ctx, pool, identityID, accountID)
 
-		c, rec := newTestContext(http.MethodGet, "http://example.com/identities?page=200000000")
-		if err := h.HandleIdentities(c); err != nil {
-			t.Fatalf("HandleIdentities() error = %v", err)
+		tests := []struct {
+			name string
+			page string
+		}{
+			{name: "valid offset beyond last page", page: "2"},
+			{name: "overflowing offset", page: "200000000"},
 		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				c, rec := newTestContext(http.MethodGet, "http://example.com/identities?page="+tt.page)
+				if err := h.HandleIdentities(c); err != nil {
+					t.Fatalf("HandleIdentities() error = %v", err)
+				}
 
-		if rec.Code != http.StatusOK {
-			t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
-		}
+				if rec.Code != http.StatusOK {
+					t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+				}
 
-		body := rec.Body.String()
-		if !strings.Contains(body, "Example Person") {
-			t.Fatalf("body missing identity row: %s", body)
-		}
-		if !strings.Contains(body, "Showing 1-1 of 1") {
-			t.Fatalf("body missing showing summary: %s", body)
-		}
-		if strings.Contains(body, "No identities found") {
-			t.Fatalf("body unexpectedly rendered empty state: %s", body)
+				body := rec.Body.String()
+				if !strings.Contains(body, "Example Person") {
+					t.Fatalf("body missing identity row: %s", body)
+				}
+				if !strings.Contains(body, "Showing 1-1 of 1") {
+					t.Fatalf("body missing showing summary: %s", body)
+				}
+				if strings.Contains(body, "No identities found") {
+					t.Fatalf("body unexpectedly rendered empty state: %s", body)
+				}
+			})
 		}
 	})
 }

--- a/internal/http/handlers/identities_integration_test.go
+++ b/internal/http/handlers/identities_integration_test.go
@@ -32,7 +32,7 @@ func TestHandleIdentitiesClampsOutOfRangePage(t *testing.T) {
 		identityID := insertCommandSearchIdentity(t, ctx, pool, "human", "person@example.com", "Example Person")
 		insertCommandSearchIdentityAccountLink(t, ctx, pool, identityID, accountID)
 
-		c, rec := newTestContext(http.MethodGet, "http://example.com/identities?page=2")
+		c, rec := newTestContext(http.MethodGet, "http://example.com/identities?page=200000000")
 		if err := h.HandleIdentities(c); err != nil {
 			t.Fatalf("HandleIdentities() error = %v", err)
 		}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an integer-overflow bug in the identities pagination handler: very large `page` query parameters (e.g., `page=200000000`) previously caused an unchecked `int32` cast that could silently wrap into a negative or nonsensical DB offset. The fix introduces a helper `pageOffsetInt32` that detects overflow and returns a boolean guard, and updates the handler to skip the initial query and fall back to a count-then-clamp path when the offset is out of range. The math in `pageOffsetInt32` is correct: the guard `pageIndex > math.MaxInt32/perPage64` ensures the product `pageIndex * perPage64` always fits in `int32`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the fix is mathematically correct and the only remaining finding is a P2 test coverage gap.

The overflow guard is correct, the handler logic properly handles both the normal and overflow paths, and an integration test exercises the new behavior. The only open item (dropped coverage of the ordinary out-of-range page path) is a P2 style concern that does not affect correctness.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/http/handlers/identities.go | Introduces overflow-safe pageOffsetInt32 helper and updates HandleIdentities to skip the DB query and clamp the page when the offset would exceed int32 bounds. |
| internal/http/handlers/identities_integration_test.go | Updates the test to use page=200000000 (int32-overflowing value) to cover the new clamp path; the prior page=2 out-of-range case is no longer exercised by this test. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[HandleIdentities page perPage] --> B[pageOffsetInt32 page perPage]
    B --> C{offset fits in int32?}
    C -- Yes OK=true --> D[Query DB: ListIdentitiesInventoryPageByFilters offset]
    C -- No OK=false --> E[rows = empty]
    D --> F{len rows > 0?}
    F -- Yes --> G[totalCount = rows 0 .TotalCount]
    F -- No --> H{requestedPage gt 1 or not OK?}
    E --> H
    H -- Yes --> I[CountIdentitiesInventoryByFilters -> totalCount]
    I --> J[newPaginatedListState -> clamped pagination.page]
    J --> K[pageOffsetInt32 pagination.page perPage]
    K --> L{totalCount gt 0 and clampedOK and offset differs?}
    L -- Yes --> M[Query DB: ListIdentitiesInventoryPageByFilters clampedOffset]
    L -- No --> N[rows = empty or unchanged]
    G --> O[Render identities page]
    M --> O
    N --> O
    H -- No --> O
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/http/handlers/identities_integration_test.go
Line: 35

Comment:
**Pre-existing out-of-range page case dropped**

The test was changed from `page=2` (a valid but out-of-range page when only 1 page of data exists) to `page=200000000` (an int32-overflowing value). The two scenarios follow different code paths: the new test exercises the `!requestedOffsetOK` branch, but the ordinary "page > last page" clamp path (`requestedPage > 1`, rows empty, `requestedOffsetOK = true`) is no longer covered here. Consider keeping both scenarios, or add a separate test for the ordinary out-of-range case.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: Implemented the identity pagination..."](https://github.com/open-sspm/open-sspm/commit/37a95e0ae6b0f02127acef543f561928517e0ef2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29569707)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->