### PR TITLE
refactor: cleanup code, unused and simplify

### DIFF
--- a/internal/connectors/aws/integration.go
+++ b/internal/connectors/aws/integration.go
@@ -122,24 +122,22 @@ func (i *AWSIntegration) Run(ctx context.Context, q *gen.Queries, pool *pgxpool.
 		})
 	}
 
-	for start := 0; start < len(accountRows); start += userBatchSize {
-		end := min(start+userBatchSize, len(accountRows))
-		_, err := registry.WriteSourceAccountRows(ctx, q, registry.WriteSourceAccountRowsParams{
-			SourceKind: "aws",
-			SourceName: i.sourceName,
-			RunID:      runID,
-			BatchSize:  userBatchSize,
-			Rows:       accountRows[start:end],
-		})
-		if err != nil {
-			return registry.ReportAndFailSyncRun(ctx, q, runID, report, registry.Event{Source: "aws", Stage: "write-users"}, err, registry.SyncErrorKindDB)
-		}
+	if _, err := registry.WriteSourceAccountRows(ctx, q, registry.WriteSourceAccountRowsParams{
+		SourceKind: "aws",
+		SourceName: i.sourceName,
+		RunID:      runID,
+		BatchSize:  userBatchSize,
+		Rows:       accountRows,
+	}); err != nil {
+		return registry.ReportAndFailSyncRun(ctx, q, runID, report, registry.Event{Source: "aws", Stage: "write-users"}, err, registry.SyncErrorKindDB)
+	}
+	if len(accountRows) > 0 {
 		report(registry.Event{
 			Source:  "aws",
 			Stage:   "write-users",
-			Current: int64(end),
+			Current: int64(len(accountRows)),
 			Total:   int64(len(accountRows)),
-			Message: fmt.Sprintf("principals %d/%d", end, len(accountRows)),
+			Message: fmt.Sprintf("principals %d/%d", len(accountRows), len(accountRows)),
 		})
 	}
 

--- a/internal/connectors/aws/integration.go
+++ b/internal/connectors/aws/integration.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/open-sspm/open-sspm/internal/connectors/registry"
 	"github.com/open-sspm/open-sspm/internal/db/gen"
@@ -53,15 +52,13 @@ func (i *AWSIntegration) Run(ctx context.Context, q *gen.Queries, pool *pgxpool.
 
 	users, err := i.client.ListUsers(ctx)
 	if err != nil {
-		report(registry.Event{Source: "aws", Stage: "list-users", Message: err.Error(), Err: err})
-		return registry.FailSyncRun(ctx, q, runID, err, registry.SyncErrorKindAPI)
+		return registry.ReportAndFailSyncRun(ctx, q, runID, report, registry.Event{Source: "aws", Stage: "list-users"}, err, registry.SyncErrorKindAPI)
 	}
 	report(registry.Event{Source: "aws", Stage: "list-users", Current: 1, Total: 1, Message: fmt.Sprintf("found %d users", len(users))})
 
 	groups, err := i.client.ListGroups(ctx)
 	if err != nil {
-		report(registry.Event{Source: "aws", Stage: "list-groups", Message: err.Error(), Err: err})
-		return registry.FailSyncRun(ctx, q, runID, err, registry.SyncErrorKindAPI)
+		return registry.ReportAndFailSyncRun(ctx, q, runID, report, registry.Event{Source: "aws", Stage: "list-groups"}, err, registry.SyncErrorKindAPI)
 	}
 	report(registry.Event{Source: "aws", Stage: "list-groups", Current: 1, Total: 1, Message: fmt.Sprintf("found %d groups", len(groups))})
 	report(registry.Event{
@@ -74,22 +71,13 @@ func (i *AWSIntegration) Run(ctx context.Context, q *gen.Queries, pool *pgxpool.
 
 	entitlementsByUser, err := i.client.ListUserEntitlements(ctx)
 	if err != nil {
-		report(registry.Event{Source: "aws", Stage: "list-assignments", Message: err.Error(), Err: err})
-		return registry.FailSyncRun(ctx, q, runID, err, registry.SyncErrorKindAPI)
+		return registry.ReportAndFailSyncRun(ctx, q, runID, report, registry.Event{Source: "aws", Stage: "list-assignments"}, err, registry.SyncErrorKindAPI)
 	}
 	report(registry.Event{Source: "aws", Stage: "list-assignments", Current: 1, Total: 1, Message: "assignments fetched"})
 
 	const userBatchSize = 1000
 	totalPrincipals := len(users) + len(groups)
-	externalIDs := make([]string, 0, totalPrincipals)
-	emails := make([]string, 0, totalPrincipals)
-	displayNames := make([]string, 0, totalPrincipals)
-	accountKinds := make([]string, 0, totalPrincipals)
-	entityCategories := make([]string, 0, totalPrincipals)
-	rawJSONs := make([][]byte, 0, totalPrincipals)
-	lastLoginAts := make([]pgtype.Timestamptz, 0, totalPrincipals)
-	lastLoginIps := make([]string, 0, totalPrincipals)
-	lastLoginRegions := make([]string, 0, totalPrincipals)
+	accountRows := make([]registry.SourceAccountRow, 0, totalPrincipals)
 
 	for _, user := range users {
 		externalID := strings.TrimSpace(user.ID)
@@ -105,15 +93,14 @@ func (i *AWSIntegration) Run(ctx context.Context, q *gen.Queries, pool *pgxpool.
 			display = externalID
 		}
 
-		externalIDs = append(externalIDs, externalID)
-		emails = append(emails, email)
-		displayNames = append(displayNames, display)
-		accountKinds = append(accountKinds, awsUserAccountKind(user))
-		entityCategories = append(entityCategories, registry.EntityCategoryUser)
-		rawJSONs = append(rawJSONs, registry.WithEntityCategory(registry.NormalizeJSON(user.RawJSON), registry.EntityCategoryUser))
-		lastLoginAts = append(lastLoginAts, pgtype.Timestamptz{})
-		lastLoginIps = append(lastLoginIps, "")
-		lastLoginRegions = append(lastLoginRegions, "")
+		accountRows = append(accountRows, registry.SourceAccountRow{
+			ExternalID:     externalID,
+			Email:          email,
+			DisplayName:    display,
+			AccountKind:    awsUserAccountKind(user),
+			EntityCategory: registry.EntityCategoryUser,
+			RawJSON:        registry.WithEntityCategory(registry.NormalizeJSON(user.RawJSON), registry.EntityCategoryUser),
+		})
 	}
 
 	for _, group := range groups {
@@ -126,52 +113,38 @@ func (i *AWSIntegration) Run(ctx context.Context, q *gen.Queries, pool *pgxpool.
 			display = externalID
 		}
 
-		externalIDs = append(externalIDs, externalID)
-		emails = append(emails, "")
-		displayNames = append(displayNames, display)
-		accountKinds = append(accountKinds, registry.AccountKindService)
-		entityCategories = append(entityCategories, registry.EntityCategoryGroup)
-		rawJSONs = append(rawJSONs, registry.WithEntityCategory(registry.NormalizeJSON(group.RawJSON), registry.EntityCategoryGroup))
-		lastLoginAts = append(lastLoginAts, pgtype.Timestamptz{})
-		lastLoginIps = append(lastLoginIps, "")
-		lastLoginRegions = append(lastLoginRegions, "")
+		accountRows = append(accountRows, registry.SourceAccountRow{
+			ExternalID:     externalID,
+			DisplayName:    display,
+			AccountKind:    registry.AccountKindService,
+			EntityCategory: registry.EntityCategoryGroup,
+			RawJSON:        registry.WithEntityCategory(registry.NormalizeJSON(group.RawJSON), registry.EntityCategoryGroup),
+		})
 	}
 
-	for start := 0; start < len(externalIDs); start += userBatchSize {
-		end := min(start+userBatchSize, len(externalIDs))
-		_, err := q.UpsertSourceAccountsBulkBySource(ctx, gen.UpsertSourceAccountsBulkBySourceParams{
-			SourceKind:       "aws",
-			SourceName:       i.sourceName,
-			SeenInRunID:      runID,
-			ExternalIds:      externalIDs[start:end],
-			Emails:           emails[start:end],
-			DisplayNames:     displayNames[start:end],
-			AccountKinds:     accountKinds[start:end],
-			EntityCategories: entityCategories[start:end],
-			RawJsons:         rawJSONs[start:end],
-			LastLoginAts:     lastLoginAts[start:end],
-			LastLoginIps:     lastLoginIps[start:end],
-			LastLoginRegions: lastLoginRegions[start:end],
+	for start := 0; start < len(accountRows); start += userBatchSize {
+		end := min(start+userBatchSize, len(accountRows))
+		_, err := registry.WriteSourceAccountRows(ctx, q, registry.WriteSourceAccountRowsParams{
+			SourceKind: "aws",
+			SourceName: i.sourceName,
+			RunID:      runID,
+			BatchSize:  userBatchSize,
+			Rows:       accountRows[start:end],
 		})
 		if err != nil {
-			report(registry.Event{Source: "aws", Stage: "write-users", Message: err.Error(), Err: err})
-			return registry.FailSyncRun(ctx, q, runID, err, registry.SyncErrorKindDB)
+			return registry.ReportAndFailSyncRun(ctx, q, runID, report, registry.Event{Source: "aws", Stage: "write-users"}, err, registry.SyncErrorKindDB)
 		}
 		report(registry.Event{
 			Source:  "aws",
 			Stage:   "write-users",
 			Current: int64(end),
-			Total:   int64(len(externalIDs)),
-			Message: fmt.Sprintf("principals %d/%d", end, len(externalIDs)),
+			Total:   int64(len(accountRows)),
+			Message: fmt.Sprintf("principals %d/%d", end, len(accountRows)),
 		})
 	}
 
 	const entitlementBatchSize = 5000
-	entAccountExternalIDs := make([]string, 0, len(users))
-	entKinds := make([]string, 0, len(users))
-	entResources := make([]string, 0, len(users))
-	entPermissions := make([]string, 0, len(users))
-	entRawJSONs := make([][]byte, 0, len(users))
+	entitlementRows := make([]registry.EntitlementRow, 0, len(users))
 
 	for _, user := range users {
 		userID := strings.TrimSpace(user.ID)
@@ -191,30 +164,24 @@ func (i *AWSIntegration) Run(ctx context.Context, q *gen.Queries, pool *pgxpool.
 			if groupID := strings.TrimSpace(fact.GroupID); groupID != "" {
 				raw["group_id"] = groupID
 			}
-			entAccountExternalIDs = append(entAccountExternalIDs, userID)
-			entKinds = append(entKinds, "aws_permission_set")
-			entResources = append(entResources, "aws_account:"+strings.TrimSpace(fact.AccountID))
-			entPermissions = append(entPermissions, permission)
-			entRawJSONs = append(entRawJSONs, registry.MarshalJSON(raw))
+			entitlementRows = append(entitlementRows, registry.EntitlementRow{
+				AccountExternalID: userID,
+				Kind:              "aws_permission_set",
+				Resource:          "aws_account:" + strings.TrimSpace(fact.AccountID),
+				Permission:        permission,
+				RawJSON:           registry.MarshalJSON(raw),
+			})
 		}
 	}
 
-	for start := 0; start < len(entAccountExternalIDs); start += entitlementBatchSize {
-		end := min(start+entitlementBatchSize, len(entAccountExternalIDs))
-		_, err := q.UpsertEntitlementsBulkBySource(ctx, gen.UpsertEntitlementsBulkBySourceParams{
-			SeenInRunID:        runID,
-			SourceKind:         "aws",
-			SourceName:         i.sourceName,
-			AccountExternalIds: entAccountExternalIDs[start:end],
-			Kinds:              entKinds[start:end],
-			Resources:          entResources[start:end],
-			Permissions:        entPermissions[start:end],
-			RawJsons:           entRawJSONs[start:end],
-		})
-		if err != nil {
-			report(registry.Event{Source: "aws", Stage: "write-users", Message: err.Error(), Err: err})
-			return registry.FailSyncRun(ctx, q, runID, err, registry.SyncErrorKindDB)
-		}
+	if _, err := registry.WriteEntitlementRows(ctx, q, registry.WriteEntitlementRowsParams{
+		SourceKind: "aws",
+		SourceName: i.sourceName,
+		RunID:      runID,
+		BatchSize:  entitlementBatchSize,
+		Rows:       entitlementRows,
+	}); err != nil {
+		return registry.ReportAndFailSyncRun(ctx, q, runID, report, registry.Event{Source: "aws", Stage: "write-users"}, err, registry.SyncErrorKindDB)
 	}
 
 	if err := registry.FinalizeAppRun(ctx, q, pool, runID, "aws", i.sourceName, time.Since(started), false); err != nil {

--- a/internal/connectors/datadog/integration.go
+++ b/internal/connectors/datadog/integration.go
@@ -212,24 +212,22 @@ func (i *DatadogIntegration) Run(ctx context.Context, q *gen.Queries, pool *pgxp
 		})
 	}
 
-	for start := 0; start < len(accountRows); start += userBatchSize {
-		end := min(start+userBatchSize, len(accountRows))
-		_, err := registry.WriteSourceAccountRows(ctx, q, registry.WriteSourceAccountRowsParams{
-			SourceKind: "datadog",
-			SourceName: i.site,
-			RunID:      runID,
-			BatchSize:  userBatchSize,
-			Rows:       accountRows[start:end],
-		})
-		if err != nil {
-			return registry.ReportAndFailSyncRun(ctx, q, runID, report, registry.Event{Source: "datadog", Stage: "write-principals"}, err, registry.SyncErrorKindDB)
-		}
+	if _, err := registry.WriteSourceAccountRows(ctx, q, registry.WriteSourceAccountRowsParams{
+		SourceKind: "datadog",
+		SourceName: i.site,
+		RunID:      runID,
+		BatchSize:  userBatchSize,
+		Rows:       accountRows,
+	}); err != nil {
+		return registry.ReportAndFailSyncRun(ctx, q, runID, report, registry.Event{Source: "datadog", Stage: "write-principals"}, err, registry.SyncErrorKindDB)
+	}
+	if len(accountRows) > 0 {
 		report(registry.Event{
 			Source:  "datadog",
 			Stage:   "write-principals",
-			Current: int64(end),
+			Current: int64(len(accountRows)),
 			Total:   int64(len(accountRows)),
-			Message: fmt.Sprintf("principals %d/%d", end, len(accountRows)),
+			Message: fmt.Sprintf("principals %d/%d", len(accountRows), len(accountRows)),
 		})
 	}
 

--- a/internal/connectors/datadog/integration.go
+++ b/internal/connectors/datadog/integration.go
@@ -10,7 +10,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/open-sspm/open-sspm/internal/connectors/registry"
 	"github.com/open-sspm/open-sspm/internal/db/gen"
@@ -60,15 +59,13 @@ func (i *DatadogIntegration) Run(ctx context.Context, q *gen.Queries, pool *pgxp
 
 	accounts, err := i.adapter.ListAccounts(ctx)
 	if err != nil {
-		report(registry.Event{Source: "datadog", Stage: "list-accounts", Message: err.Error(), Err: err})
-		return registry.FailSyncRun(ctx, q, runID, err, registry.SyncErrorKindAPI)
+		return registry.ReportAndFailSyncRun(ctx, q, runID, report, registry.Event{Source: "datadog", Stage: "list-accounts"}, err, registry.SyncErrorKindAPI)
 	}
 	report(registry.Event{Source: "datadog", Stage: "list-accounts", Current: 1, Total: 1, Message: fmt.Sprintf("found %d accounts", len(accounts))})
 
 	roles, err := i.adapter.ListRoles(ctx)
 	if err != nil {
-		report(registry.Event{Source: "datadog", Stage: "list-roles", Message: err.Error(), Err: err})
-		return registry.FailSyncRun(ctx, q, runID, err, registry.SyncErrorKindAPI)
+		return registry.ReportAndFailSyncRun(ctx, q, runID, report, registry.Event{Source: "datadog", Stage: "list-roles"}, err, registry.SyncErrorKindAPI)
 	}
 	report(registry.Event{Source: "datadog", Stage: "list-roles", Current: 1, Total: 1, Message: fmt.Sprintf("found %d roles", len(roles))})
 
@@ -161,8 +158,7 @@ func (i *DatadogIntegration) Run(ctx context.Context, q *gen.Queries, pool *pgxp
 			firstErr = firstNonCancelErr
 		}
 		if firstErr != nil {
-			report(registry.Event{Source: "datadog", Stage: "fetch-role-members", Message: firstErr.Error(), Err: firstErr})
-			return registry.FailSyncRun(ctx, q, runID, firstErr, registry.SyncErrorKindAPI)
+			return registry.ReportAndFailSyncRun(ctx, q, runID, report, registry.Event{Source: "datadog", Stage: "fetch-role-members"}, firstErr, registry.SyncErrorKindAPI)
 		}
 	}
 
@@ -176,15 +172,7 @@ func (i *DatadogIntegration) Run(ctx context.Context, q *gen.Queries, pool *pgxp
 
 	const userBatchSize = 1000
 	totalPrincipals := len(accounts) + len(roles)
-	externalIDs := make([]string, 0, totalPrincipals)
-	emails := make([]string, 0, totalPrincipals)
-	displayNames := make([]string, 0, totalPrincipals)
-	accountKinds := make([]string, 0, totalPrincipals)
-	entityCategories := make([]string, 0, totalPrincipals)
-	rawJSONs := make([][]byte, 0, totalPrincipals)
-	lastLoginAts := make([]pgtype.Timestamptz, 0, totalPrincipals)
-	lastLoginIps := make([]string, 0, totalPrincipals)
-	lastLoginRegions := make([]string, 0, totalPrincipals)
+	accountRows := make([]registry.SourceAccountRow, 0, totalPrincipals)
 
 	for _, account := range accounts {
 		externalID := strings.TrimSpace(account.ExternalID)
@@ -195,15 +183,15 @@ func (i *DatadogIntegration) Run(ctx context.Context, q *gen.Queries, pool *pgxp
 		if display == "" {
 			display = externalID
 		}
-		externalIDs = append(externalIDs, externalID)
-		emails = append(emails, matching.NormalizeEmail(account.Email))
-		displayNames = append(displayNames, display)
-		accountKinds = append(accountKinds, account.AccountKind)
-		entityCategories = append(entityCategories, account.EntityCategory)
-		rawJSONs = append(rawJSONs, registry.WithEntityCategory(registry.NormalizeJSON(account.RawJSON), account.EntityCategory))
-		lastLoginAts = append(lastLoginAts, registry.PgTimestamptzPtr(account.LastLoginAt))
-		lastLoginIps = append(lastLoginIps, "")
-		lastLoginRegions = append(lastLoginRegions, "")
+		accountRows = append(accountRows, registry.SourceAccountRow{
+			ExternalID:     externalID,
+			Email:          matching.NormalizeEmail(account.Email),
+			DisplayName:    display,
+			AccountKind:    account.AccountKind,
+			EntityCategory: account.EntityCategory,
+			RawJSON:        registry.WithEntityCategory(registry.NormalizeJSON(account.RawJSON), account.EntityCategory),
+			LastLoginAt:    registry.PgTimestamptzPtr(account.LastLoginAt),
+		})
 	}
 
 	for _, role := range roles {
@@ -215,52 +203,38 @@ func (i *DatadogIntegration) Run(ctx context.Context, q *gen.Queries, pool *pgxp
 		if display == "" {
 			display = roleExternalID
 		}
-		externalIDs = append(externalIDs, roleExternalID)
-		emails = append(emails, "")
-		displayNames = append(displayNames, display)
-		accountKinds = append(accountKinds, registry.AccountKindService)
-		entityCategories = append(entityCategories, registry.EntityCategoryRole)
-		rawJSONs = append(rawJSONs, registry.WithEntityCategory(registry.NormalizeJSON(role.RawJSON), registry.EntityCategoryRole))
-		lastLoginAts = append(lastLoginAts, pgtype.Timestamptz{})
-		lastLoginIps = append(lastLoginIps, "")
-		lastLoginRegions = append(lastLoginRegions, "")
+		accountRows = append(accountRows, registry.SourceAccountRow{
+			ExternalID:     roleExternalID,
+			DisplayName:    display,
+			AccountKind:    registry.AccountKindService,
+			EntityCategory: registry.EntityCategoryRole,
+			RawJSON:        registry.WithEntityCategory(registry.NormalizeJSON(role.RawJSON), registry.EntityCategoryRole),
+		})
 	}
 
-	for start := 0; start < len(externalIDs); start += userBatchSize {
-		end := min(start+userBatchSize, len(externalIDs))
-		_, err := q.UpsertSourceAccountsBulkBySource(ctx, gen.UpsertSourceAccountsBulkBySourceParams{
-			SourceKind:       "datadog",
-			SourceName:       i.site,
-			SeenInRunID:      runID,
-			ExternalIds:      externalIDs[start:end],
-			Emails:           emails[start:end],
-			DisplayNames:     displayNames[start:end],
-			AccountKinds:     accountKinds[start:end],
-			EntityCategories: entityCategories[start:end],
-			RawJsons:         rawJSONs[start:end],
-			LastLoginAts:     lastLoginAts[start:end],
-			LastLoginIps:     lastLoginIps[start:end],
-			LastLoginRegions: lastLoginRegions[start:end],
+	for start := 0; start < len(accountRows); start += userBatchSize {
+		end := min(start+userBatchSize, len(accountRows))
+		_, err := registry.WriteSourceAccountRows(ctx, q, registry.WriteSourceAccountRowsParams{
+			SourceKind: "datadog",
+			SourceName: i.site,
+			RunID:      runID,
+			BatchSize:  userBatchSize,
+			Rows:       accountRows[start:end],
 		})
 		if err != nil {
-			report(registry.Event{Source: "datadog", Stage: "write-principals", Message: err.Error(), Err: err})
-			return registry.FailSyncRun(ctx, q, runID, err, registry.SyncErrorKindDB)
+			return registry.ReportAndFailSyncRun(ctx, q, runID, report, registry.Event{Source: "datadog", Stage: "write-principals"}, err, registry.SyncErrorKindDB)
 		}
 		report(registry.Event{
 			Source:  "datadog",
 			Stage:   "write-principals",
 			Current: int64(end),
-			Total:   int64(len(externalIDs)),
-			Message: fmt.Sprintf("principals %d/%d", end, len(externalIDs)),
+			Total:   int64(len(accountRows)),
+			Message: fmt.Sprintf("principals %d/%d", end, len(accountRows)),
 		})
 	}
 
 	const entitlementBatchSize = 5000
-	entAccountExternalIDs := make([]string, 0, len(accounts))
-	entKinds := make([]string, 0, len(accounts))
-	entResources := make([]string, 0, len(accounts))
-	entPermissions := make([]string, 0, len(accounts))
-	entRawJSONs := make([][]byte, 0, len(accounts))
+	entitlementRows := make([]registry.EntitlementRow, 0, len(accounts))
 
 	for _, account := range accounts {
 		accountExternalID := strings.TrimSpace(account.ExternalID)
@@ -277,33 +251,27 @@ func (i *DatadogIntegration) Run(ctx context.Context, q *gen.Queries, pool *pgxp
 			if externalID == "" {
 				continue
 			}
-			entAccountExternalIDs = append(entAccountExternalIDs, accountExternalID)
-			entKinds = append(entKinds, "datadog_role")
-			entResources = append(entResources, "datadog_role:"+externalID)
-			entPermissions = append(entPermissions, "member")
-			entRawJSONs = append(entRawJSONs, registry.MarshalJSON(map[string]string{
-				"role_id":   roleID,
-				"role_name": roleName,
-			}))
+			entitlementRows = append(entitlementRows, registry.EntitlementRow{
+				AccountExternalID: accountExternalID,
+				Kind:              "datadog_role",
+				Resource:          "datadog_role:" + externalID,
+				Permission:        "member",
+				RawJSON: registry.MarshalJSON(map[string]string{
+					"role_id":   roleID,
+					"role_name": roleName,
+				}),
+			})
 		}
 	}
 
-	for start := 0; start < len(entAccountExternalIDs); start += entitlementBatchSize {
-		end := min(start+entitlementBatchSize, len(entAccountExternalIDs))
-		_, err := q.UpsertEntitlementsBulkBySource(ctx, gen.UpsertEntitlementsBulkBySourceParams{
-			SeenInRunID:        runID,
-			SourceKind:         "datadog",
-			SourceName:         i.site,
-			AccountExternalIds: entAccountExternalIDs[start:end],
-			Kinds:              entKinds[start:end],
-			Resources:          entResources[start:end],
-			Permissions:        entPermissions[start:end],
-			RawJsons:           entRawJSONs[start:end],
-		})
-		if err != nil {
-			report(registry.Event{Source: "datadog", Stage: "write-principals", Message: err.Error(), Err: err})
-			return registry.FailSyncRun(ctx, q, runID, err, registry.SyncErrorKindDB)
-		}
+	if _, err := registry.WriteEntitlementRows(ctx, q, registry.WriteEntitlementRowsParams{
+		SourceKind: "datadog",
+		SourceName: i.site,
+		RunID:      runID,
+		BatchSize:  entitlementBatchSize,
+		Rows:       entitlementRows,
+	}); err != nil {
+		return registry.ReportAndFailSyncRun(ctx, q, runID, report, registry.Event{Source: "datadog", Stage: "write-principals"}, err, registry.SyncErrorKindDB)
 	}
 
 	if err := registry.FinalizeAppRun(ctx, q, pool, runID, "datadog", i.site, time.Since(started), false); err != nil {

--- a/internal/connectors/datadog/integration_test.go
+++ b/internal/connectors/datadog/integration_test.go
@@ -4,22 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"net/url"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/golang-migrate/migrate/v4"
-	_ "github.com/golang-migrate/migrate/v4/database/postgres"
-	_ "github.com/golang-migrate/migrate/v4/source/file"
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/open-sspm/open-sspm/internal/connectors/registry"
 	"github.com/open-sspm/open-sspm/internal/db/gen"
+	"github.com/open-sspm/open-sspm/internal/testdb"
 )
 
 type stubDatadogAdapter struct {
@@ -434,89 +426,17 @@ func TestDatadogIntegrationRunFailsWhenRoleMemberFetchFails(t *testing.T) {
 func withDatadogTestDatabase(t *testing.T, fn func(context.Context, *pgxpool.Pool, *gen.Queries, *migrate.Migrate)) {
 	t.Helper()
 
-	baseURL := os.Getenv("TEST_DATABASE_URL")
-	if baseURL == "" {
-		t.Skip("TEST_DATABASE_URL is not set")
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
-	defer cancel()
-
-	adminURL, err := datadogTestDatabaseAdminURL(baseURL)
-	if err != nil {
-		t.Fatalf("datadogTestDatabaseAdminURL() err = %v", err)
-	}
-
-	adminConn, err := pgx.Connect(ctx, adminURL)
-	if err != nil {
-		t.Fatalf("pgx.Connect() err = %v", err)
-	}
-	defer adminConn.Close(ctx)
-
-	dbName := "test_datadog_" + strings.ReplaceAll(uuid.NewString(), "-", "")
-	if _, err := adminConn.Exec(ctx, "CREATE DATABASE "+pgx.Identifier{dbName}.Sanitize()); err != nil {
-		t.Fatalf("CREATE DATABASE %s: %v", dbName, err)
-	}
-	defer func() {
-		dropCtx, dropCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer dropCancel()
-		_, _ = adminConn.Exec(dropCtx, "DROP DATABASE IF EXISTS "+pgx.Identifier{dbName}.Sanitize()+" WITH (FORCE)")
-	}()
-
-	testURL, err := datadogTestDatabaseURLWithName(baseURL, dbName)
-	if err != nil {
-		t.Fatalf("datadogTestDatabaseURLWithName() err = %v", err)
-	}
-
-	migrator, err := migrate.New("file://"+datadogTestMigrationsDir(t), testURL)
-	if err != nil {
-		t.Fatalf("migrate.New() err = %v", err)
-	}
-	defer func() {
-		_, _ = migrator.Close()
-	}()
-
-	pool, err := pgxpool.New(ctx, testURL)
-	if err != nil {
-		t.Fatalf("pgxpool.New() err = %v", err)
-	}
-	defer pool.Close()
-
-	fn(ctx, pool, gen.New(pool), migrator)
+	testdb.WithDatabase(t, testdb.Options{
+		DatabaseURLVars: []string{"TEST_DATABASE_URL"},
+		NamePrefix:      "test_datadog",
+		Timeout:         90 * time.Second,
+	}, func(ctx context.Context, pool *pgxpool.Pool, migrator *migrate.Migrate) {
+		fn(ctx, pool, gen.New(pool), migrator)
+	})
 }
 
 func migrateDatadogUp(t *testing.T, migrator *migrate.Migrate) {
 	t.Helper()
 
-	if err := migrator.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
-		t.Fatalf("migrate up: %v", err)
-	}
-}
-
-func datadogTestMigrationsDir(t *testing.T) string {
-	t.Helper()
-
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	return filepath.Join(filepath.Dir(file), "..", "..", "..", "db", "migrations")
-}
-
-func datadogTestDatabaseAdminURL(raw string) (string, error) {
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		return "", err
-	}
-	parsed.Path = "/postgres"
-	return parsed.String(), nil
-}
-
-func datadogTestDatabaseURLWithName(raw, dbName string) (string, error) {
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		return "", err
-	}
-	parsed.Path = "/" + dbName
-	return parsed.String(), nil
+	testdb.MigrateUp(t, migrator)
 }

--- a/internal/connectors/entra/discovery_normalization_test.go
+++ b/internal/connectors/entra/discovery_normalization_test.go
@@ -3,6 +3,8 @@ package entra
 import (
 	"testing"
 	"time"
+
+	"github.com/open-sspm/open-sspm/internal/discovery"
 )
 
 func TestNormalizeEntraDiscovery_VendorPrecedence(t *testing.T) {
@@ -36,7 +38,7 @@ func TestNormalizeEntraDiscovery_VendorPrecedence(t *testing.T) {
 		t.Fatalf("len(events)=%d want 3", len(events))
 	}
 
-	sourceByAppID := map[string]normalizedDiscoverySource{}
+	sourceByAppID := map[string]discovery.SourceRow{}
 	for _, source := range sources {
 		sourceByAppID[source.SourceAppID] = source
 	}
@@ -51,7 +53,7 @@ func TestNormalizeEntraDiscovery_VendorPrecedence(t *testing.T) {
 		t.Fatalf("service principal vendor = %q want %q", got, "Publisher Three")
 	}
 
-	eventByID := map[string]normalizedDiscoveryEvent{}
+	eventByID := map[string]discovery.EventRow{}
 	for _, event := range events {
 		eventByID[event.EventExternalID] = event
 	}
@@ -90,7 +92,7 @@ func TestNormalizeEntraDiscovery_GrantActorResolution(t *testing.T) {
 		t.Fatalf("len(events)=%d want 3", len(events))
 	}
 
-	eventByID := map[string]normalizedDiscoveryEvent{}
+	eventByID := map[string]discovery.EventRow{}
 	for _, event := range events {
 		eventByID[event.EventExternalID] = event
 	}

--- a/internal/connectors/entra/full_sync_integration_test.go
+++ b/internal/connectors/entra/full_sync_integration_test.go
@@ -3,24 +3,17 @@ package entra
 import (
 	"context"
 	"encoding/json"
-	"net/url"
-	"os"
-	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/golang-migrate/migrate/v4"
-	_ "github.com/golang-migrate/migrate/v4/database/postgres"
-	_ "github.com/golang-migrate/migrate/v4/source/file"
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/open-sspm/open-sspm/internal/connectors/registry"
 	"github.com/open-sspm/open-sspm/internal/db/gen"
 	"github.com/open-sspm/open-sspm/internal/discovery"
+	"github.com/open-sspm/open-sspm/internal/testdb"
 )
 
 type fullSyncTestClient struct {
@@ -694,89 +687,13 @@ func TestEntraRunDiscoveryPersistsSourcesAndEvents(t *testing.T) {
 func withEntraTestDB(t *testing.T, fn func(context.Context, *pgxpool.Pool, *gen.Queries, *migrate.Migrate)) {
 	t.Helper()
 
-	baseURL := strings.TrimSpace(os.Getenv("OPENSSPM_TEST_DATABASE_URL"))
-	if baseURL == "" {
-		t.Skip("OPENSSPM_TEST_DATABASE_URL is not set")
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-
-	adminURL, err := entraTestDatabaseAdminURL(baseURL)
-	if err != nil {
-		t.Fatalf("entraTestDatabaseAdminURL() err = %v", err)
-	}
-
-	adminConn, err := pgx.Connect(ctx, adminURL)
-	if err != nil {
-		t.Fatalf("pgx.Connect(admin) err = %v", err)
-	}
-	defer adminConn.Close(ctx)
-
-	dbName := "opensspm_entra_" + strings.ReplaceAll(uuid.NewString(), "-", "")
-	if _, err := adminConn.Exec(ctx, "CREATE DATABASE "+pgx.Identifier{dbName}.Sanitize()); err != nil {
-		t.Fatalf("CREATE DATABASE err = %v", err)
-	}
-	defer func() {
-		dropCtx, dropCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer dropCancel()
-		_, _ = adminConn.Exec(dropCtx, "DROP DATABASE IF EXISTS "+pgx.Identifier{dbName}.Sanitize()+" WITH (FORCE)")
-	}()
-
-	testURL, err := entraTestDatabaseURLWithName(baseURL, dbName)
-	if err != nil {
-		t.Fatalf("entraTestDatabaseURLWithName() err = %v", err)
-	}
-
-	migrator, err := migrate.New("file://"+entraTestMigrationsDir(t), testURL)
-	if err != nil {
-		t.Fatalf("migrate.New() err = %v", err)
-	}
-	defer func() {
-		_, _ = migrator.Close()
-	}()
-
-	pool, err := pgxpool.New(ctx, testURL)
-	if err != nil {
-		t.Fatalf("pgxpool.New() err = %v", err)
-	}
-	defer pool.Close()
-
-	fn(ctx, pool, gen.New(pool), migrator)
+	testdb.WithDatabase(t, testdb.Options{NamePrefix: "opensspm_entra"}, func(ctx context.Context, pool *pgxpool.Pool, migrator *migrate.Migrate) {
+		fn(ctx, pool, gen.New(pool), migrator)
+	})
 }
 
 func migrateEntraUp(t *testing.T, migrator *migrate.Migrate) {
 	t.Helper()
 
-	if err := migrator.Up(); err != nil && err != migrate.ErrNoChange {
-		t.Fatalf("migrate up: %v", err)
-	}
-}
-
-func entraTestMigrationsDir(t *testing.T) string {
-	t.Helper()
-
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	return filepath.Join(filepath.Dir(file), "..", "..", "..", "db", "migrations")
-}
-
-func entraTestDatabaseAdminURL(raw string) (string, error) {
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		return "", err
-	}
-	parsed.Path = "/postgres"
-	return parsed.String(), nil
-}
-
-func entraTestDatabaseURLWithName(raw, dbName string) (string, error) {
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		return "", err
-	}
-	parsed.Path = "/" + dbName
-	return parsed.String(), nil
+	testdb.MigrateUp(t, migrator)
 }

--- a/internal/connectors/entra/integration.go
+++ b/internal/connectors/entra/integration.go
@@ -1324,31 +1324,6 @@ func (i *EntraIntegration) upsertCredentialAuditEvents(ctx context.Context, q *g
 	return nil
 }
 
-type normalizedDiscoverySource struct {
-	CanonicalKey     string
-	SourceAppID      string
-	SourceAppName    string
-	SourceAppDomain  string
-	SourceVendorName string
-	SeenAt           time.Time
-}
-
-type normalizedDiscoveryEvent struct {
-	CanonicalKey     string
-	SignalKind       string
-	EventExternalID  string
-	SourceAppID      string
-	SourceAppName    string
-	SourceAppDomain  string
-	SourceVendorName string
-	ActorExternalID  string
-	ActorEmail       string
-	ActorDisplayName string
-	ObservedAt       time.Time
-	Scopes           []string
-	RawJSON          []byte
-}
-
 func (i *EntraIntegration) syncDiscovery(ctx context.Context, q *gen.Queries, report func(registry.Event), runID int64, applications []Application, servicePrincipals []ServicePrincipal) error {
 	now := time.Now().UTC()
 
@@ -1450,9 +1425,9 @@ func (i *EntraIntegration) resolveGrantActors(ctx context.Context, report func(r
 	return users
 }
 
-func normalizeEntraDiscovery(signIns []SignInEvent, grants []OAuth2PermissionGrant, applications []Application, servicePrincipals []ServicePrincipal, users []User, tenantID string, now time.Time) ([]normalizedDiscoverySource, []normalizedDiscoveryEvent, error) {
-	sourceByID := map[string]normalizedDiscoverySource{}
-	events := make([]normalizedDiscoveryEvent, 0, len(signIns)+len(grants))
+func normalizeEntraDiscovery(signIns []SignInEvent, grants []OAuth2PermissionGrant, applications []Application, servicePrincipals []ServicePrincipal, users []User, tenantID string, now time.Time) ([]discovery.SourceRow, []discovery.EventRow, error) {
+	sourceByID := map[string]discovery.SourceRow{}
+	events := make([]discovery.EventRow, 0, len(signIns)+len(grants))
 
 	appDisplayByAppID := make(map[string]string, len(applications))
 	appVendorByAppID := make(map[string]string, len(applications))
@@ -1544,7 +1519,7 @@ func normalizeEntraDiscovery(signIns []SignInEvent, grants []OAuth2PermissionGra
 
 		current := sourceByID[sourceAppID]
 		if current.SourceAppID == "" || observedAt.After(current.SeenAt) {
-			sourceByID[sourceAppID] = normalizedDiscoverySource{
+			sourceByID[sourceAppID] = discovery.SourceRow{
 				CanonicalKey:     metadata.CanonicalKey,
 				SourceAppID:      sourceAppID,
 				SourceAppName:    sourceAppName,
@@ -1564,7 +1539,7 @@ func normalizeEntraDiscovery(signIns []SignInEvent, grants []OAuth2PermissionGra
 			return nil, nil, fmt.Errorf("serialize entra sign-in %s: %w", eventExternalID, err)
 		}
 
-		events = append(events, normalizedDiscoveryEvent{
+		events = append(events, discovery.EventRow{
 			CanonicalKey:     metadata.CanonicalKey,
 			SignalKind:       discovery.SignalKindIDPSSO,
 			EventExternalID:  eventExternalID,
@@ -1627,7 +1602,7 @@ func normalizeEntraDiscovery(signIns []SignInEvent, grants []OAuth2PermissionGra
 
 		current := sourceByID[sourceAppID]
 		if current.SourceAppID == "" || observedAt.After(current.SeenAt) {
-			sourceByID[sourceAppID] = normalizedDiscoverySource{
+			sourceByID[sourceAppID] = discovery.SourceRow{
 				CanonicalKey:     metadata.CanonicalKey,
 				SourceAppID:      sourceAppID,
 				SourceAppName:    sourceAppName,
@@ -1671,7 +1646,7 @@ func normalizeEntraDiscovery(signIns []SignInEvent, grants []OAuth2PermissionGra
 			return nil, nil, fmt.Errorf("serialize entra oauth grant %s: %w", eventExternalID, err)
 		}
 
-		events = append(events, normalizedDiscoveryEvent{
+		events = append(events, discovery.EventRow{
 			CanonicalKey:     metadata.CanonicalKey,
 			SignalKind:       discovery.SignalKindOAuth,
 			EventExternalID:  eventExternalID,
@@ -1688,205 +1663,37 @@ func normalizeEntraDiscovery(signIns []SignInEvent, grants []OAuth2PermissionGra
 		})
 	}
 
-	sourceRows := make([]normalizedDiscoverySource, 0, len(sourceByID))
+	sourceRows := make([]discovery.SourceRow, 0, len(sourceByID))
 	for _, sourceRow := range sourceByID {
 		sourceRows = append(sourceRows, sourceRow)
 	}
 	return sourceRows, events, nil
 }
 
-func (i *EntraIntegration) writeDiscoveryRows(ctx context.Context, q *gen.Queries, report func(registry.Event), runID int64, sources []normalizedDiscoverySource, events []normalizedDiscoveryEvent) error {
-	total := len(sources) + len(events)
-	report(registry.Event{
-		Source:  "entra",
-		Stage:   "write-discovery",
-		Current: 0,
-		Total:   int64(total),
-		Message: fmt.Sprintf("writing %d discovery records", total),
+func (i *EntraIntegration) writeDiscoveryRows(ctx context.Context, q *gen.Queries, report func(registry.Event), runID int64, sources []discovery.SourceRow, events []discovery.EventRow) error {
+	return discovery.WriteRows(ctx, q, discovery.WriteRowsParams{
+		SourceKind: "entra",
+		SourceName: i.tenantID,
+		RunID:      runID,
+		Sources:    sources,
+		Events:     events,
+		Report:     discoveryProgressReporter(report),
 	})
+}
 
-	appMeta := map[string]discovery.AppMetadata{}
-	firstSeenByKey := map[string]time.Time{}
-	lastSeenByKey := map[string]time.Time{}
-	addMeta := func(key string, seenAt time.Time, sample discovery.AppMetadata) {
-		if key == "" {
+func discoveryProgressReporter(report func(registry.Event)) func(discovery.ProgressEvent) {
+	return func(event discovery.ProgressEvent) {
+		if report == nil {
 			return
 		}
-		if _, ok := appMeta[key]; !ok {
-			appMeta[key] = sample
-			firstSeenByKey[key] = seenAt
-			lastSeenByKey[key] = seenAt
-			return
-		}
-		if seenAt.Before(firstSeenByKey[key]) {
-			firstSeenByKey[key] = seenAt
-		}
-		if seenAt.After(lastSeenByKey[key]) {
-			lastSeenByKey[key] = seenAt
-		}
-	}
-
-	for _, source := range sources {
-		meta := discovery.BuildMetadata(discovery.CanonicalInput{
-			SourceKind:       "entra",
-			SourceName:       i.tenantID,
-			SourceAppID:      source.SourceAppID,
-			SourceAppName:    source.SourceAppName,
-			SourceDomain:     source.SourceAppDomain,
-			SourceVendorName: source.SourceVendorName,
-		})
-		meta.CanonicalKey = source.CanonicalKey
-		addMeta(source.CanonicalKey, source.SeenAt, meta)
-	}
-	for _, event := range events {
-		meta := discovery.BuildMetadata(discovery.CanonicalInput{
-			SourceKind:       "entra",
-			SourceName:       i.tenantID,
-			SourceAppID:      event.SourceAppID,
-			SourceAppName:    event.SourceAppName,
-			SourceDomain:     event.SourceAppDomain,
-			SourceVendorName: event.SourceVendorName,
-		})
-		meta.CanonicalKey = event.CanonicalKey
-		addMeta(event.CanonicalKey, event.ObservedAt, meta)
-	}
-
-	if len(appMeta) > 0 {
-		canonicalKeys := make([]string, 0, len(appMeta))
-		displayNames := make([]string, 0, len(appMeta))
-		primaryDomains := make([]string, 0, len(appMeta))
-		vendorNames := make([]string, 0, len(appMeta))
-		firstSeenAts := make([]pgtype.Timestamptz, 0, len(appMeta))
-		lastSeenAts := make([]pgtype.Timestamptz, 0, len(appMeta))
-		for key, meta := range appMeta {
-			canonicalKeys = append(canonicalKeys, key)
-			displayNames = append(displayNames, meta.DisplayName)
-			primaryDomains = append(primaryDomains, meta.Domain)
-			vendorNames = append(vendorNames, meta.VendorName)
-			firstSeenAt := firstSeenByKey[key]
-			lastSeenAt := lastSeenByKey[key]
-			firstSeenAts = append(firstSeenAts, registry.PgTimestamptzPtr(&firstSeenAt))
-			lastSeenAts = append(lastSeenAts, registry.PgTimestamptzPtr(&lastSeenAt))
-		}
-		if _, err := q.UpsertSaaSAppsBulk(ctx, gen.UpsertSaaSAppsBulkParams{
-			CanonicalKeys:  canonicalKeys,
-			DisplayNames:   displayNames,
-			PrimaryDomains: primaryDomains,
-			VendorNames:    vendorNames,
-			FirstSeenAts:   firstSeenAts,
-			LastSeenAts:    lastSeenAts,
-		}); err != nil {
-			return fmt.Errorf("upsert saas apps: %w", err)
-		}
-	}
-
-	written := 0
-	if len(sources) > 0 {
-		canonicalKeys := make([]string, 0, len(sources))
-		sourceAppIDs := make([]string, 0, len(sources))
-		sourceAppNames := make([]string, 0, len(sources))
-		sourceAppDomains := make([]string, 0, len(sources))
-		seenAts := make([]pgtype.Timestamptz, 0, len(sources))
-		for _, source := range sources {
-			canonicalKeys = append(canonicalKeys, source.CanonicalKey)
-			sourceAppIDs = append(sourceAppIDs, source.SourceAppID)
-			sourceAppNames = append(sourceAppNames, source.SourceAppName)
-			sourceAppDomains = append(sourceAppDomains, source.SourceAppDomain)
-			seenAts = append(seenAts, registry.PgTimestamptzPtr(&source.SeenAt))
-		}
-		if _, err := q.UpsertSaaSAppSourcesBulkBySource(ctx, gen.UpsertSaaSAppSourcesBulkBySourceParams{
-			SourceKind:       "entra",
-			SourceName:       i.tenantID,
-			SeenInRunID:      runID,
-			CanonicalKeys:    canonicalKeys,
-			SourceAppIds:     sourceAppIDs,
-			SourceAppNames:   sourceAppNames,
-			SourceAppDomains: sourceAppDomains,
-			SeenAts:          seenAts,
-		}); err != nil {
-			return fmt.Errorf("upsert saas app sources: %w", err)
-		}
-		written += len(sources)
 		report(registry.Event{
-			Source:  "entra",
-			Stage:   "write-discovery",
-			Current: int64(written),
-			Total:   int64(total),
-			Message: fmt.Sprintf("sources %d/%d", written, total),
+			Source:  event.Source,
+			Stage:   event.Stage,
+			Current: event.Current,
+			Total:   event.Total,
+			Message: event.Message,
 		})
 	}
-
-	if len(events) > 0 {
-		canonicalKeys := make([]string, 0, len(events))
-		signalKinds := make([]string, 0, len(events))
-		eventExternalIDs := make([]string, 0, len(events))
-		sourceAppIDs := make([]string, 0, len(events))
-		sourceAppNames := make([]string, 0, len(events))
-		sourceAppDomains := make([]string, 0, len(events))
-		actorExternalIDs := make([]string, 0, len(events))
-		actorEmails := make([]string, 0, len(events))
-		actorDisplayNames := make([]string, 0, len(events))
-		observedAts := make([]pgtype.Timestamptz, 0, len(events))
-		scopesJSONs := make([][]byte, 0, len(events))
-		rawJSONs := make([][]byte, 0, len(events))
-		ingestedBySignal := map[string]int{}
-		for _, event := range events {
-			canonicalKeys = append(canonicalKeys, event.CanonicalKey)
-			signalKinds = append(signalKinds, event.SignalKind)
-			eventExternalIDs = append(eventExternalIDs, event.EventExternalID)
-			sourceAppIDs = append(sourceAppIDs, event.SourceAppID)
-			sourceAppNames = append(sourceAppNames, event.SourceAppName)
-			sourceAppDomains = append(sourceAppDomains, event.SourceAppDomain)
-			actorExternalIDs = append(actorExternalIDs, event.ActorExternalID)
-			actorEmails = append(actorEmails, event.ActorEmail)
-			actorDisplayNames = append(actorDisplayNames, event.ActorDisplayName)
-			observedAts = append(observedAts, registry.PgTimestamptzPtr(&event.ObservedAt))
-			scopesJSONs = append(scopesJSONs, discovery.ScopesJSON(event.Scopes))
-			rawJSONs = append(rawJSONs, registry.NormalizeJSON(event.RawJSON))
-			ingestedBySignal[event.SignalKind]++
-		}
-		if _, err := q.UpsertSaaSAppEventsBulkBySource(ctx, gen.UpsertSaaSAppEventsBulkBySourceParams{
-			SourceKind:        "entra",
-			SourceName:        i.tenantID,
-			SeenInRunID:       runID,
-			CanonicalKeys:     canonicalKeys,
-			SignalKinds:       signalKinds,
-			EventExternalIds:  eventExternalIDs,
-			SourceAppIds:      sourceAppIDs,
-			SourceAppNames:    sourceAppNames,
-			SourceAppDomains:  sourceAppDomains,
-			ActorExternalIds:  actorExternalIDs,
-			ActorEmails:       actorEmails,
-			ActorDisplayNames: actorDisplayNames,
-			ObservedAts:       observedAts,
-			ScopesJsons:       scopesJSONs,
-			RawJsons:          rawJSONs,
-		}); err != nil {
-			return fmt.Errorf("upsert saas app events: %w", err)
-		}
-		for signalKind, count := range ingestedBySignal {
-			metrics.DiscoveryEventsIngestedTotal.WithLabelValues("entra", signalKind).Add(float64(count))
-		}
-		written += len(events)
-		report(registry.Event{
-			Source:  "entra",
-			Stage:   "write-discovery",
-			Current: int64(written),
-			Total:   int64(total),
-			Message: fmt.Sprintf("events %d/%d", written, total),
-		})
-	}
-
-	if written == 0 {
-		report(registry.Event{
-			Source:  "entra",
-			Stage:   "write-discovery",
-			Current: 0,
-			Total:   0,
-			Message: "no discovery records to write",
-		})
-	}
-	return nil
 }
 
 func (i *EntraIntegration) seedEntraAutoBindings(ctx context.Context, q *gen.Queries) error {

--- a/internal/connectors/entra/integration.go
+++ b/internal/connectors/entra/integration.go
@@ -1677,23 +1677,8 @@ func (i *EntraIntegration) writeDiscoveryRows(ctx context.Context, q *gen.Querie
 		RunID:      runID,
 		Sources:    sources,
 		Events:     events,
-		Report:     discoveryProgressReporter(report),
+		Report:     registry.DiscoveryProgressReporter(report),
 	})
-}
-
-func discoveryProgressReporter(report func(registry.Event)) func(discovery.ProgressEvent) {
-	return func(event discovery.ProgressEvent) {
-		if report == nil {
-			return
-		}
-		report(registry.Event{
-			Source:  event.Source,
-			Stage:   event.Stage,
-			Current: event.Current,
-			Total:   event.Total,
-			Message: event.Message,
-		})
-	}
 }
 
 func (i *EntraIntegration) seedEntraAutoBindings(ctx context.Context, q *gen.Queries) error {

--- a/internal/connectors/googleworkspace/integration.go
+++ b/internal/connectors/googleworkspace/integration.go
@@ -111,31 +111,6 @@ type googleWorkspaceCredentialAuditEventRow struct {
 	RawJSON              []byte
 }
 
-type normalizedDiscoverySource struct {
-	CanonicalKey     string
-	SourceAppID      string
-	SourceAppName    string
-	SourceAppDomain  string
-	SourceVendorName string
-	SeenAt           time.Time
-}
-
-type normalizedDiscoveryEvent struct {
-	CanonicalKey     string
-	SignalKind       string
-	EventExternalID  string
-	SourceAppID      string
-	SourceAppName    string
-	SourceAppDomain  string
-	SourceVendorName string
-	ActorExternalID  string
-	ActorEmail       string
-	ActorDisplayName string
-	ObservedAt       time.Time
-	Scopes           []string
-	RawJSON          []byte
-}
-
 func NewGoogleWorkspaceIntegration(client *Client, customerID, primaryDomain string, discoveryEnabled bool) *GoogleWorkspaceIntegration {
 	return &GoogleWorkspaceIntegration{
 		client:           client,
@@ -1114,9 +1089,9 @@ func (i *GoogleWorkspaceIntegration) syncDiscovery(ctx context.Context, q *gen.Q
 	return nil
 }
 
-func (i *GoogleWorkspaceIntegration) normalizeDiscovery(loginActivities, tokenActivities []WorkspaceActivity, tokenGrants []WorkspaceOAuthTokenGrant, now time.Time) ([]normalizedDiscoverySource, []normalizedDiscoveryEvent) {
-	sourceByID := map[string]normalizedDiscoverySource{}
-	events := make([]normalizedDiscoveryEvent, 0, len(loginActivities)+len(tokenActivities)+len(tokenGrants))
+func (i *GoogleWorkspaceIntegration) normalizeDiscovery(loginActivities, tokenActivities []WorkspaceActivity, tokenGrants []WorkspaceOAuthTokenGrant, now time.Time) ([]discovery.SourceRow, []discovery.EventRow) {
+	sourceByID := map[string]discovery.SourceRow{}
+	events := make([]discovery.EventRow, 0, len(loginActivities)+len(tokenActivities)+len(tokenGrants))
 
 	upsertSource := func(signalKind, sourceAppID, sourceAppName, sourceDomain, sourceVendor string, seenAt time.Time) (discovery.AppMetadata, bool) {
 		sourceAppID = strings.TrimSpace(sourceAppID)
@@ -1140,7 +1115,7 @@ func (i *GoogleWorkspaceIntegration) normalizeDiscovery(loginActivities, tokenAc
 		})
 		current := sourceByID[sourceAppID]
 		if current.SourceAppID == "" || seenAt.After(current.SeenAt) {
-			sourceByID[sourceAppID] = normalizedDiscoverySource{
+			sourceByID[sourceAppID] = discovery.SourceRow{
 				CanonicalKey:     metadata.CanonicalKey,
 				SourceAppID:      sourceAppID,
 				SourceAppName:    sourceAppName,
@@ -1169,7 +1144,7 @@ func (i *GoogleWorkspaceIntegration) normalizeDiscovery(loginActivities, tokenAc
 			actorExternalID = actorEmail
 		}
 		if len(activity.Events) == 0 {
-			events = append(events, normalizedDiscoveryEvent{
+			events = append(events, discovery.EventRow{
 				CanonicalKey:     metadata.CanonicalKey,
 				SignalKind:       discovery.SignalKindIDPSSO,
 				EventExternalID:  activityEventExternalID("login", activity, 0),
@@ -1187,7 +1162,7 @@ func (i *GoogleWorkspaceIntegration) normalizeDiscovery(loginActivities, tokenAc
 			continue
 		}
 		for idx := range activity.Events {
-			events = append(events, normalizedDiscoveryEvent{
+			events = append(events, discovery.EventRow{
 				CanonicalKey:     metadata.CanonicalKey,
 				SignalKind:       discovery.SignalKindIDPSSO,
 				EventExternalID:  activityEventExternalID("login", activity, idx),
@@ -1222,7 +1197,7 @@ func (i *GoogleWorkspaceIntegration) normalizeDiscovery(loginActivities, tokenAc
 		}
 		scopes := discovery.NormalizeScopes(append(activity.ParameterValues("scope"), activity.ParameterValues("scopes")...))
 		if len(activity.Events) == 0 {
-			events = append(events, normalizedDiscoveryEvent{
+			events = append(events, discovery.EventRow{
 				CanonicalKey:     metadata.CanonicalKey,
 				SignalKind:       discovery.SignalKindOAuth,
 				EventExternalID:  activityEventExternalID("token", activity, 0),
@@ -1240,7 +1215,7 @@ func (i *GoogleWorkspaceIntegration) normalizeDiscovery(loginActivities, tokenAc
 			continue
 		}
 		for idx := range activity.Events {
-			events = append(events, normalizedDiscoveryEvent{
+			events = append(events, discovery.EventRow{
 				CanonicalKey:     metadata.CanonicalKey,
 				SignalKind:       discovery.SignalKindOAuth,
 				EventExternalID:  activityEventExternalID("token", activity, idx),
@@ -1267,7 +1242,7 @@ func (i *GoogleWorkspaceIntegration) normalizeDiscovery(loginActivities, tokenAc
 		}
 		userKey := strings.TrimSpace(grant.UserKey)
 		actorEmail := normalizeEmail(userKey)
-		events = append(events, normalizedDiscoveryEvent{
+		events = append(events, discovery.EventRow{
 			CanonicalKey:     metadata.CanonicalKey,
 			SignalKind:       discovery.SignalKindOAuth,
 			EventExternalID:  "inventory:" + googleWorkspaceGrantExternalID(sourceAppID, userKey),
@@ -1284,7 +1259,7 @@ func (i *GoogleWorkspaceIntegration) normalizeDiscovery(loginActivities, tokenAc
 		})
 	}
 
-	sources := make([]normalizedDiscoverySource, 0, len(sourceByID))
+	sources := make([]discovery.SourceRow, 0, len(sourceByID))
 	for _, row := range sourceByID {
 		sources = append(sources, row)
 	}
@@ -1356,174 +1331,30 @@ func activityEventExternalID(prefix string, activity WorkspaceActivity, idx int)
 	return fmt.Sprintf("%s:%x", prefix, h.Sum64())
 }
 
-func (i *GoogleWorkspaceIntegration) writeDiscoveryRows(ctx context.Context, q *gen.Queries, report func(registry.Event), runID int64, sources []normalizedDiscoverySource, events []normalizedDiscoveryEvent) error {
-	total := len(sources) + len(events)
-	report(registry.Event{Source: configstore.KindGoogleWorkspace, Stage: "write-discovery", Current: 0, Total: int64(total), Message: fmt.Sprintf("writing %d discovery records", total)})
+func (i *GoogleWorkspaceIntegration) writeDiscoveryRows(ctx context.Context, q *gen.Queries, report func(registry.Event), runID int64, sources []discovery.SourceRow, events []discovery.EventRow) error {
+	return discovery.WriteRows(ctx, q, discovery.WriteRowsParams{
+		SourceKind: configstore.KindGoogleWorkspace,
+		SourceName: i.customerID,
+		RunID:      runID,
+		Sources:    sources,
+		Events:     events,
+		Report:     discoveryProgressReporter(report),
+	})
+}
 
-	appMeta := map[string]discovery.AppMetadata{}
-	firstSeenByKey := map[string]time.Time{}
-	lastSeenByKey := map[string]time.Time{}
-	addMeta := func(key string, seenAt time.Time, sample discovery.AppMetadata) {
-		if key == "" {
+func discoveryProgressReporter(report func(registry.Event)) func(discovery.ProgressEvent) {
+	return func(event discovery.ProgressEvent) {
+		if report == nil {
 			return
 		}
-		if _, ok := appMeta[key]; !ok {
-			appMeta[key] = sample
-			firstSeenByKey[key] = seenAt
-			lastSeenByKey[key] = seenAt
-			return
-		}
-		if seenAt.Before(firstSeenByKey[key]) {
-			firstSeenByKey[key] = seenAt
-		}
-		if seenAt.After(lastSeenByKey[key]) {
-			lastSeenByKey[key] = seenAt
-		}
-	}
-
-	for _, source := range sources {
-		meta := discovery.BuildMetadata(discovery.CanonicalInput{
-			SourceKind:       configstore.KindGoogleWorkspace,
-			SourceName:       i.customerID,
-			SourceAppID:      source.SourceAppID,
-			SourceAppName:    source.SourceAppName,
-			SourceDomain:     source.SourceAppDomain,
-			SourceVendorName: source.SourceVendorName,
+		report(registry.Event{
+			Source:  event.Source,
+			Stage:   event.Stage,
+			Current: event.Current,
+			Total:   event.Total,
+			Message: event.Message,
 		})
-		meta.CanonicalKey = source.CanonicalKey
-		addMeta(source.CanonicalKey, source.SeenAt, meta)
 	}
-	for _, event := range events {
-		meta := discovery.BuildMetadata(discovery.CanonicalInput{
-			SourceKind:       configstore.KindGoogleWorkspace,
-			SourceName:       i.customerID,
-			SourceAppID:      event.SourceAppID,
-			SourceAppName:    event.SourceAppName,
-			SourceDomain:     event.SourceAppDomain,
-			SourceVendorName: event.SourceVendorName,
-		})
-		meta.CanonicalKey = event.CanonicalKey
-		addMeta(event.CanonicalKey, event.ObservedAt, meta)
-	}
-
-	if len(appMeta) > 0 {
-		canonicalKeys := make([]string, 0, len(appMeta))
-		displayNames := make([]string, 0, len(appMeta))
-		primaryDomains := make([]string, 0, len(appMeta))
-		vendorNames := make([]string, 0, len(appMeta))
-		firstSeenAts := make([]pgtype.Timestamptz, 0, len(appMeta))
-		lastSeenAts := make([]pgtype.Timestamptz, 0, len(appMeta))
-		for key, meta := range appMeta {
-			canonicalKeys = append(canonicalKeys, key)
-			displayNames = append(displayNames, meta.DisplayName)
-			primaryDomains = append(primaryDomains, meta.Domain)
-			vendorNames = append(vendorNames, meta.VendorName)
-			firstSeenAt := firstSeenByKey[key]
-			lastSeenAt := lastSeenByKey[key]
-			firstSeenAts = append(firstSeenAts, registry.PgTimestamptzPtr(&firstSeenAt))
-			lastSeenAts = append(lastSeenAts, registry.PgTimestamptzPtr(&lastSeenAt))
-		}
-		if _, err := q.UpsertSaaSAppsBulk(ctx, gen.UpsertSaaSAppsBulkParams{
-			CanonicalKeys:  canonicalKeys,
-			DisplayNames:   displayNames,
-			PrimaryDomains: primaryDomains,
-			VendorNames:    vendorNames,
-			FirstSeenAts:   firstSeenAts,
-			LastSeenAts:    lastSeenAts,
-		}); err != nil {
-			return fmt.Errorf("upsert saas apps: %w", err)
-		}
-	}
-
-	written := 0
-	if len(sources) > 0 {
-		canonicalKeys := make([]string, 0, len(sources))
-		sourceAppIDs := make([]string, 0, len(sources))
-		sourceAppNames := make([]string, 0, len(sources))
-		sourceAppDomains := make([]string, 0, len(sources))
-		seenAts := make([]pgtype.Timestamptz, 0, len(sources))
-		for _, source := range sources {
-			canonicalKeys = append(canonicalKeys, source.CanonicalKey)
-			sourceAppIDs = append(sourceAppIDs, source.SourceAppID)
-			sourceAppNames = append(sourceAppNames, source.SourceAppName)
-			sourceAppDomains = append(sourceAppDomains, source.SourceAppDomain)
-			seenAts = append(seenAts, registry.PgTimestamptzPtr(&source.SeenAt))
-		}
-		if _, err := q.UpsertSaaSAppSourcesBulkBySource(ctx, gen.UpsertSaaSAppSourcesBulkBySourceParams{
-			SourceKind:       configstore.KindGoogleWorkspace,
-			SourceName:       i.customerID,
-			SeenInRunID:      runID,
-			CanonicalKeys:    canonicalKeys,
-			SourceAppIds:     sourceAppIDs,
-			SourceAppNames:   sourceAppNames,
-			SourceAppDomains: sourceAppDomains,
-			SeenAts:          seenAts,
-		}); err != nil {
-			return fmt.Errorf("upsert saas app sources: %w", err)
-		}
-		written += len(sources)
-		report(registry.Event{Source: configstore.KindGoogleWorkspace, Stage: "write-discovery", Current: int64(written), Total: int64(total), Message: fmt.Sprintf("sources %d/%d", written, total)})
-	}
-
-	if len(events) > 0 {
-		canonicalKeys := make([]string, 0, len(events))
-		signalKinds := make([]string, 0, len(events))
-		eventExternalIDs := make([]string, 0, len(events))
-		sourceAppIDs := make([]string, 0, len(events))
-		sourceAppNames := make([]string, 0, len(events))
-		sourceAppDomains := make([]string, 0, len(events))
-		actorExternalIDs := make([]string, 0, len(events))
-		actorEmails := make([]string, 0, len(events))
-		actorDisplayNames := make([]string, 0, len(events))
-		observedAts := make([]pgtype.Timestamptz, 0, len(events))
-		scopesJSONs := make([][]byte, 0, len(events))
-		rawJSONs := make([][]byte, 0, len(events))
-		ingestedBySignal := map[string]int{}
-		for _, event := range events {
-			canonicalKeys = append(canonicalKeys, event.CanonicalKey)
-			signalKinds = append(signalKinds, event.SignalKind)
-			eventExternalIDs = append(eventExternalIDs, event.EventExternalID)
-			sourceAppIDs = append(sourceAppIDs, event.SourceAppID)
-			sourceAppNames = append(sourceAppNames, event.SourceAppName)
-			sourceAppDomains = append(sourceAppDomains, event.SourceAppDomain)
-			actorExternalIDs = append(actorExternalIDs, event.ActorExternalID)
-			actorEmails = append(actorEmails, event.ActorEmail)
-			actorDisplayNames = append(actorDisplayNames, event.ActorDisplayName)
-			observedAts = append(observedAts, registry.PgTimestamptzPtr(&event.ObservedAt))
-			scopesJSONs = append(scopesJSONs, discovery.ScopesJSON(event.Scopes))
-			rawJSONs = append(rawJSONs, registry.NormalizeJSON(event.RawJSON))
-			ingestedBySignal[event.SignalKind]++
-		}
-		if _, err := q.UpsertSaaSAppEventsBulkBySource(ctx, gen.UpsertSaaSAppEventsBulkBySourceParams{
-			SourceKind:        configstore.KindGoogleWorkspace,
-			SourceName:        i.customerID,
-			SeenInRunID:       runID,
-			CanonicalKeys:     canonicalKeys,
-			SignalKinds:       signalKinds,
-			EventExternalIds:  eventExternalIDs,
-			SourceAppIds:      sourceAppIDs,
-			SourceAppNames:    sourceAppNames,
-			SourceAppDomains:  sourceAppDomains,
-			ActorExternalIds:  actorExternalIDs,
-			ActorEmails:       actorEmails,
-			ActorDisplayNames: actorDisplayNames,
-			ObservedAts:       observedAts,
-			ScopesJsons:       scopesJSONs,
-			RawJsons:          rawJSONs,
-		}); err != nil {
-			return fmt.Errorf("upsert saas app events: %w", err)
-		}
-		for signalKind, count := range ingestedBySignal {
-			metrics.DiscoveryEventsIngestedTotal.WithLabelValues(configstore.KindGoogleWorkspace, signalKind).Add(float64(count))
-		}
-		written += len(events)
-		report(registry.Event{Source: configstore.KindGoogleWorkspace, Stage: "write-discovery", Current: int64(written), Total: int64(total), Message: fmt.Sprintf("events %d/%d", written, total)})
-	}
-
-	if written == 0 {
-		report(registry.Event{Source: configstore.KindGoogleWorkspace, Stage: "write-discovery", Current: 0, Total: 0, Message: "no discovery records to write"})
-	}
-	return nil
 }
 
 func (i *GoogleWorkspaceIntegration) seedGoogleWorkspaceAutoBindings(ctx context.Context, q *gen.Queries, runID int64) error {

--- a/internal/connectors/googleworkspace/integration.go
+++ b/internal/connectors/googleworkspace/integration.go
@@ -1338,23 +1338,8 @@ func (i *GoogleWorkspaceIntegration) writeDiscoveryRows(ctx context.Context, q *
 		RunID:      runID,
 		Sources:    sources,
 		Events:     events,
-		Report:     discoveryProgressReporter(report),
+		Report:     registry.DiscoveryProgressReporter(report),
 	})
-}
-
-func discoveryProgressReporter(report func(registry.Event)) func(discovery.ProgressEvent) {
-	return func(event discovery.ProgressEvent) {
-		if report == nil {
-			return
-		}
-		report(registry.Event{
-			Source:  event.Source,
-			Stage:   event.Stage,
-			Current: event.Current,
-			Total:   event.Total,
-			Message: event.Message,
-		})
-	}
 }
 
 func (i *GoogleWorkspaceIntegration) seedGoogleWorkspaceAutoBindings(ctx context.Context, q *gen.Queries, runID int64) error {

--- a/internal/connectors/okta/integration.go
+++ b/internal/connectors/okta/integration.go
@@ -890,23 +890,8 @@ func (i *OktaIntegration) writeDiscoveryRows(ctx context.Context, q *gen.Queries
 		RunID:      runID,
 		Sources:    sources,
 		Events:     events,
-		Report:     discoveryProgressReporter(report),
+		Report:     registry.DiscoveryProgressReporter(report),
 	})
-}
-
-func discoveryProgressReporter(report func(registry.Event)) func(discovery.ProgressEvent) {
-	return func(event discovery.ProgressEvent) {
-		if report == nil {
-			return
-		}
-		report(registry.Event{
-			Source:  event.Source,
-			Stage:   event.Stage,
-			Current: event.Current,
-			Total:   event.Total,
-			Message: event.Message,
-		})
-	}
 }
 
 func (i *OktaIntegration) seedOktaAutoBindings(ctx context.Context, q *gen.Queries) error {

--- a/internal/connectors/okta/integration.go
+++ b/internal/connectors/okta/integration.go
@@ -729,31 +729,6 @@ func (i *OktaIntegration) syncOktaAppGroupAssignments(ctx context.Context, q *ge
 	return firstErr
 }
 
-type normalizedDiscoverySource struct {
-	CanonicalKey     string
-	SourceAppID      string
-	SourceAppName    string
-	SourceAppDomain  string
-	SourceVendorName string
-	SeenAt           time.Time
-}
-
-type normalizedDiscoveryEvent struct {
-	CanonicalKey     string
-	SignalKind       string
-	EventExternalID  string
-	SourceAppID      string
-	SourceAppName    string
-	SourceAppDomain  string
-	SourceVendorName string
-	ActorExternalID  string
-	ActorEmail       string
-	ActorDisplayName string
-	ObservedAt       time.Time
-	Scopes           []string
-	RawJSON          []byte
-}
-
 func (i *OktaIntegration) syncDiscovery(ctx context.Context, q *gen.Queries, report func(registry.Event), runID int64) error {
 	report(registry.Event{Source: "okta", Stage: "list-discovery-events", Current: 0, Total: 1, Message: "listing discovery events"})
 
@@ -807,9 +782,9 @@ func (i *OktaIntegration) syncDiscovery(ctx context.Context, q *gen.Queries, rep
 	return nil
 }
 
-func normalizeOktaDiscovery(events []SystemLogEvent, sourceName string, now time.Time) ([]normalizedDiscoverySource, []normalizedDiscoveryEvent) {
-	sourceByID := make(map[string]normalizedDiscoverySource, len(events))
-	normalizedEvents := make([]normalizedDiscoveryEvent, 0, len(events))
+func normalizeOktaDiscovery(events []SystemLogEvent, sourceName string, now time.Time) ([]discovery.SourceRow, []discovery.EventRow) {
+	sourceByID := make(map[string]discovery.SourceRow, len(events))
+	normalizedEvents := make([]discovery.EventRow, 0, len(events))
 
 	for _, event := range events {
 		sourceAppID := strings.TrimSpace(event.AppID)
@@ -855,7 +830,7 @@ func normalizeOktaDiscovery(events []SystemLogEvent, sourceName string, now time
 
 		current := sourceByID[sourceAppID]
 		if current.SourceAppID == "" || observedAt.After(current.SeenAt) {
-			sourceByID[sourceAppID] = normalizedDiscoverySource{
+			sourceByID[sourceAppID] = discovery.SourceRow{
 				CanonicalKey:     metadata.CanonicalKey,
 				SourceAppID:      sourceAppID,
 				SourceAppName:    sourceAppName,
@@ -865,7 +840,7 @@ func normalizeOktaDiscovery(events []SystemLogEvent, sourceName string, now time
 			}
 		}
 
-		normalizedEvents = append(normalizedEvents, normalizedDiscoveryEvent{
+		normalizedEvents = append(normalizedEvents, discovery.EventRow{
 			CanonicalKey:     metadata.CanonicalKey,
 			SignalKind:       signalKind,
 			EventExternalID:  strings.TrimSpace(event.ID),
@@ -882,7 +857,7 @@ func normalizeOktaDiscovery(events []SystemLogEvent, sourceName string, now time
 		})
 	}
 
-	sourceRows := make([]normalizedDiscoverySource, 0, len(sourceByID))
+	sourceRows := make([]discovery.SourceRow, 0, len(sourceByID))
 	for _, sourceRow := range sourceByID {
 		sourceRows = append(sourceRows, sourceRow)
 	}
@@ -908,200 +883,30 @@ func oktaDiscoverySignalKind(eventType string, hasApp bool) string {
 	return ""
 }
 
-func (i *OktaIntegration) writeDiscoveryRows(ctx context.Context, q *gen.Queries, report func(registry.Event), runID int64, sources []normalizedDiscoverySource, events []normalizedDiscoveryEvent) error {
-	total := len(sources) + len(events)
-	report(registry.Event{
-		Source:  "okta",
-		Stage:   "write-discovery",
-		Current: 0,
-		Total:   int64(total),
-		Message: fmt.Sprintf("writing %d discovery records", total),
+func (i *OktaIntegration) writeDiscoveryRows(ctx context.Context, q *gen.Queries, report func(registry.Event), runID int64, sources []discovery.SourceRow, events []discovery.EventRow) error {
+	return discovery.WriteRows(ctx, q, discovery.WriteRowsParams{
+		SourceKind: "okta",
+		SourceName: i.sourceName,
+		RunID:      runID,
+		Sources:    sources,
+		Events:     events,
+		Report:     discoveryProgressReporter(report),
 	})
+}
 
-	appMeta := map[string]discovery.AppMetadata{}
-	firstSeenByKey := map[string]time.Time{}
-	lastSeenByKey := map[string]time.Time{}
-	addMeta := func(key string, seenAt time.Time, sample discovery.AppMetadata) {
-		if key == "" {
+func discoveryProgressReporter(report func(registry.Event)) func(discovery.ProgressEvent) {
+	return func(event discovery.ProgressEvent) {
+		if report == nil {
 			return
 		}
-		if _, ok := appMeta[key]; !ok {
-			appMeta[key] = sample
-			firstSeenByKey[key] = seenAt
-			lastSeenByKey[key] = seenAt
-			return
-		}
-		if seenAt.Before(firstSeenByKey[key]) {
-			firstSeenByKey[key] = seenAt
-		}
-		if seenAt.After(lastSeenByKey[key]) {
-			lastSeenByKey[key] = seenAt
-		}
-	}
-
-	for _, source := range sources {
-		meta := discovery.BuildMetadata(discovery.CanonicalInput{
-			SourceKind:       "okta",
-			SourceName:       i.sourceName,
-			SourceAppID:      source.SourceAppID,
-			SourceAppName:    source.SourceAppName,
-			SourceDomain:     source.SourceAppDomain,
-			SourceVendorName: source.SourceVendorName,
-		})
-		meta.CanonicalKey = source.CanonicalKey
-		addMeta(source.CanonicalKey, source.SeenAt, meta)
-	}
-	for _, event := range events {
-		meta := discovery.BuildMetadata(discovery.CanonicalInput{
-			SourceKind:       "okta",
-			SourceName:       i.sourceName,
-			SourceAppID:      event.SourceAppID,
-			SourceAppName:    event.SourceAppName,
-			SourceDomain:     event.SourceAppDomain,
-			SourceVendorName: event.SourceVendorName,
-		})
-		meta.CanonicalKey = event.CanonicalKey
-		addMeta(event.CanonicalKey, event.ObservedAt, meta)
-	}
-
-	if len(appMeta) > 0 {
-		canonicalKeys := make([]string, 0, len(appMeta))
-		displayNames := make([]string, 0, len(appMeta))
-		primaryDomains := make([]string, 0, len(appMeta))
-		vendorNames := make([]string, 0, len(appMeta))
-		firstSeenAts := make([]pgtype.Timestamptz, 0, len(appMeta))
-		lastSeenAts := make([]pgtype.Timestamptz, 0, len(appMeta))
-
-		for key, meta := range appMeta {
-			canonicalKeys = append(canonicalKeys, key)
-			displayNames = append(displayNames, meta.DisplayName)
-			primaryDomains = append(primaryDomains, meta.Domain)
-			vendorNames = append(vendorNames, meta.VendorName)
-			firstSeenAt := firstSeenByKey[key]
-			lastSeenAt := lastSeenByKey[key]
-			firstSeenAts = append(firstSeenAts, registry.PgTimestamptzPtr(&firstSeenAt))
-			lastSeenAts = append(lastSeenAts, registry.PgTimestamptzPtr(&lastSeenAt))
-		}
-
-		if _, err := q.UpsertSaaSAppsBulk(ctx, gen.UpsertSaaSAppsBulkParams{
-			CanonicalKeys:  canonicalKeys,
-			DisplayNames:   displayNames,
-			PrimaryDomains: primaryDomains,
-			VendorNames:    vendorNames,
-			FirstSeenAts:   firstSeenAts,
-			LastSeenAts:    lastSeenAts,
-		}); err != nil {
-			return fmt.Errorf("upsert saas apps: %w", err)
-		}
-	}
-
-	written := 0
-	if len(sources) > 0 {
-		canonicalKeys := make([]string, 0, len(sources))
-		sourceAppIDs := make([]string, 0, len(sources))
-		sourceAppNames := make([]string, 0, len(sources))
-		sourceAppDomains := make([]string, 0, len(sources))
-		seenAts := make([]pgtype.Timestamptz, 0, len(sources))
-		for _, source := range sources {
-			canonicalKeys = append(canonicalKeys, source.CanonicalKey)
-			sourceAppIDs = append(sourceAppIDs, source.SourceAppID)
-			sourceAppNames = append(sourceAppNames, source.SourceAppName)
-			sourceAppDomains = append(sourceAppDomains, source.SourceAppDomain)
-			seenAts = append(seenAts, registry.PgTimestamptzPtr(&source.SeenAt))
-		}
-		if _, err := q.UpsertSaaSAppSourcesBulkBySource(ctx, gen.UpsertSaaSAppSourcesBulkBySourceParams{
-			SourceKind:       "okta",
-			SourceName:       i.sourceName,
-			SeenInRunID:      runID,
-			CanonicalKeys:    canonicalKeys,
-			SourceAppIds:     sourceAppIDs,
-			SourceAppNames:   sourceAppNames,
-			SourceAppDomains: sourceAppDomains,
-			SeenAts:          seenAts,
-		}); err != nil {
-			return fmt.Errorf("upsert saas app sources: %w", err)
-		}
-		written += len(sources)
 		report(registry.Event{
-			Source:  "okta",
-			Stage:   "write-discovery",
-			Current: int64(written),
-			Total:   int64(total),
-			Message: fmt.Sprintf("sources %d/%d", written, total),
+			Source:  event.Source,
+			Stage:   event.Stage,
+			Current: event.Current,
+			Total:   event.Total,
+			Message: event.Message,
 		})
 	}
-
-	if len(events) > 0 {
-		canonicalKeys := make([]string, 0, len(events))
-		signalKinds := make([]string, 0, len(events))
-		eventExternalIDs := make([]string, 0, len(events))
-		sourceAppIDs := make([]string, 0, len(events))
-		sourceAppNames := make([]string, 0, len(events))
-		sourceAppDomains := make([]string, 0, len(events))
-		actorExternalIDs := make([]string, 0, len(events))
-		actorEmails := make([]string, 0, len(events))
-		actorDisplayNames := make([]string, 0, len(events))
-		observedAts := make([]pgtype.Timestamptz, 0, len(events))
-		scopesJSONs := make([][]byte, 0, len(events))
-		rawJSONs := make([][]byte, 0, len(events))
-		ingestedBySignal := map[string]int{}
-		for _, event := range events {
-			canonicalKeys = append(canonicalKeys, event.CanonicalKey)
-			signalKinds = append(signalKinds, event.SignalKind)
-			eventExternalIDs = append(eventExternalIDs, event.EventExternalID)
-			sourceAppIDs = append(sourceAppIDs, event.SourceAppID)
-			sourceAppNames = append(sourceAppNames, event.SourceAppName)
-			sourceAppDomains = append(sourceAppDomains, event.SourceAppDomain)
-			actorExternalIDs = append(actorExternalIDs, event.ActorExternalID)
-			actorEmails = append(actorEmails, event.ActorEmail)
-			actorDisplayNames = append(actorDisplayNames, event.ActorDisplayName)
-			observedAts = append(observedAts, registry.PgTimestamptzPtr(&event.ObservedAt))
-			scopesJSONs = append(scopesJSONs, discovery.ScopesJSON(event.Scopes))
-			rawJSONs = append(rawJSONs, registry.NormalizeJSON(event.RawJSON))
-			ingestedBySignal[event.SignalKind]++
-		}
-		if _, err := q.UpsertSaaSAppEventsBulkBySource(ctx, gen.UpsertSaaSAppEventsBulkBySourceParams{
-			SourceKind:        "okta",
-			SourceName:        i.sourceName,
-			SeenInRunID:       runID,
-			CanonicalKeys:     canonicalKeys,
-			SignalKinds:       signalKinds,
-			EventExternalIds:  eventExternalIDs,
-			SourceAppIds:      sourceAppIDs,
-			SourceAppNames:    sourceAppNames,
-			SourceAppDomains:  sourceAppDomains,
-			ActorExternalIds:  actorExternalIDs,
-			ActorEmails:       actorEmails,
-			ActorDisplayNames: actorDisplayNames,
-			ObservedAts:       observedAts,
-			ScopesJsons:       scopesJSONs,
-			RawJsons:          rawJSONs,
-		}); err != nil {
-			return fmt.Errorf("upsert saas app events: %w", err)
-		}
-		for signalKind, count := range ingestedBySignal {
-			metrics.DiscoveryEventsIngestedTotal.WithLabelValues("okta", signalKind).Add(float64(count))
-		}
-		written += len(events)
-		report(registry.Event{
-			Source:  "okta",
-			Stage:   "write-discovery",
-			Current: int64(written),
-			Total:   int64(total),
-			Message: fmt.Sprintf("events %d/%d", written, total),
-		})
-	}
-
-	if written == 0 {
-		report(registry.Event{
-			Source:  "okta",
-			Stage:   "write-discovery",
-			Current: 0,
-			Total:   0,
-			Message: "no discovery records to write",
-		})
-	}
-	return nil
 }
 
 func (i *OktaIntegration) seedOktaAutoBindings(ctx context.Context, q *gen.Queries) error {

--- a/internal/connectors/registry/bulk_rows.go
+++ b/internal/connectors/registry/bulk_rows.go
@@ -1,0 +1,172 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/open-sspm/open-sspm/internal/db/gen"
+)
+
+type SourceAccountRow struct {
+	ExternalID      string
+	Email           string
+	DisplayName     string
+	AccountKind     string
+	EntityCategory  string
+	RawJSON         []byte
+	LastLoginAt     pgtype.Timestamptz
+	LastLoginIP     string
+	LastLoginRegion string
+}
+
+type WriteSourceAccountRowsParams struct {
+	SourceKind string
+	SourceName string
+	RunID      int64
+	BatchSize  int
+	Rows       []SourceAccountRow
+}
+
+func WriteSourceAccountRows(ctx context.Context, q *gen.Queries, params WriteSourceAccountRowsParams) (int, error) {
+	if len(params.Rows) == 0 {
+		return 0, nil
+	}
+	if q == nil {
+		return 0, fmt.Errorf("write source accounts for %s/%s: queries is nil", params.SourceKind, params.SourceName)
+	}
+
+	batchSize := params.BatchSize
+	if batchSize <= 0 {
+		batchSize = 1000
+	}
+
+	written := 0
+	for start := 0; start < len(params.Rows); start += batchSize {
+		end := min(start+batchSize, len(params.Rows))
+		batch := params.Rows[start:end]
+
+		externalIDs := make([]string, 0, len(batch))
+		emails := make([]string, 0, len(batch))
+		displayNames := make([]string, 0, len(batch))
+		accountKinds := make([]string, 0, len(batch))
+		entityCategories := make([]string, 0, len(batch))
+		rawJSONs := make([][]byte, 0, len(batch))
+		lastLoginAts := make([]pgtype.Timestamptz, 0, len(batch))
+		lastLoginIPs := make([]string, 0, len(batch))
+		lastLoginRegions := make([]string, 0, len(batch))
+
+		for _, row := range batch {
+			externalID := strings.TrimSpace(row.ExternalID)
+			if externalID == "" {
+				continue
+			}
+			externalIDs = append(externalIDs, externalID)
+			emails = append(emails, row.Email)
+			displayNames = append(displayNames, row.DisplayName)
+			accountKinds = append(accountKinds, row.AccountKind)
+			entityCategories = append(entityCategories, row.EntityCategory)
+			rawJSONs = append(rawJSONs, NormalizeJSON(row.RawJSON))
+			lastLoginAts = append(lastLoginAts, row.LastLoginAt)
+			lastLoginIPs = append(lastLoginIPs, row.LastLoginIP)
+			lastLoginRegions = append(lastLoginRegions, row.LastLoginRegion)
+		}
+		if len(externalIDs) == 0 {
+			continue
+		}
+
+		affected, err := q.UpsertSourceAccountsBulkBySource(ctx, gen.UpsertSourceAccountsBulkBySourceParams{
+			SourceKind:       params.SourceKind,
+			SourceName:       params.SourceName,
+			SeenInRunID:      params.RunID,
+			ExternalIds:      externalIDs,
+			Emails:           emails,
+			DisplayNames:     displayNames,
+			AccountKinds:     accountKinds,
+			EntityCategories: entityCategories,
+			RawJsons:         rawJSONs,
+			LastLoginAts:     lastLoginAts,
+			LastLoginIps:     lastLoginIPs,
+			LastLoginRegions: lastLoginRegions,
+		})
+		if err != nil {
+			return written, err
+		}
+		written += int(affected)
+	}
+	return written, nil
+}
+
+type EntitlementRow struct {
+	AccountExternalID string
+	Kind              string
+	Resource          string
+	Permission        string
+	RawJSON           []byte
+}
+
+type WriteEntitlementRowsParams struct {
+	SourceKind string
+	SourceName string
+	RunID      int64
+	BatchSize  int
+	Rows       []EntitlementRow
+}
+
+func WriteEntitlementRows(ctx context.Context, q *gen.Queries, params WriteEntitlementRowsParams) (int, error) {
+	if len(params.Rows) == 0 {
+		return 0, nil
+	}
+	if q == nil {
+		return 0, fmt.Errorf("write entitlements for %s/%s: queries is nil", params.SourceKind, params.SourceName)
+	}
+
+	batchSize := params.BatchSize
+	if batchSize <= 0 {
+		batchSize = 5000
+	}
+
+	written := 0
+	for start := 0; start < len(params.Rows); start += batchSize {
+		end := min(start+batchSize, len(params.Rows))
+		batch := params.Rows[start:end]
+
+		accountExternalIDs := make([]string, 0, len(batch))
+		kinds := make([]string, 0, len(batch))
+		resources := make([]string, 0, len(batch))
+		permissions := make([]string, 0, len(batch))
+		rawJSONs := make([][]byte, 0, len(batch))
+
+		for _, row := range batch {
+			accountExternalID := strings.TrimSpace(row.AccountExternalID)
+			if accountExternalID == "" {
+				continue
+			}
+			accountExternalIDs = append(accountExternalIDs, accountExternalID)
+			kinds = append(kinds, row.Kind)
+			resources = append(resources, row.Resource)
+			permissions = append(permissions, row.Permission)
+			rawJSONs = append(rawJSONs, NormalizeJSON(row.RawJSON))
+		}
+		if len(accountExternalIDs) == 0 {
+			continue
+		}
+
+		affected, err := q.UpsertEntitlementsBulkBySource(ctx, gen.UpsertEntitlementsBulkBySourceParams{
+			SeenInRunID:        params.RunID,
+			SourceKind:         params.SourceKind,
+			SourceName:         params.SourceName,
+			AccountExternalIds: accountExternalIDs,
+			Kinds:              kinds,
+			Resources:          resources,
+			Permissions:        permissions,
+			RawJsons:           rawJSONs,
+		})
+		if err != nil {
+			return written, err
+		}
+		written += int(affected)
+	}
+	return written, nil
+}

--- a/internal/connectors/registry/discovery_progress.go
+++ b/internal/connectors/registry/discovery_progress.go
@@ -1,0 +1,18 @@
+package registry
+
+import "github.com/open-sspm/open-sspm/internal/discovery"
+
+func DiscoveryProgressReporter(report func(Event)) func(discovery.ProgressEvent) {
+	return func(event discovery.ProgressEvent) {
+		if report == nil {
+			return
+		}
+		report(Event{
+			Source:  event.Source,
+			Stage:   event.Stage,
+			Current: event.Current,
+			Total:   event.Total,
+			Message: event.Message,
+		})
+	}
+}

--- a/internal/connectors/registry/discovery_progress_test.go
+++ b/internal/connectors/registry/discovery_progress_test.go
@@ -1,0 +1,46 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/open-sspm/open-sspm/internal/discovery"
+)
+
+func TestDiscoveryProgressReporterMapsEvent(t *testing.T) {
+	t.Parallel()
+
+	var got Event
+	reporter := DiscoveryProgressReporter(func(event Event) {
+		got = event
+	})
+
+	reporter(discovery.ProgressEvent{
+		Source:  "okta",
+		Stage:   "write-discovery",
+		Current: 2,
+		Total:   5,
+		Message: "sources 2/5",
+	})
+
+	if got.Source != "okta" {
+		t.Fatalf("Source = %q, want okta", got.Source)
+	}
+	if got.Stage != "write-discovery" {
+		t.Fatalf("Stage = %q, want write-discovery", got.Stage)
+	}
+	if got.Current != 2 {
+		t.Fatalf("Current = %d, want 2", got.Current)
+	}
+	if got.Total != 5 {
+		t.Fatalf("Total = %d, want 5", got.Total)
+	}
+	if got.Message != "sources 2/5" {
+		t.Fatalf("Message = %q, want sources 2/5", got.Message)
+	}
+}
+
+func TestDiscoveryProgressReporterAllowsNilReport(t *testing.T) {
+	t.Parallel()
+
+	DiscoveryProgressReporter(nil)(discovery.ProgressEvent{})
+}

--- a/internal/connectors/registry/helpers.go
+++ b/internal/connectors/registry/helpers.go
@@ -123,6 +123,22 @@ func FailSyncRun(ctx context.Context, q *gen.Queries, runID int64, err error, er
 	return err
 }
 
+func ReportAndFailSyncRun(ctx context.Context, q *gen.Queries, runID int64, report func(Event), event Event, err error, errorKind string) error {
+	if err == nil {
+		return nil
+	}
+	if event.Message == "" {
+		event.Message = err.Error()
+	}
+	if event.Err == nil {
+		event.Err = err
+	}
+	if report != nil {
+		report(event)
+	}
+	return FailSyncRun(ctx, q, runID, err, errorKind)
+}
+
 func FinalizeOktaRun(ctx context.Context, q *gen.Queries, pool *pgxpool.Pool, runID int64, sourceName string, duration time.Duration, finalizeDiscovery bool) error {
 	tx, err := pool.Begin(ctx)
 	if err != nil {
@@ -248,11 +264,7 @@ func FinalizeOktaRun(ctx context.Context, q *gen.Queries, pool *pgxpool.Pool, ru
 		counts["saas_app_events_expired"] = expired
 	}
 
-	stats := MarshalJSON(map[string]any{
-		"counts":      counts,
-		"duration_ms": duration.Milliseconds(),
-	})
-	if err := finalizeSuccessfulRunInTx(ctx, qtx, runID, stats, "okta", sourceName); err != nil {
+	if err := finalizeRunCountsInTx(ctx, qtx, runID, counts, duration, "okta", sourceName); err != nil {
 		return err
 	}
 
@@ -417,11 +429,7 @@ func FinalizeAppRun(ctx context.Context, q *gen.Queries, pool *pgxpool.Pool, run
 		counts["saas_app_events_expired"] = expired
 	}
 
-	stats := MarshalJSON(map[string]any{
-		"counts":      counts,
-		"duration_ms": duration.Milliseconds(),
-	})
-	if err := finalizeSuccessfulRunInTx(ctx, qtx, runID, stats, sourceKind, sourceName); err != nil {
+	if err := finalizeRunCountsInTx(ctx, qtx, runID, counts, duration, sourceKind, sourceName); err != nil {
 		return err
 	}
 
@@ -481,11 +489,7 @@ func FinalizeDiscoveryRun(ctx context.Context, q *gen.Queries, pool *pgxpool.Poo
 	}
 	counts["saas_app_events_expired"] = expired
 
-	stats := MarshalJSON(map[string]any{
-		"counts":      counts,
-		"duration_ms": duration.Milliseconds(),
-	})
-	if err := finalizeSuccessfulRunInTx(ctx, qtx, runID, stats, sourceKind, sourceName); err != nil {
+	if err := finalizeRunCountsInTx(ctx, qtx, runID, counts, duration, sourceKind, sourceName); err != nil {
 		return err
 	}
 
@@ -512,6 +516,14 @@ func MarshalJSON(v any) []byte {
 		panic(fmt.Errorf("registry: marshal json: %w", err))
 	}
 	return b
+}
+
+func finalizeRunCountsInTx(ctx context.Context, q *gen.Queries, runID int64, counts map[string]int64, duration time.Duration, sourceKind, sourceName string) error {
+	stats := MarshalJSON(map[string]any{
+		"counts":      counts,
+		"duration_ms": duration.Milliseconds(),
+	})
+	return finalizeSuccessfulRunInTx(ctx, q, runID, stats, sourceKind, sourceName)
 }
 
 func finalizeSuccessfulRunInTx(ctx context.Context, q *gen.Queries, runID int64, stats []byte, sourceKind, sourceName string) error {

--- a/internal/connectors/registry/sync_runs_integration_test.go
+++ b/internal/connectors/registry/sync_runs_integration_test.go
@@ -2,26 +2,18 @@ package registry
 
 import (
 	"context"
-	"errors"
-	"net/url"
-	"os"
-	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/golang-migrate/migrate/v4"
-	_ "github.com/golang-migrate/migrate/v4/database/postgres"
-	_ "github.com/golang-migrate/migrate/v4/source/file"
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/open-sspm/open-sspm/internal/connectors/configstore"
 	"github.com/open-sspm/open-sspm/internal/db/gen"
 	"github.com/open-sspm/open-sspm/internal/readmodels"
+	"github.com/open-sspm/open-sspm/internal/testdb"
 )
 
 const syncRunsTestConnectorSecretKey = "0123456789abcdef0123456789abcdef"
@@ -388,63 +380,15 @@ type syncRunState struct {
 func withSyncRunsTestDB(t *testing.T, fn func(context.Context, *pgxpool.Pool, *gen.Queries, *migrate.Migrate)) {
 	t.Helper()
 
-	baseURL := strings.TrimSpace(os.Getenv("OPENSSPM_TEST_DATABASE_URL"))
-	if baseURL == "" {
-		t.Skip("OPENSSPM_TEST_DATABASE_URL is not set")
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-
-	adminURL, err := testDatabaseAdminURL(baseURL)
-	if err != nil {
-		t.Fatalf("testDatabaseAdminURL() err = %v", err)
-	}
-
-	adminConn, err := pgx.Connect(ctx, adminURL)
-	if err != nil {
-		t.Fatalf("pgx.Connect(admin) err = %v", err)
-	}
-	defer adminConn.Close(ctx)
-
-	dbName := "opensspm_syncruns_" + strings.ReplaceAll(uuid.NewString(), "-", "")
-	if _, err := adminConn.Exec(ctx, "CREATE DATABASE "+pgx.Identifier{dbName}.Sanitize()); err != nil {
-		t.Fatalf("CREATE DATABASE err = %v", err)
-	}
-	defer func() {
-		dropCtx, dropCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer dropCancel()
-		_, _ = adminConn.Exec(dropCtx, "DROP DATABASE IF EXISTS "+pgx.Identifier{dbName}.Sanitize()+" WITH (FORCE)")
-	}()
-
-	testURL, err := testDatabaseURLWithName(baseURL, dbName)
-	if err != nil {
-		t.Fatalf("testDatabaseURLWithName() err = %v", err)
-	}
-
-	migrator, err := migrate.New("file://"+testMigrationsDir(t), testURL)
-	if err != nil {
-		t.Fatalf("migrate.New() err = %v", err)
-	}
-	defer func() {
-		_, _ = migrator.Close()
-	}()
-
-	pool, err := pgxpool.New(ctx, testURL)
-	if err != nil {
-		t.Fatalf("pgxpool.New() err = %v", err)
-	}
-	defer pool.Close()
-
-	fn(ctx, pool, gen.New(pool), migrator)
+	testdb.WithDatabase(t, testdb.Options{NamePrefix: "opensspm_syncruns"}, func(ctx context.Context, pool *pgxpool.Pool, migrator *migrate.Migrate) {
+		fn(ctx, pool, gen.New(pool), migrator)
+	})
 }
 
 func migrateUp(t *testing.T, migrator *migrate.Migrate) {
 	t.Helper()
 
-	if err := migrator.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
-		t.Fatalf("migrate up: %v", err)
-	}
+	testdb.MigrateUp(t, migrator)
 }
 
 func insertSyncRunRow(t *testing.T, ctx context.Context, pool *pgxpool.Pool, seed syncRunSeed) int64 {
@@ -550,32 +494,4 @@ func insertSyncRunsTestAppAsset(t *testing.T, ctx context.Context, q *gen.Querie
 	}
 
 	return appAsset.ID
-}
-
-func testMigrationsDir(t *testing.T) string {
-	t.Helper()
-
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	return filepath.Join(filepath.Dir(file), "..", "..", "..", "db", "migrations")
-}
-
-func testDatabaseAdminURL(raw string) (string, error) {
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		return "", err
-	}
-	parsed.Path = "/postgres"
-	return parsed.String(), nil
-}
-
-func testDatabaseURLWithName(raw, dbName string) (string, error) {
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		return "", err
-	}
-	parsed.Path = "/" + dbName
-	return parsed.String(), nil
 }

--- a/internal/db/gen/entity_category_integration_test.go
+++ b/internal/db/gen/entity_category_integration_test.go
@@ -2,22 +2,12 @@ package gen
 
 import (
 	"context"
-	"errors"
-	"net/url"
-	"os"
-	"path/filepath"
-	"runtime"
 	"slices"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/golang-migrate/migrate/v4"
-	_ "github.com/golang-migrate/migrate/v4/database/postgres"
-	_ "github.com/golang-migrate/migrate/v4/source/file"
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/open-sspm/open-sspm/internal/testdb"
 )
 
 func TestGenericAccountQueriesFilterEntityCategory(t *testing.T) {
@@ -412,63 +402,15 @@ type accountSeed struct {
 func withEntityCategoryTestDatabase(t *testing.T, fn func(context.Context, *pgxpool.Pool, *Queries, *migrate.Migrate)) {
 	t.Helper()
 
-	baseURL := strings.TrimSpace(os.Getenv("OPENSSPM_TEST_DATABASE_URL"))
-	if baseURL == "" {
-		t.Skip("OPENSSPM_TEST_DATABASE_URL is not set")
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-
-	adminURL, err := testDatabaseAdminURL(baseURL)
-	if err != nil {
-		t.Fatalf("testDatabaseAdminURL() err = %v", err)
-	}
-
-	adminConn, err := pgx.Connect(ctx, adminURL)
-	if err != nil {
-		t.Fatalf("pgx.Connect(admin) err = %v", err)
-	}
-	defer adminConn.Close(ctx)
-
-	dbName := "opensspm_entity_category_" + strings.ReplaceAll(uuid.NewString(), "-", "")
-	if _, err := adminConn.Exec(ctx, "CREATE DATABASE "+pgx.Identifier{dbName}.Sanitize()); err != nil {
-		t.Fatalf("CREATE DATABASE err = %v", err)
-	}
-	defer func() {
-		dropCtx, dropCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer dropCancel()
-		_, _ = adminConn.Exec(dropCtx, "DROP DATABASE IF EXISTS "+pgx.Identifier{dbName}.Sanitize()+" WITH (FORCE)")
-	}()
-
-	testURL, err := testDatabaseURLWithName(baseURL, dbName)
-	if err != nil {
-		t.Fatalf("testDatabaseURLWithName() err = %v", err)
-	}
-
-	migrator, err := migrate.New("file://"+testMigrationsDir(t), testURL)
-	if err != nil {
-		t.Fatalf("migrate.New() err = %v", err)
-	}
-	defer func() {
-		_, _ = migrator.Close()
-	}()
-
-	pool, err := pgxpool.New(ctx, testURL)
-	if err != nil {
-		t.Fatalf("pgxpool.New() err = %v", err)
-	}
-	defer pool.Close()
-
-	fn(ctx, pool, New(pool), migrator)
+	testdb.WithDatabase(t, testdb.Options{NamePrefix: "opensspm_entity_category"}, func(ctx context.Context, pool *pgxpool.Pool, migrator *migrate.Migrate) {
+		fn(ctx, pool, New(pool), migrator)
+	})
 }
 
 func migrateUp(t *testing.T, migrator *migrate.Migrate) {
 	t.Helper()
 
-	if err := migrator.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
-		t.Fatalf("migrate up: %v", err)
-	}
+	testdb.MigrateUp(t, migrator)
 }
 
 func insertSyncRun(t *testing.T, ctx context.Context, pool *pgxpool.Pool, sourceKind, sourceName string) int64 {
@@ -594,32 +536,4 @@ func accountExternalIDs(rows []Account) []string {
 	}
 	slices.Sort(ids)
 	return ids
-}
-
-func testMigrationsDir(t *testing.T) string {
-	t.Helper()
-
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	return filepath.Join(filepath.Dir(file), "..", "..", "..", "db", "migrations")
-}
-
-func testDatabaseAdminURL(raw string) (string, error) {
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		return "", err
-	}
-	parsed.Path = "/postgres"
-	return parsed.String(), nil
-}
-
-func testDatabaseURLWithName(raw, dbName string) (string, error) {
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		return "", err
-	}
-	parsed.Path = "/" + dbName
-	return parsed.String(), nil
 }

--- a/internal/discovery/rows.go
+++ b/internal/discovery/rows.go
@@ -1,0 +1,288 @@
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/open-sspm/open-sspm/internal/db/gen"
+	"github.com/open-sspm/open-sspm/internal/metrics"
+)
+
+type SourceRow struct {
+	CanonicalKey     string
+	SourceAppID      string
+	SourceAppName    string
+	SourceAppDomain  string
+	SourceVendorName string
+	SeenAt           time.Time
+}
+
+type EventRow struct {
+	CanonicalKey     string
+	SignalKind       string
+	EventExternalID  string
+	SourceAppID      string
+	SourceAppName    string
+	SourceAppDomain  string
+	SourceVendorName string
+	ActorExternalID  string
+	ActorEmail       string
+	ActorDisplayName string
+	ObservedAt       time.Time
+	Scopes           []string
+	RawJSON          []byte
+}
+
+type WriteRowsParams struct {
+	SourceKind string
+	SourceName string
+	RunID      int64
+	Sources    []SourceRow
+	Events     []EventRow
+	Report     func(ProgressEvent)
+}
+
+type ProgressEvent struct {
+	Source  string
+	Stage   string
+	Current int64
+	Total   int64
+	Message string
+}
+
+func WriteRows(ctx context.Context, q *gen.Queries, params WriteRowsParams) error {
+	sourceKind := strings.TrimSpace(params.SourceKind)
+	sourceName := strings.TrimSpace(params.SourceName)
+	if q == nil {
+		return fmt.Errorf("write discovery rows for %s/%s: queries is nil", sourceKind, sourceName)
+	}
+
+	total := len(params.Sources) + len(params.Events)
+	report(params.Report, ProgressEvent{
+		Source:  sourceKind,
+		Stage:   "write-discovery",
+		Current: 0,
+		Total:   int64(total),
+		Message: fmt.Sprintf("writing %d discovery records", total),
+	})
+
+	appMeta := map[string]AppMetadata{}
+	firstSeenByKey := map[string]time.Time{}
+	lastSeenByKey := map[string]time.Time{}
+	addMeta := func(key string, seenAt time.Time, sample AppMetadata) {
+		if key == "" {
+			return
+		}
+		if _, ok := appMeta[key]; !ok {
+			appMeta[key] = sample
+			firstSeenByKey[key] = seenAt
+			lastSeenByKey[key] = seenAt
+			return
+		}
+		if seenAt.Before(firstSeenByKey[key]) {
+			firstSeenByKey[key] = seenAt
+		}
+		if seenAt.After(lastSeenByKey[key]) {
+			lastSeenByKey[key] = seenAt
+		}
+	}
+
+	for _, source := range params.Sources {
+		meta := BuildMetadata(CanonicalInput{
+			SourceKind:       sourceKind,
+			SourceName:       sourceName,
+			SourceAppID:      source.SourceAppID,
+			SourceAppName:    source.SourceAppName,
+			SourceDomain:     source.SourceAppDomain,
+			SourceVendorName: source.SourceVendorName,
+		})
+		meta.CanonicalKey = source.CanonicalKey
+		addMeta(source.CanonicalKey, source.SeenAt, meta)
+	}
+	for _, event := range params.Events {
+		meta := BuildMetadata(CanonicalInput{
+			SourceKind:       sourceKind,
+			SourceName:       sourceName,
+			SourceAppID:      event.SourceAppID,
+			SourceAppName:    event.SourceAppName,
+			SourceDomain:     event.SourceAppDomain,
+			SourceVendorName: event.SourceVendorName,
+		})
+		meta.CanonicalKey = event.CanonicalKey
+		addMeta(event.CanonicalKey, event.ObservedAt, meta)
+	}
+
+	if len(appMeta) > 0 {
+		canonicalKeys := make([]string, 0, len(appMeta))
+		displayNames := make([]string, 0, len(appMeta))
+		primaryDomains := make([]string, 0, len(appMeta))
+		vendorNames := make([]string, 0, len(appMeta))
+		firstSeenAts := make([]pgtype.Timestamptz, 0, len(appMeta))
+		lastSeenAts := make([]pgtype.Timestamptz, 0, len(appMeta))
+		for key, meta := range appMeta {
+			firstSeenAt := firstSeenByKey[key]
+			lastSeenAt := lastSeenByKey[key]
+			canonicalKeys = append(canonicalKeys, key)
+			displayNames = append(displayNames, meta.DisplayName)
+			primaryDomains = append(primaryDomains, meta.Domain)
+			vendorNames = append(vendorNames, meta.VendorName)
+			firstSeenAts = append(firstSeenAts, pgTimestamptz(firstSeenAt))
+			lastSeenAts = append(lastSeenAts, pgTimestamptz(lastSeenAt))
+		}
+		if _, err := q.UpsertSaaSAppsBulk(ctx, gen.UpsertSaaSAppsBulkParams{
+			CanonicalKeys:  canonicalKeys,
+			DisplayNames:   displayNames,
+			PrimaryDomains: primaryDomains,
+			VendorNames:    vendorNames,
+			FirstSeenAts:   firstSeenAts,
+			LastSeenAts:    lastSeenAts,
+		}); err != nil {
+			return fmt.Errorf("upsert saas apps: %w", err)
+		}
+	}
+
+	written := 0
+	if len(params.Sources) > 0 {
+		if err := writeSourceRows(ctx, q, params, sourceKind, sourceName); err != nil {
+			return err
+		}
+		written += len(params.Sources)
+		report(params.Report, ProgressEvent{
+			Source:  sourceKind,
+			Stage:   "write-discovery",
+			Current: int64(written),
+			Total:   int64(total),
+			Message: fmt.Sprintf("sources %d/%d", written, total),
+		})
+	}
+
+	if len(params.Events) > 0 {
+		if err := writeEventRows(ctx, q, params, sourceKind, sourceName); err != nil {
+			return err
+		}
+		written += len(params.Events)
+		report(params.Report, ProgressEvent{
+			Source:  sourceKind,
+			Stage:   "write-discovery",
+			Current: int64(written),
+			Total:   int64(total),
+			Message: fmt.Sprintf("events %d/%d", written, total),
+		})
+	}
+
+	if written == 0 {
+		report(params.Report, ProgressEvent{
+			Source:  sourceKind,
+			Stage:   "write-discovery",
+			Current: 0,
+			Total:   0,
+			Message: "no discovery records to write",
+		})
+	}
+	return nil
+}
+
+func writeSourceRows(ctx context.Context, q *gen.Queries, params WriteRowsParams, sourceKind, sourceName string) error {
+	canonicalKeys := make([]string, 0, len(params.Sources))
+	sourceAppIDs := make([]string, 0, len(params.Sources))
+	sourceAppNames := make([]string, 0, len(params.Sources))
+	sourceAppDomains := make([]string, 0, len(params.Sources))
+	seenAts := make([]pgtype.Timestamptz, 0, len(params.Sources))
+	for _, source := range params.Sources {
+		canonicalKeys = append(canonicalKeys, source.CanonicalKey)
+		sourceAppIDs = append(sourceAppIDs, source.SourceAppID)
+		sourceAppNames = append(sourceAppNames, source.SourceAppName)
+		sourceAppDomains = append(sourceAppDomains, source.SourceAppDomain)
+		seenAts = append(seenAts, pgTimestamptz(source.SeenAt))
+	}
+	if _, err := q.UpsertSaaSAppSourcesBulkBySource(ctx, gen.UpsertSaaSAppSourcesBulkBySourceParams{
+		SourceKind:       sourceKind,
+		SourceName:       sourceName,
+		SeenInRunID:      params.RunID,
+		CanonicalKeys:    canonicalKeys,
+		SourceAppIds:     sourceAppIDs,
+		SourceAppNames:   sourceAppNames,
+		SourceAppDomains: sourceAppDomains,
+		SeenAts:          seenAts,
+	}); err != nil {
+		return fmt.Errorf("upsert saas app sources: %w", err)
+	}
+	return nil
+}
+
+func writeEventRows(ctx context.Context, q *gen.Queries, params WriteRowsParams, sourceKind, sourceName string) error {
+	canonicalKeys := make([]string, 0, len(params.Events))
+	signalKinds := make([]string, 0, len(params.Events))
+	eventExternalIDs := make([]string, 0, len(params.Events))
+	sourceAppIDs := make([]string, 0, len(params.Events))
+	sourceAppNames := make([]string, 0, len(params.Events))
+	sourceAppDomains := make([]string, 0, len(params.Events))
+	actorExternalIDs := make([]string, 0, len(params.Events))
+	actorEmails := make([]string, 0, len(params.Events))
+	actorDisplayNames := make([]string, 0, len(params.Events))
+	observedAts := make([]pgtype.Timestamptz, 0, len(params.Events))
+	scopesJSONs := make([][]byte, 0, len(params.Events))
+	rawJSONs := make([][]byte, 0, len(params.Events))
+	ingestedBySignal := map[string]int{}
+	for _, event := range params.Events {
+		canonicalKeys = append(canonicalKeys, event.CanonicalKey)
+		signalKinds = append(signalKinds, event.SignalKind)
+		eventExternalIDs = append(eventExternalIDs, event.EventExternalID)
+		sourceAppIDs = append(sourceAppIDs, event.SourceAppID)
+		sourceAppNames = append(sourceAppNames, event.SourceAppName)
+		sourceAppDomains = append(sourceAppDomains, event.SourceAppDomain)
+		actorExternalIDs = append(actorExternalIDs, event.ActorExternalID)
+		actorEmails = append(actorEmails, event.ActorEmail)
+		actorDisplayNames = append(actorDisplayNames, event.ActorDisplayName)
+		observedAts = append(observedAts, pgTimestamptz(event.ObservedAt))
+		scopesJSONs = append(scopesJSONs, ScopesJSON(event.Scopes))
+		rawJSONs = append(rawJSONs, normalizeJSON(event.RawJSON))
+		ingestedBySignal[event.SignalKind]++
+	}
+	if _, err := q.UpsertSaaSAppEventsBulkBySource(ctx, gen.UpsertSaaSAppEventsBulkBySourceParams{
+		SourceKind:        sourceKind,
+		SourceName:        sourceName,
+		SeenInRunID:       params.RunID,
+		CanonicalKeys:     canonicalKeys,
+		SignalKinds:       signalKinds,
+		EventExternalIds:  eventExternalIDs,
+		SourceAppIds:      sourceAppIDs,
+		SourceAppNames:    sourceAppNames,
+		SourceAppDomains:  sourceAppDomains,
+		ActorExternalIds:  actorExternalIDs,
+		ActorEmails:       actorEmails,
+		ActorDisplayNames: actorDisplayNames,
+		ObservedAts:       observedAts,
+		ScopesJsons:       scopesJSONs,
+		RawJsons:          rawJSONs,
+	}); err != nil {
+		return fmt.Errorf("upsert saas app events: %w", err)
+	}
+	for signalKind, count := range ingestedBySignal {
+		metrics.DiscoveryEventsIngestedTotal.WithLabelValues(sourceKind, signalKind).Add(float64(count))
+	}
+	return nil
+}
+
+func report(report func(ProgressEvent), event ProgressEvent) {
+	if report != nil {
+		report(event)
+	}
+}
+
+func pgTimestamptz(t time.Time) pgtype.Timestamptz {
+	if t.IsZero() {
+		return pgtype.Timestamptz{}
+	}
+	return pgtype.Timestamptz{Time: t, Valid: true}
+}
+
+func normalizeJSON(b []byte) []byte {
+	if len(b) == 0 {
+		return []byte("{}")
+	}
+	return b
+}

--- a/internal/http/handlers/command_integration_test.go
+++ b/internal/http/handlers/command_integration_test.go
@@ -3,22 +3,13 @@ package handlers
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
-	"net/url"
-	"os"
-	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/golang-migrate/migrate/v4"
-	_ "github.com/golang-migrate/migrate/v4/database/postgres"
-	_ "github.com/golang-migrate/migrate/v4/source/file"
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/open-sspm/open-sspm/internal/config"
@@ -26,6 +17,7 @@ import (
 	connregistry "github.com/open-sspm/open-sspm/internal/connectors/registry"
 	"github.com/open-sspm/open-sspm/internal/db/gen"
 	"github.com/open-sspm/open-sspm/internal/readmodels"
+	"github.com/open-sspm/open-sspm/internal/testdb"
 )
 
 const commandSearchTestConnectorSecretKey = "0123456789abcdef0123456789abcdef"
@@ -362,64 +354,16 @@ func TestHandleCommandSearchUsesLiveDiscoveryPostureBadges(t *testing.T) {
 func withCommandSearchTestDatabase(t *testing.T, fn func(context.Context, *pgxpool.Pool, *gen.Queries, *Handlers)) {
 	t.Helper()
 
-	baseURL := strings.TrimSpace(os.Getenv("OPENSSPM_TEST_DATABASE_URL"))
-	if baseURL == "" {
-		t.Skip("OPENSSPM_TEST_DATABASE_URL is not set")
-	}
+	testdb.WithDatabase(t, testdb.Options{NamePrefix: "opensspm_command_search"}, func(ctx context.Context, pool *pgxpool.Pool, migrator *migrate.Migrate) {
+		testdb.MigrateUp(t, migrator)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-
-	adminURL, err := commandSearchTestDatabaseAdminURL(baseURL)
-	if err != nil {
-		t.Fatalf("commandSearchTestDatabaseAdminURL() err = %v", err)
-	}
-
-	adminConn, err := pgx.Connect(ctx, adminURL)
-	if err != nil {
-		t.Fatalf("pgx.Connect(admin) err = %v", err)
-	}
-	defer adminConn.Close(ctx)
-
-	dbName := "opensspm_command_search_" + strings.ReplaceAll(uuid.NewString(), "-", "")
-	if _, err := adminConn.Exec(ctx, "CREATE DATABASE "+pgx.Identifier{dbName}.Sanitize()); err != nil {
-		t.Fatalf("CREATE DATABASE err = %v", err)
-	}
-	defer func() {
-		dropCtx, dropCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer dropCancel()
-		_, _ = adminConn.Exec(dropCtx, "DROP DATABASE IF EXISTS "+pgx.Identifier{dbName}.Sanitize()+" WITH (FORCE)")
-	}()
-
-	testURL, err := commandSearchTestDatabaseURLWithName(baseURL, dbName)
-	if err != nil {
-		t.Fatalf("commandSearchTestDatabaseURLWithName() err = %v", err)
-	}
-
-	migrator, err := migrate.New("file://"+commandSearchTestMigrationsDir(t), testURL)
-	if err != nil {
-		t.Fatalf("migrate.New() err = %v", err)
-	}
-	defer func() {
-		_, _ = migrator.Close()
-	}()
-
-	if err := migrator.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
-		t.Fatalf("migrate up: %v", err)
-	}
-
-	pool, err := pgxpool.New(ctx, testURL)
-	if err != nil {
-		t.Fatalf("pgxpool.New() err = %v", err)
-	}
-	defer pool.Close()
-
-	q := gen.New(pool)
-	fn(ctx, pool, q, &Handlers{
-		Cfg:      config.Config{ConnectorSecretKey: []byte(commandSearchTestConnectorSecretKey)},
-		Q:        q,
-		Pool:     pool,
-		Registry: newCommandSearchTestRegistry(t),
+		q := gen.New(pool)
+		fn(ctx, pool, q, &Handlers{
+			Cfg:      config.Config{ConnectorSecretKey: []byte(commandSearchTestConnectorSecretKey)},
+			Q:        q,
+			Pool:     pool,
+			Registry: newCommandSearchTestRegistry(t),
+		})
 	})
 }
 
@@ -826,32 +770,4 @@ func insertCommandSearchOktaApp(t *testing.T, ctx context.Context, q *gen.Querie
 	if _, err := q.PromoteOktaAppsSeenInRun(ctx, pgtype.Int8{Int64: runID, Valid: true}); err != nil {
 		t.Fatalf("PromoteOktaAppsSeenInRun %s: %v", externalID, err)
 	}
-}
-
-func commandSearchTestMigrationsDir(t *testing.T) string {
-	t.Helper()
-
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	return filepath.Join(filepath.Dir(file), "..", "..", "..", "db", "migrations")
-}
-
-func commandSearchTestDatabaseAdminURL(raw string) (string, error) {
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		return "", err
-	}
-	parsed.Path = "/postgres"
-	return parsed.String(), nil
-}
-
-func commandSearchTestDatabaseURLWithName(raw, dbName string) (string, error) {
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		return "", err
-	}
-	parsed.Path = "/" + dbName
-	return parsed.String(), nil
 }

--- a/internal/http/handlers/discovery.go
+++ b/internal/http/handlers/discovery.go
@@ -418,45 +418,37 @@ func (h *Handlers) validateDiscoveryGovernanceUpdate(ctx context.Context, summar
 }
 
 func (h *Handlers) persistDiscoveryGovernanceUpdate(ctx context.Context, appID int64, form discoveryGovernanceFormInput, identityRefs discoveryGovernanceIdentityRefs, validated discoveryGovernanceValidatedInput, principal auth.Principal) error {
-	tx, err := h.Pool.Begin(ctx)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_ = tx.Rollback(ctx)
-	}()
-	qtx := h.Q.WithTx(tx)
-
 	authUserID := pgtype.Int8{Int64: principal.UserID, Valid: principal.UserID > 0}
-	if _, err := qtx.UpsertSaaSAppReviewGovernance(ctx, gen.UpsertSaaSAppReviewGovernanceParams{
-		SaasAppID:             appID,
-		OwnerIdentityID:       identityRefs.ownerIdentityID,
-		TicketRef:             form.ticketRefInput,
-		Notes:                 form.notesInput,
-		ReviewDisposition:     form.reviewDispositionInput,
-		ReviewOwnerIdentityID: identityRefs.reviewOwnerIdentityID,
-		FollowUpDueDate:       validated.followUpDueDate,
-		ReplacementSaasAppID:  validated.replacementRef,
-		UpdatedByAuthUserID:   authUserID,
-	}); err != nil {
-		return err
-	}
+	return h.WithTx(ctx, func(qtx *gen.Queries) error {
+		if _, err := qtx.UpsertSaaSAppReviewGovernance(ctx, gen.UpsertSaaSAppReviewGovernanceParams{
+			SaasAppID:             appID,
+			OwnerIdentityID:       identityRefs.ownerIdentityID,
+			TicketRef:             form.ticketRefInput,
+			Notes:                 form.notesInput,
+			ReviewDisposition:     form.reviewDispositionInput,
+			ReviewOwnerIdentityID: identityRefs.reviewOwnerIdentityID,
+			FollowUpDueDate:       validated.followUpDueDate,
+			ReplacementSaasAppID:  validated.replacementRef,
+			UpdatedByAuthUserID:   authUserID,
+		}); err != nil {
+			return err
+		}
 
-	if err := qtx.InsertSaaSAppReviewDecision(ctx, gen.InsertSaaSAppReviewDecisionParams{
-		SaasAppID:             appID,
-		OwnerIdentityID:       identityRefs.ownerIdentityID,
-		ReviewOwnerIdentityID: identityRefs.reviewOwnerIdentityID,
-		ReviewDisposition:     form.reviewDispositionInput,
-		TicketRef:             form.ticketRefInput,
-		Notes:                 form.notesInput,
-		FollowUpDueDate:       validated.followUpDueDate,
-		ReplacementSaasAppID:  validated.replacementRef,
-		ChangedByAuthUserID:   authUserID,
-	}); err != nil {
-		return err
-	}
-
-	return tx.Commit(ctx)
+		if err := qtx.InsertSaaSAppReviewDecision(ctx, gen.InsertSaaSAppReviewDecisionParams{
+			SaasAppID:             appID,
+			OwnerIdentityID:       identityRefs.ownerIdentityID,
+			ReviewOwnerIdentityID: identityRefs.reviewOwnerIdentityID,
+			ReviewDisposition:     form.reviewDispositionInput,
+			TicketRef:             form.ticketRefInput,
+			Notes:                 form.notesInput,
+			FollowUpDueDate:       validated.followUpDueDate,
+			ReplacementSaasAppID:  validated.replacementRef,
+			ChangedByAuthUserID:   authUserID,
+		}); err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 func (h *Handlers) renderDiscoveryGovernanceSuccess(c *echo.Context, appID int64) error {

--- a/internal/http/handlers/helpers.go
+++ b/internal/http/handlers/helpers.go
@@ -1,0 +1,42 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/labstack/echo/v5"
+	"github.com/open-sspm/open-sspm/internal/db/gen"
+	"github.com/open-sspm/open-sspm/internal/http/viewmodels"
+)
+
+func destructiveAlert(title, message string) *viewmodels.AlertViewData {
+	return &viewmodels.AlertViewData{
+		Title:       title,
+		Message:     message,
+		Destructive: true,
+	}
+}
+
+func redirectWithFlash(c *echo.Context, path string, toast viewmodels.ToastViewData) error {
+	setFlashToast(c, toast)
+	return c.Redirect(http.StatusSeeOther, path)
+}
+
+func (h *Handlers) WithTx(ctx context.Context, fn func(*gen.Queries) error) error {
+	if h.Pool == nil {
+		return errors.New("database pool not configured")
+	}
+	tx, err := h.Pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	if err := fn(h.Q.WithTx(tx)); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}

--- a/internal/http/handlers/helpers.go
+++ b/internal/http/handlers/helpers.go
@@ -27,6 +27,9 @@ func (h *Handlers) WithTx(ctx context.Context, fn func(*gen.Queries) error) erro
 	if h.Pool == nil {
 		return errors.New("database pool not configured")
 	}
+	if h.Q == nil {
+		return errors.New("database queries not configured")
+	}
 	tx, err := h.Pool.Begin(ctx)
 	if err != nil {
 		return err

--- a/internal/http/handlers/settings.go
+++ b/internal/http/handlers/settings.go
@@ -217,22 +217,12 @@ func (h *Handlers) handleConnectorToggle(c *echo.Context, kind string) error {
 			return h.renderConnectorsPage(c, kind, "", alert)
 		}
 	}
-	tx, err := h.Pool.Begin(ctx)
-	if err != nil {
-		return h.RenderError(c, err)
-	}
-	defer func() {
-		_ = tx.Rollback(ctx)
-	}()
-
-	qtx := h.Q.WithTx(tx)
-	if _, err := qtx.UpdateConnectorConfigEnabled(ctx, gen.UpdateConnectorConfigEnabledParams{Kind: kind, Enabled: enabled}); err != nil {
-		return h.RenderError(c, err)
-	}
-	if err := readmodels.NewProjector(nil, qtx, readmodels.RefreshConfigFromConfig(h.Cfg)).RefreshConnectorSourceState(ctx); err != nil {
-		return h.RenderError(c, err)
-	}
-	if err := tx.Commit(ctx); err != nil {
+	if err := h.WithTx(ctx, func(qtx *gen.Queries) error {
+		if _, err := qtx.UpdateConnectorConfigEnabled(ctx, gen.UpdateConnectorConfigEnabledParams{Kind: kind, Enabled: enabled}); err != nil {
+			return err
+		}
+		return readmodels.NewProjector(nil, qtx, readmodels.RefreshConfigFromConfig(h.Cfg)).RefreshConnectorSourceState(ctx)
+	}); err != nil {
 		return h.RenderError(c, err)
 	}
 	if isHX(c) {
@@ -267,23 +257,15 @@ func (h *Handlers) handleConnectorSave(c *echo.Context, kind string) error {
 		}
 	}
 
-	tx, err := h.Pool.Begin(ctx)
-	if err != nil {
-		return h.RenderError(c, err)
-	}
-	defer func() {
-		_ = tx.Rollback(ctx)
-	}()
-	if err := configStore.SaveConnectorConfigTx(ctx, h.Q.WithTx(tx), kind, mergedConfig); err != nil {
+	if err := h.WithTx(ctx, func(qtx *gen.Queries) error {
+		if err := configStore.SaveConnectorConfigTx(ctx, qtx, kind, mergedConfig); err != nil {
+			return err
+		}
+		return readmodels.NewProjector(nil, qtx, readmodels.RefreshConfigFromConfig(h.Cfg)).RefreshConnectorSourceState(ctx)
+	}); err != nil {
 		if errors.Is(err, configstore.ErrConnectorSecretKeyRequired) {
 			return h.renderConnectorsPage(c, kind, "", connectorAlert(err))
 		}
-		return h.RenderError(c, err)
-	}
-	if err := readmodels.NewProjector(nil, h.Q.WithTx(tx), readmodels.RefreshConfigFromConfig(h.Cfg)).RefreshConnectorSourceState(ctx); err != nil {
-		return h.RenderError(c, err)
-	}
-	if err := tx.Commit(ctx); err != nil {
 		return h.RenderError(c, err)
 	}
 	return c.Redirect(http.StatusSeeOther, "/settings/connectors?saved="+kind)

--- a/internal/http/handlers/settings_users.go
+++ b/internal/http/handlers/settings_users.go
@@ -65,11 +65,7 @@ func (h *Handlers) HandleSettingsUsersCreate(c *echo.Context) error {
 		return h.renderSettingsUsersPage(c, settingsUsersPageOptions{
 			openAdd: true,
 			addForm: form,
-			alert: &viewmodels.AlertViewData{
-				Title:       "Email required",
-				Message:     "Provide an email address for the user.",
-				Destructive: true,
-			},
+			alert:   destructiveAlert("Email required", "Provide an email address for the user."),
 		})
 	}
 
@@ -79,11 +75,7 @@ func (h *Handlers) HandleSettingsUsersCreate(c *echo.Context) error {
 		return h.renderSettingsUsersPage(c, settingsUsersPageOptions{
 			openAdd: true,
 			addForm: form,
-			alert: &viewmodels.AlertViewData{
-				Title:       "Invalid group",
-				Message:     "Group must be admin or viewer.",
-				Destructive: true,
-			},
+			alert:   destructiveAlert("Invalid group", "Group must be admin or viewer."),
 		})
 	}
 
@@ -91,11 +83,7 @@ func (h *Handlers) HandleSettingsUsersCreate(c *echo.Context) error {
 		return h.renderSettingsUsersPage(c, settingsUsersPageOptions{
 			openAdd: true,
 			addForm: form,
-			alert: &viewmodels.AlertViewData{
-				Title:       "Password required",
-				Message:     "Provide a password for the user.",
-				Destructive: true,
-			},
+			alert:   destructiveAlert("Password required", "Provide a password for the user."),
 		})
 	}
 
@@ -106,11 +94,7 @@ func (h *Handlers) HandleSettingsUsersCreate(c *echo.Context) error {
 		return h.renderSettingsUsersPage(c, settingsUsersPageOptions{
 			openAdd: true,
 			addForm: form,
-			alert: &viewmodels.AlertViewData{
-				Title:       "Passwords do not match",
-				Message:     "Confirm the password to continue.",
-				Destructive: true,
-			},
+			alert:   destructiveAlert("Passwords do not match", "Confirm the password to continue."),
 		})
 	}
 
@@ -118,22 +102,14 @@ func (h *Handlers) HandleSettingsUsersCreate(c *echo.Context) error {
 		return h.renderSettingsUsersPage(c, settingsUsersPageOptions{
 			openAdd: true,
 			addForm: form,
-			alert: &viewmodels.AlertViewData{
-				Title:       "Password too short",
-				Message:     "Use at least 8 characters.",
-				Destructive: true,
-			},
+			alert:   destructiveAlert("Password too short", "Use at least 8 characters."),
 		})
 	}
 	if len(password) > 128 {
 		return h.renderSettingsUsersPage(c, settingsUsersPageOptions{
 			openAdd: true,
 			addForm: form,
-			alert: &viewmodels.AlertViewData{
-				Title:       "Password too long",
-				Message:     "Use at most 128 characters.",
-				Destructive: true,
-			},
+			alert:   destructiveAlert("Password too long", "Use at most 128 characters."),
 		})
 	}
 
@@ -153,23 +129,17 @@ func (h *Handlers) HandleSettingsUsersCreate(c *echo.Context) error {
 			return h.renderSettingsUsersPage(c, settingsUsersPageOptions{
 				openAdd: true,
 				addForm: form,
-				alert: &viewmodels.AlertViewData{
-					Title:       "User already exists",
-					Message:     "A user with that email address already exists.",
-					Destructive: true,
-				},
+				alert:   destructiveAlert("User already exists", "A user with that email address already exists."),
 			})
 		}
 		return h.RenderError(c, err)
 	}
 
-	setFlashToast(c, viewmodels.ToastViewData{
+	return redirectWithFlash(c, "/settings/users", viewmodels.ToastViewData{
 		Category:    "success",
 		Title:       "User created",
 		Description: form.Email,
 	})
-
-	return c.Redirect(http.StatusSeeOther, "/settings/users")
 }
 
 func (h *Handlers) HandleSettingsUserUpdate(c *echo.Context) error {
@@ -358,19 +328,17 @@ func (h *Handlers) HandleSettingsUserUpdate(c *echo.Context) error {
 	}
 
 	if !changeRole && !changePassword {
-		setFlashToast(c, viewmodels.ToastViewData{
+		return redirectWithFlash(c, "/settings/users", viewmodels.ToastViewData{
 			Category: "info",
 			Title:    "No changes",
 		})
-		return c.Redirect(http.StatusSeeOther, "/settings/users")
 	}
 
-	setFlashToast(c, viewmodels.ToastViewData{
+	return redirectWithFlash(c, "/settings/users", viewmodels.ToastViewData{
 		Category:    "success",
 		Title:       settingsUserUpdateSuccessTitle(changeRole, changePassword),
 		Description: strings.TrimSpace(user.Email),
 	})
-	return c.Redirect(http.StatusSeeOther, "/settings/users")
 }
 
 func settingsUserUpdateSuccessTitle(changeRole, changePassword bool) string {

--- a/internal/readmodels/projector_integration_test.go
+++ b/internal/readmodels/projector_integration_test.go
@@ -2,23 +2,16 @@ package readmodels
 
 import (
 	"context"
-	"errors"
-	"net/url"
-	"os"
-	"path/filepath"
-	"runtime"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/golang-migrate/migrate/v4"
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/open-sspm/open-sspm/internal/connectors/configstore"
 	"github.com/open-sspm/open-sspm/internal/db/gen"
+	"github.com/open-sspm/open-sspm/internal/testdb"
 )
 
 const readModelsTestConnectorSecretKey = "0123456789abcdef0123456789abcdef"
@@ -146,63 +139,15 @@ func TestProjectorRefreshConnectorSourceStateDoesNotLetDiscoveryFreshnessKeepNon
 func withReadModelsTestDatabase(t *testing.T, fn func(context.Context, *pgxpool.Pool, *gen.Queries, *migrate.Migrate)) {
 	t.Helper()
 
-	baseURL := strings.TrimSpace(os.Getenv("OPENSSPM_TEST_DATABASE_URL"))
-	if baseURL == "" {
-		t.Skip("OPENSSPM_TEST_DATABASE_URL is not set")
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-
-	adminURL, err := testDatabaseAdminURL(baseURL)
-	if err != nil {
-		t.Fatalf("testDatabaseAdminURL() err = %v", err)
-	}
-
-	adminConn, err := pgx.Connect(ctx, adminURL)
-	if err != nil {
-		t.Fatalf("pgx.Connect(admin) err = %v", err)
-	}
-	defer adminConn.Close(ctx)
-
-	dbName := "opensspm_readmodels_" + strings.ReplaceAll(uuid.NewString(), "-", "")
-	if _, err := adminConn.Exec(ctx, "CREATE DATABASE "+pgx.Identifier{dbName}.Sanitize()); err != nil {
-		t.Fatalf("CREATE DATABASE err = %v", err)
-	}
-	defer func() {
-		dropCtx, dropCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer dropCancel()
-		_, _ = adminConn.Exec(dropCtx, "DROP DATABASE IF EXISTS "+pgx.Identifier{dbName}.Sanitize()+" WITH (FORCE)")
-	}()
-
-	testURL, err := testDatabaseURLWithName(baseURL, dbName)
-	if err != nil {
-		t.Fatalf("testDatabaseURLWithName() err = %v", err)
-	}
-
-	migrator, err := migrate.New("file://"+readModelsMigrationsDir(t), testURL)
-	if err != nil {
-		t.Fatalf("migrate.New() err = %v", err)
-	}
-	defer func() {
-		_, _ = migrator.Close()
-	}()
-
-	pool, err := pgxpool.New(ctx, testURL)
-	if err != nil {
-		t.Fatalf("pgxpool.New() err = %v", err)
-	}
-	defer pool.Close()
-
-	fn(ctx, pool, gen.New(pool), migrator)
+	testdb.WithDatabase(t, testdb.Options{NamePrefix: "opensspm_readmodels"}, func(ctx context.Context, pool *pgxpool.Pool, migrator *migrate.Migrate) {
+		fn(ctx, pool, gen.New(pool), migrator)
+	})
 }
 
 func migrateUpReadModels(t *testing.T, migrator *migrate.Migrate) {
 	t.Helper()
 
-	if err := migrator.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
-		t.Fatalf("migrate up: %v", err)
-	}
+	testdb.MigrateUp(t, migrator)
 }
 
 func insertReadModelsConnectorConfig(t *testing.T, ctx context.Context, pool *pgxpool.Pool, kind string, enabled bool, cfg any) {
@@ -298,32 +243,4 @@ func fetchConnectorSourceStateTimes(t *testing.T, ctx context.Context, pool *pgx
 
 func int64String(v int64) string {
 	return strconv.FormatInt(v, 10)
-}
-
-func readModelsMigrationsDir(t *testing.T) string {
-	t.Helper()
-
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "db", "migrations"))
-}
-
-func testDatabaseAdminURL(baseURL string) (string, error) {
-	parsed, err := url.Parse(baseURL)
-	if err != nil {
-		return "", err
-	}
-	parsed.Path = "/postgres"
-	return parsed.String(), nil
-}
-
-func testDatabaseURLWithName(baseURL, dbName string) (string, error) {
-	parsed, err := url.Parse(baseURL)
-	if err != nil {
-		return "", err
-	}
-	parsed.Path = "/" + dbName
-	return parsed.String(), nil
 }

--- a/internal/sync/sync_jobs_integration_test.go
+++ b/internal/sync/sync_jobs_integration_test.go
@@ -3,21 +3,12 @@ package sync
 import (
 	"context"
 	"errors"
-	"fmt"
-	"net/url"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/golang-migrate/migrate/v4"
-	_ "github.com/golang-migrate/migrate/v4/database/postgres"
-	_ "github.com/golang-migrate/migrate/v4/source/file"
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/open-sspm/open-sspm/internal/testdb"
 )
 
 func TestSyncJobStore_ManualPromotesPendingScheduledJob(t *testing.T) {
@@ -155,90 +146,14 @@ func TestSyncJobStore_DuplicateClaimedManualJobReturnsBusyError(t *testing.T) {
 func withSyncJobsTestDB(t *testing.T, fn func(context.Context, *dbSyncJobStore)) {
 	t.Helper()
 
-	baseURL := strings.TrimSpace(os.Getenv("OPENSSPM_TEST_DATABASE_URL"))
-	if baseURL == "" {
-		t.Skip("OPENSSPM_TEST_DATABASE_URL is not set")
-	}
+	testdb.WithDatabase(t, testdb.Options{NamePrefix: "opensspm_syncjobs"}, func(ctx context.Context, pool *pgxpool.Pool, migrator *migrate.Migrate) {
+		testdb.MigrateUp(t, migrator)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
+		store, ok := NewSyncJobStore(pool).(*dbSyncJobStore)
+		if !ok || store == nil {
+			t.Fatalf("NewSyncJobStore() did not return *dbSyncJobStore")
+		}
 
-	adminURL, err := testDatabaseAdminURL(baseURL)
-	if err != nil {
-		t.Fatalf("testDatabaseAdminURL() err = %v", err)
-	}
-
-	adminConn, err := pgx.Connect(ctx, adminURL)
-	if err != nil {
-		t.Fatalf("pgx.Connect(admin) err = %v", err)
-	}
-	defer adminConn.Close(ctx)
-
-	dbName := "opensspm_syncjobs_" + strings.ReplaceAll(uuid.NewString(), "-", "")
-	if _, err := adminConn.Exec(ctx, "CREATE DATABASE "+pgx.Identifier{dbName}.Sanitize()); err != nil {
-		t.Fatalf("CREATE DATABASE err = %v", err)
-	}
-	defer func() {
-		dropCtx, dropCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer dropCancel()
-		_, _ = adminConn.Exec(dropCtx, "DROP DATABASE IF EXISTS "+pgx.Identifier{dbName}.Sanitize()+" WITH (FORCE)")
-	}()
-
-	testURL, err := testDatabaseURLWithName(baseURL, dbName)
-	if err != nil {
-		t.Fatalf("testDatabaseURLWithName() err = %v", err)
-	}
-	if err := applyTestMigrations(testURL); err != nil {
-		t.Fatalf("applyTestMigrations() err = %v", err)
-	}
-
-	pool, err := pgxpool.New(ctx, testURL)
-	if err != nil {
-		t.Fatalf("pgxpool.New() err = %v", err)
-	}
-	defer pool.Close()
-
-	store, ok := NewSyncJobStore(pool).(*dbSyncJobStore)
-	if !ok || store == nil {
-		t.Fatalf("NewSyncJobStore() did not return *dbSyncJobStore")
-	}
-
-	fn(ctx, store)
-}
-
-func testDatabaseAdminURL(raw string) (string, error) {
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		return "", err
-	}
-	parsed.Path = "/postgres"
-	return parsed.String(), nil
-}
-
-func testDatabaseURLWithName(raw, dbName string) (string, error) {
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		return "", err
-	}
-	parsed.Path = "/" + dbName
-	return parsed.String(), nil
-}
-
-func applyTestMigrations(databaseURL string) error {
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		return fmt.Errorf("runtime.Caller failed")
-	}
-	migrationsDir := filepath.Join(filepath.Dir(file), "..", "..", "db", "migrations")
-	m, err := migrate.New("file://"+migrationsDir, databaseURL)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_, _ = m.Close()
-	}()
-	if err := m.Up(); err != nil && err != migrate.ErrNoChange {
-		return err
-	}
-	return nil
+		fn(ctx, store)
+	})
 }

--- a/internal/testdb/testdb.go
+++ b/internal/testdb/testdb.go
@@ -1,0 +1,138 @@
+package testdb
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-migrate/migrate/v4"
+	_ "github.com/golang-migrate/migrate/v4/database/postgres"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type Options struct {
+	DatabaseURLVars []string
+	NamePrefix      string
+	Timeout         time.Duration
+}
+
+func WithDatabase(t *testing.T, opts Options, fn func(context.Context, *pgxpool.Pool, *migrate.Migrate)) {
+	t.Helper()
+
+	baseURL := strings.TrimSpace(databaseURLFromEnv(t, opts.DatabaseURLVars))
+	if baseURL == "" {
+		return
+	}
+
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = 2 * time.Minute
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	adminURL, err := databaseURLWithName(baseURL, "postgres")
+	if err != nil {
+		t.Fatalf("test database admin URL: %v", err)
+	}
+
+	adminConn, err := pgx.Connect(ctx, adminURL)
+	if err != nil {
+		t.Fatalf("pgx.Connect(admin) err = %v", err)
+	}
+	defer adminConn.Close(ctx)
+
+	dbName := sanitizedNamePrefix(opts.NamePrefix) + strings.ReplaceAll(uuid.NewString(), "-", "")
+	if _, err := adminConn.Exec(ctx, "CREATE DATABASE "+pgx.Identifier{dbName}.Sanitize()); err != nil {
+		t.Fatalf("CREATE DATABASE %s: %v", dbName, err)
+	}
+	defer func() {
+		dropCtx, dropCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer dropCancel()
+		_, _ = adminConn.Exec(dropCtx, "DROP DATABASE IF EXISTS "+pgx.Identifier{dbName}.Sanitize()+" WITH (FORCE)")
+	}()
+
+	testURL, err := databaseURLWithName(baseURL, dbName)
+	if err != nil {
+		t.Fatalf("test database URL: %v", err)
+	}
+
+	migrator, err := migrate.New("file://"+MigrationsDir(t), testURL)
+	if err != nil {
+		t.Fatalf("migrate.New() err = %v", err)
+	}
+	defer func() {
+		_, _ = migrator.Close()
+	}()
+
+	pool, err := pgxpool.New(ctx, testURL)
+	if err != nil {
+		t.Fatalf("pgxpool.New() err = %v", err)
+	}
+	defer pool.Close()
+
+	fn(ctx, pool, migrator)
+}
+
+func MigrateUp(t *testing.T, migrator *migrate.Migrate) {
+	t.Helper()
+
+	if err := migrator.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		t.Fatalf("migrate up: %v", err)
+	}
+}
+
+func MigrationsDir(t *testing.T) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Join(filepath.Dir(file), "..", "..", "db", "migrations")
+}
+
+func databaseURLFromEnv(t *testing.T, envVars []string) string {
+	t.Helper()
+
+	if len(envVars) == 0 {
+		envVars = []string{"OPENSSPM_TEST_DATABASE_URL"}
+	}
+	for _, envVar := range envVars {
+		if value := strings.TrimSpace(os.Getenv(envVar)); value != "" {
+			return value
+		}
+	}
+	t.Skipf("%s is not set", strings.Join(envVars, " or "))
+	return ""
+}
+
+func databaseURLWithName(raw, dbName string) (string, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	parsed.Path = "/" + dbName
+	return parsed.String(), nil
+}
+
+func sanitizedNamePrefix(prefix string) string {
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" {
+		return "opensspm_test_"
+	}
+	if !strings.HasSuffix(prefix, "_") {
+		prefix += "_"
+	}
+	return prefix
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a broad cleanup that eliminates substantial duplication across the codebase: local `normalizedDiscoverySource`/`Event` structs and their matching write loops are replaced by shared `discovery.SourceRow`/`EventRow` types and a single `discovery.WriteRows` function; per-connector DB setup boilerplate (~500 lines) is consolidated into `internal/testdb`; and inline transaction blocks throughout the HTTP handlers are replaced by a new `h.WithTx` helper. New `WriteSourceAccountRows`, `WriteEntitlementRows`, and `ReportAndFailSyncRun` helpers similarly consolidate connector-level batching and error-reporting patterns.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 style/cosmetic observations with no correctness or data-integrity impact

All remaining findings are P2: one cosmetic UX regression in progress reporting (Current always equals Total after the batching refactor) and one dead-code guard in testdb. No correctness, security, or data-integrity issues were found. The core refactoring faithfully preserves the behavior of every replaced code path, and the new WithTx helper now includes the nil guard for h.Q that was flagged in a prior review.

internal/connectors/aws/integration.go and internal/connectors/datadog/integration.go for the progress-reporting change; internal/testdb/testdb.go for the dead-code guard after t.Skipf

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/connectors/registry/bulk_rows.go | New file centralizing WriteSourceAccountRows and WriteEntitlementRows with internal batching; nil-guards q and handles empty-externalID rows correctly |
| internal/discovery/rows.go | New file consolidating WriteRows, SourceRow, EventRow, and ProgressEvent types previously duplicated across three connectors; logic is faithful to the original per-connector implementations |
| internal/http/handlers/helpers.go | New file extracting WithTx, destructiveAlert, and redirectWithFlash helpers; WithTx now properly nil-guards both Pool and Q, resolving a prior review concern |
| internal/testdb/testdb.go | New shared test-database helper eliminating ~500 lines of duplicated setup across integration tests; MigrationsDir correctly anchors to this file's source location; contains a dead-code guard after t.Skipf |
| internal/connectors/aws/integration.go | Refactored to use WriteSourceAccountRows and WriteEntitlementRows; progress reporting now shows Current==Total immediately instead of per-batch intermediate values |
| internal/connectors/datadog/integration.go | Same progress-reporting change as aws/integration.go; otherwise correct refactor to shared bulk-row helpers |
| internal/connectors/registry/helpers.go | Adds ReportAndFailSyncRun helper and extracts finalizeRunCountsInTx; both changes reduce boilerplate without altering behavior |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/http/handlers/helpers.go`, line 668-683 ([link](https://github.com/open-sspm/open-sspm/blob/b9770d42ed3fb6194bfab106a26e804515f21eed/internal/http/handlers/helpers.go#L668-L683)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Missing nil guard for `h.Q` in `WithTx`**

   `h.Pool` is guarded with a nil check, but `h.Q.WithTx(tx)` will panic at runtime if `h.Q` is ever nil. In practice `Q` is always set alongside `Pool` when constructing `Handlers`, but given that `Pool` already has a defensive check the absence of a comparable guard for `Q` is an inconsistency. If `Q` is nil for any reason (e.g. partial initialisation in tests or future refactors), the panic will surface as an unrecoverable 500 rather than a clean error.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/http/handlers/helpers.go
   Line: 668-683

   Comment:
   **Missing nil guard for `h.Q` in `WithTx`**

   `h.Pool` is guarded with a nil check, but `h.Q.WithTx(tx)` will panic at runtime if `h.Q` is ever nil. In practice `Q` is always set alongside `Pool` when constructing `Handlers`, but given that `Pool` already has a defensive check the absence of a comparable guard for `Q` is an inconsistency. If `Q` is nil for any reason (e.g. partial initialisation in tests or future refactors), the panic will surface as an unrecoverable 500 rather than a clean error.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/connectors/aws/integration.go
Line: 131-141

Comment:
**Progress reporting always shows 100% completion**

The old batching loop emitted one progress event per batch (e.g. `principals 500/1000`, then `1000/1000`), giving real-time feedback for large syncs. The new single-shot report always sets `Current == Total`, so the UI jumps straight to 100% regardless of how many batches `WriteSourceAccountRows` processes internally. The same pattern appears in `datadog/integration.go`. If a sync writes 50 000 accounts across 50 batches, the UI will show no progress until all batches finish and then show 100% at once.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/testdb/testdb.go
Line: 3225-3228

Comment:
**Dead code after `t.Skipf`**

`t.Skipf` calls `runtime.Goexit()`, so the `return ""` on the next line is unreachable. The `if baseURL == ""` check back in `WithDatabase` is therefore also dead code — the function can only return a non-empty string or never return at all. This is harmless today but may confuse future readers into thinking there is a valid empty-string code path that requires the early-return guard.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Guard Handlers WithTx against nil querie..."](https://github.com/open-sspm/open-sspm/commit/47bd6f7e6195647e67520a83290cb032eb826c4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29633527)</sub>

<!-- /greptile_comment -->