### PR TITLE
feat: move rules to yaml, m1 

### DIFF
--- a/cmd/open-sspm/root.go
+++ b/cmd/open-sspm/root.go
@@ -9,14 +9,15 @@ import (
 )
 
 var structuredLoggingCommandNames = map[string]struct{}{
-	"serve":            {},
-	"worker":           {},
-	"worker-discovery": {},
-	"sync":             {},
-	"sync-discovery":   {},
-	"migrate":          {},
-	"seed-rules":       {},
-	"validate-rules":   {},
+	"serve":                  {},
+	"worker":                 {},
+	"worker-discovery":       {},
+	"sync":                   {},
+	"sync-discovery":         {},
+	"migrate":                {},
+	"seed-rules":             {},
+	"validate-rules":         {},
+	"validate-risk-policies": {},
 }
 
 type commandExecutionContext struct {
@@ -106,6 +107,7 @@ func init() {
 		migrateCmd,
 		seedRulesCmd,
 		validateRulesCmd,
+		validateRiskPoliciesCmd,
 		specVersionCmd,
 		usersCmd,
 	)

--- a/cmd/open-sspm/validate_risk_policies.go
+++ b/cmd/open-sspm/validate_risk_policies.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/open-sspm/open-sspm/internal/riskpolicy"
+	"github.com/spf13/cobra"
+)
+
+var validateRiskPoliciesCmd = &cobra.Command{
+	Use:   "validate-risk-policies",
+	Short: "Validate embedded risk policy packs without touching the DB.",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		registry, err := riskpolicy.LoadBuiltin()
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("validated %d risk policy packs (%d CEL expressions)\n", registry.PackCount(), registry.CompiledExpressionCount())
+		return nil
+	},
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/identitystore v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.36.13
 	github.com/golang-migrate/migrate/v4 v4.19.1
+	github.com/google/cel-go v0.20.1
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/vault/api v1.22.0
 	github.com/jackc/pgx/v5 v5.9.2
@@ -33,6 +34,7 @@ require (
 	golang.org/x/oauth2 v0.34.0
 	golang.org/x/sync v0.19.0
 	golang.org/x/term v0.39.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -63,7 +65,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
-	github.com/google/cel-go v0.20.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
@@ -117,5 +118,4 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20250818200422-3122310a409c // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250818200422-3122310a409c // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/riskpolicy/cel.go
+++ b/internal/riskpolicy/cel.go
@@ -30,6 +30,9 @@ func compilePack(name string, pack PolicyPack) (CompiledPack, error) {
 		if issues != nil && issues.Err() != nil {
 			return fmt.Errorf("%s: %s: compile %q: %w", name, ruleID, expression, issues.Err())
 		}
+		if !ast.OutputType().IsExactType(cel.BoolType) {
+			return fmt.Errorf("%s: %s: compile %q: expression must return bool, got %s", name, ruleID, expression, ast.OutputType())
+		}
 		compiled.expressions = append(compiled.expressions, CompiledExpression{
 			RuleID:     ruleID,
 			Expression: expression,

--- a/internal/riskpolicy/cel.go
+++ b/internal/riskpolicy/cel.go
@@ -1,0 +1,166 @@
+package riskpolicy
+
+import (
+	"fmt"
+
+	"github.com/google/cel-go/cel"
+)
+
+type CompiledExpression struct {
+	RuleID     string
+	Expression string
+	ast        *cel.Ast
+}
+
+func compilePack(name string, pack PolicyPack) (CompiledPack, error) {
+	if err := validatePolicyPack(name, pack); err != nil {
+		return CompiledPack{}, err
+	}
+	env, err := newEnv(pack)
+	if err != nil {
+		return CompiledPack{}, fmt.Errorf("%s: create CEL env: %w", name, err)
+	}
+
+	compiled := CompiledPack{
+		Policy:      pack,
+		expressions: make([]CompiledExpression, 0, expressionCount(pack)),
+	}
+	compile := func(ruleID, expression string) error {
+		ast, issues := env.Compile(expression)
+		if issues != nil && issues.Err() != nil {
+			return fmt.Errorf("%s: %s: compile %q: %w", name, ruleID, expression, issues.Err())
+		}
+		compiled.expressions = append(compiled.expressions, CompiledExpression{
+			RuleID:     ruleID,
+			Expression: expression,
+			ast:        ast,
+		})
+		return nil
+	}
+
+	for _, rule := range pack.Spec.Suggestions.BusinessCriticality {
+		if err := compile(rule.ID, rule.When); err != nil {
+			return CompiledPack{}, err
+		}
+	}
+	for _, rule := range pack.Spec.Suggestions.DataClassification {
+		if err := compile(rule.ID, rule.When); err != nil {
+			return CompiledPack{}, err
+		}
+	}
+	for _, rule := range pack.Spec.Scoring.Rules {
+		if err := compile(rule.ID, rule.When); err != nil {
+			return CompiledPack{}, err
+		}
+	}
+	for _, rule := range pack.Spec.Levels {
+		if err := compile("level:"+rule.Level, rule.When); err != nil {
+			return CompiledPack{}, err
+		}
+	}
+	for _, rule := range pack.Spec.Rules {
+		if err := compile(rule.ID, rule.When); err != nil {
+			return CompiledPack{}, err
+		}
+	}
+	for _, scopedRule := range pack.Spec.ScopedRules {
+		for _, rule := range scopedRule.Rules {
+			if err := compile(scopedRule.ID+"/"+rule.ID, rule.When); err != nil {
+				return CompiledPack{}, err
+			}
+		}
+	}
+	return compiled, nil
+}
+
+func newEnv(pack PolicyPack) (*cel.Env, error) {
+	opts := domainEnvOptions(pack.Metadata.Domain)
+	for name := range pack.Spec.Constants {
+		opts = append(opts, cel.Variable(name, cel.ListType(cel.StringType)))
+	}
+	return cel.NewEnv(opts...)
+}
+
+func domainEnvOptions(domain Domain) []cel.EnvOption {
+	switch domain {
+	case DomainCredential:
+		return []cel.EnvOption{
+			cel.Variable("source_kind", cel.StringType),
+			cel.Variable("source_name", cel.StringType),
+			cel.Variable("credential_kind", cel.StringType),
+			cel.Variable("status", cel.StringType),
+			cel.Variable("expires_at", cel.NullableType(cel.TimestampType)),
+			cel.Variable("last_used_at", cel.NullableType(cel.TimestampType)),
+			cel.Variable("created_at", cel.NullableType(cel.TimestampType)),
+			cel.Variable("created_by_external_id", cel.StringType),
+			cel.Variable("created_by_display_name", cel.StringType),
+			cel.Variable("approved_by_external_id", cel.StringType),
+			cel.Variable("approved_by_display_name", cel.StringType),
+			cel.Variable("asset_ref_kind", cel.StringType),
+			cel.Variable("asset_ref_external_id", cel.StringType),
+			cel.Variable("scope_json", cel.DynType),
+			cel.Variable("evaluated_at", cel.TimestampType),
+		}
+	case DomainSaaS:
+		return []cel.EnvOption{
+			cel.Variable("canonical_key", cel.StringType),
+			cel.Variable("display_name", cel.StringType),
+			cel.Variable("primary_domain", cel.StringType),
+			cel.Variable("vendor_name", cel.StringType),
+			cel.Variable("source_kind", cel.StringType),
+			cel.Variable("source_name", cel.StringType),
+			cel.Variable("actors_30d", cel.IntType),
+			cel.Variable("has_privileged_scope", cel.BoolType),
+			cel.Variable("has_confidential_scope", cel.BoolType),
+			cel.Variable("managed_state", cel.StringType),
+			cel.Variable("managed_reason", cel.StringType),
+			cel.Variable("owner_identity_id", cel.IntType),
+			cel.Variable("governance_state", cel.StringType),
+			cel.Variable("review_disposition", cel.StringType),
+			cel.Variable("follow_up_due_date", cel.NullableType(cel.TimestampType)),
+			cel.Variable("effective_business_criticality", cel.StringType),
+			cel.Variable("effective_data_classification", cel.StringType),
+			cel.Variable("connector_binding_configured", cel.BoolType),
+			cel.Variable("connector_binding_enabled", cel.BoolType),
+			cel.Variable("connector_binding_stale", cel.BoolType),
+			cel.Variable("connector_binding_healthy", cel.BoolType),
+			cel.Variable("score", cel.IntType),
+		}
+	case DomainIdentity:
+		return []cel.EnvOption{
+			cel.Variable("identity_id", cel.IntType),
+			cel.Variable("principal_ref", cel.StringType),
+			cel.Variable("principal_type", cel.StringType),
+			cel.Variable("source_kind", cel.StringType),
+			cel.Variable("source_name", cel.StringType),
+			cel.Variable("display_name", cel.StringType),
+			cel.Variable("primary_email", cel.StringType),
+			cel.Variable("last_seen_at", cel.NullableType(cel.TimestampType)),
+			cel.Variable("owner_presence", cel.StringType),
+			cel.Variable("governance_state", cel.StringType),
+			cel.Variable("linked_assets_count", cel.IntType),
+			cel.Variable("linked_credentials_count", cel.IntType),
+			cel.Variable("credential_signals", cel.ListType(cel.StringType)),
+			cel.Variable("has_critical_credential", cel.BoolType),
+			cel.Variable("has_high_risk_credential", cel.BoolType),
+			cel.Variable("has_expired_credential", cel.BoolType),
+			cel.Variable("has_expiring_credential", cel.BoolType),
+			cel.Variable("has_unused_credential", cel.BoolType),
+			cel.Variable("has_stale_evidence", cel.BoolType),
+		}
+	default:
+		return nil
+	}
+}
+
+func expressionCount(pack PolicyPack) int {
+	count := len(pack.Spec.Suggestions.BusinessCriticality) +
+		len(pack.Spec.Suggestions.DataClassification) +
+		len(pack.Spec.Scoring.Rules) +
+		len(pack.Spec.Levels) +
+		len(pack.Spec.Rules)
+	for _, scopedRule := range pack.Spec.ScopedRules {
+		count += len(scopedRule.Rules)
+	}
+	return count
+}

--- a/internal/riskpolicy/loader.go
+++ b/internal/riskpolicy/loader.go
@@ -1,0 +1,217 @@
+package riskpolicy
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"io"
+	"io/fs"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed policies/*.yaml
+var builtinPolicyFS embed.FS
+
+type Registry struct {
+	packs []CompiledPack
+}
+
+type CompiledPack struct {
+	Policy      PolicyPack
+	expressions []CompiledExpression
+}
+
+func LoadBuiltin() (*Registry, error) {
+	names, err := fs.Glob(builtinPolicyFS, "policies/*.yaml")
+	if err != nil {
+		return nil, err
+	}
+	docs := make(map[string][]byte, len(names))
+	for _, name := range names {
+		data, err := builtinPolicyFS.ReadFile(name)
+		if err != nil {
+			return nil, err
+		}
+		docs[name] = data
+	}
+	return LoadDocuments(docs)
+}
+
+func LoadDocuments(docs map[string][]byte) (*Registry, error) {
+	names := make([]string, 0, len(docs))
+	for name := range docs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	registry := &Registry{
+		packs: make([]CompiledPack, 0, len(names)),
+	}
+	seenPackIDs := make(map[string]string, len(names))
+	for _, name := range names {
+		pack, err := decodePolicyPack(name, docs[name])
+		if err != nil {
+			return nil, err
+		}
+		if previous := seenPackIDs[pack.Metadata.ID]; previous != "" {
+			return nil, fmt.Errorf("%s: duplicate policy pack id %q also defined in %s", name, pack.Metadata.ID, previous)
+		}
+		seenPackIDs[pack.Metadata.ID] = name
+
+		compiled, err := compilePack(name, pack)
+		if err != nil {
+			return nil, err
+		}
+		registry.packs = append(registry.packs, compiled)
+	}
+	return registry, nil
+}
+
+func (r *Registry) Packs() []PolicyPack {
+	if r == nil {
+		return nil
+	}
+	packs := make([]PolicyPack, 0, len(r.packs))
+	for _, pack := range r.packs {
+		packs = append(packs, clonePolicyPack(pack.Policy))
+	}
+	return packs
+}
+
+func (r *Registry) PackCount() int {
+	if r == nil {
+		return 0
+	}
+	return len(r.packs)
+}
+
+func (r *Registry) CompiledExpressionCount() int {
+	if r == nil {
+		return 0
+	}
+	var count int
+	for _, pack := range r.packs {
+		count += len(pack.expressions)
+	}
+	return count
+}
+
+func decodePolicyPack(name string, data []byte) (PolicyPack, error) {
+	var pack PolicyPack
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&pack); err != nil {
+		return PolicyPack{}, fmt.Errorf("%s: decode policy: %w", name, err)
+	}
+	var trailing any
+	if err := dec.Decode(&trailing); err != nil && err != io.EOF {
+		return PolicyPack{}, fmt.Errorf("%s: decode policy trailing document: %w", name, err)
+	} else if err == nil {
+		return PolicyPack{}, fmt.Errorf("%s: multiple YAML documents are not supported", name)
+	}
+	normalizePolicyPack(&pack)
+	return pack, nil
+}
+
+func clonePolicyPack(pack PolicyPack) PolicyPack {
+	cloned := pack
+	cloned.Spec.Constants = make(map[string][]string, len(pack.Spec.Constants))
+	for key, values := range pack.Spec.Constants {
+		cloned.Spec.Constants[key] = cloneSlice(values)
+	}
+	cloned.Spec.Suggestions.BusinessCriticality = cloneSlice(pack.Spec.Suggestions.BusinessCriticality)
+	cloned.Spec.Suggestions.DataClassification = cloneSlice(pack.Spec.Suggestions.DataClassification)
+	cloned.Spec.Scoring.Rules = cloneSlice(pack.Spec.Scoring.Rules)
+	cloned.Spec.Levels = cloneSlice(pack.Spec.Levels)
+	cloned.Spec.Rules = cloneSlice(pack.Spec.Rules)
+	cloned.Spec.ScopedRules = cloneSlice(pack.Spec.ScopedRules)
+	for i := range cloned.Spec.ScopedRules {
+		cloned.Spec.ScopedRules[i].Scope.App.DomainMatches = cloneSlice(pack.Spec.ScopedRules[i].Scope.App.DomainMatches)
+		cloned.Spec.ScopedRules[i].Rules = cloneSlice(pack.Spec.ScopedRules[i].Rules)
+	}
+	return cloned
+}
+
+func cloneSlice[T any](values []T) []T {
+	if values == nil {
+		return nil
+	}
+	return append([]T(nil), values...)
+}
+
+func normalizePolicyPack(pack *PolicyPack) {
+	pack.APIVersion = strings.TrimSpace(pack.APIVersion)
+	pack.Kind = strings.TrimSpace(pack.Kind)
+	pack.Metadata.ID = strings.TrimSpace(pack.Metadata.ID)
+	pack.Metadata.Version = strings.TrimSpace(pack.Metadata.Version)
+	pack.Metadata.Domain = Domain(strings.ToLower(strings.TrimSpace(string(pack.Metadata.Domain))))
+	pack.Spec.Inputs.Schema = strings.TrimSpace(pack.Spec.Inputs.Schema)
+	for i := range pack.Spec.Rules {
+		normalizeRule(&pack.Spec.Rules[i])
+	}
+	for i := range pack.Spec.Scoring.Rules {
+		pack.Spec.Scoring.Rules[i].ID = strings.TrimSpace(pack.Spec.Scoring.Rules[i].ID)
+		pack.Spec.Scoring.Rules[i].When = strings.TrimSpace(pack.Spec.Scoring.Rules[i].When)
+		pack.Spec.Scoring.Rules[i].Signal.Severity = NormalizeSeverity(pack.Spec.Scoring.Rules[i].Signal.Severity)
+		pack.Spec.Scoring.Rules[i].Signal.Title = strings.TrimSpace(pack.Spec.Scoring.Rules[i].Signal.Title)
+		pack.Spec.Scoring.Rules[i].Signal.Evidence = strings.TrimSpace(pack.Spec.Scoring.Rules[i].Signal.Evidence)
+	}
+	for i := range pack.Spec.Levels {
+		pack.Spec.Levels[i].Level = NormalizeSeverity(pack.Spec.Levels[i].Level)
+		pack.Spec.Levels[i].When = strings.TrimSpace(pack.Spec.Levels[i].When)
+	}
+	normalizeSuggestions(&pack.Spec.Suggestions)
+	normalizeAggregation(&pack.Spec.Aggregation)
+	for i := range pack.Spec.ScopedRules {
+		pack.Spec.ScopedRules[i].ID = strings.TrimSpace(pack.Spec.ScopedRules[i].ID)
+		normalizeAppScope(&pack.Spec.ScopedRules[i].Scope.App)
+		pack.Spec.ScopedRules[i].Suggestions.BusinessCriticality = strings.ToLower(strings.TrimSpace(pack.Spec.ScopedRules[i].Suggestions.BusinessCriticality))
+		pack.Spec.ScopedRules[i].Suggestions.DataClassification = strings.ToLower(strings.TrimSpace(pack.Spec.ScopedRules[i].Suggestions.DataClassification))
+		for j := range pack.Spec.ScopedRules[i].Rules {
+			normalizeRule(&pack.Spec.ScopedRules[i].Rules[j])
+		}
+	}
+}
+
+func normalizeRule(rule *Rule) {
+	rule.ID = strings.TrimSpace(rule.ID)
+	rule.Severity = NormalizeSeverity(rule.Severity)
+	rule.When = strings.TrimSpace(rule.When)
+	rule.Title = strings.TrimSpace(rule.Title)
+	rule.Evidence = strings.TrimSpace(rule.Evidence)
+}
+
+func normalizeSuggestions(suggestions *Suggestions) {
+	for i := range suggestions.BusinessCriticality {
+		suggestions.BusinessCriticality[i].ID = strings.TrimSpace(suggestions.BusinessCriticality[i].ID)
+		suggestions.BusinessCriticality[i].Level = strings.ToLower(strings.TrimSpace(suggestions.BusinessCriticality[i].Level))
+		suggestions.BusinessCriticality[i].When = strings.TrimSpace(suggestions.BusinessCriticality[i].When)
+	}
+	for i := range suggestions.DataClassification {
+		suggestions.DataClassification[i].ID = strings.TrimSpace(suggestions.DataClassification[i].ID)
+		suggestions.DataClassification[i].Level = strings.ToLower(strings.TrimSpace(suggestions.DataClassification[i].Level))
+		suggestions.DataClassification[i].When = strings.TrimSpace(suggestions.DataClassification[i].When)
+	}
+}
+
+func normalizeAggregation(aggregation *Aggregation) {
+	aggregation.RiskLevel.Strategy = strings.ToLower(strings.TrimSpace(aggregation.RiskLevel.Strategy))
+	aggregation.RiskLevel.Default = NormalizeSeverity(aggregation.RiskLevel.Default)
+	aggregation.RiskReasonCount.Strategy = strings.ToLower(strings.TrimSpace(aggregation.RiskReasonCount.Strategy))
+	aggregation.RiskReasonCount.Default = strings.TrimSpace(aggregation.RiskReasonCount.Default)
+}
+
+func normalizeAppScope(scope *AppScope) {
+	scope.CanonicalKey = strings.ToLower(strings.TrimSpace(scope.CanonicalKey))
+	scope.PrimaryDomain = strings.ToLower(strings.TrimSpace(scope.PrimaryDomain))
+	scope.VendorName = strings.TrimSpace(scope.VendorName)
+	scope.SourceKind = strings.ToLower(strings.TrimSpace(scope.SourceKind))
+	scope.SourceName = strings.TrimSpace(scope.SourceName)
+	scope.Category = strings.ToLower(strings.TrimSpace(scope.Category))
+	for i := range scope.DomainMatches {
+		scope.DomainMatches[i] = strings.ToLower(strings.TrimSpace(scope.DomainMatches[i]))
+	}
+}

--- a/internal/riskpolicy/policies/credential.v1.yaml
+++ b/internal/riskpolicy/policies/credential.v1.yaml
@@ -1,0 +1,60 @@
+api_version: risk.open-sspm.io/v1
+kind: RiskPolicyPack
+metadata:
+  id: builtin-credential-risk
+  version: 1.0.0
+  domain: credential
+spec:
+  inputs:
+    schema: credential_risk_input.v1
+  constants:
+    active_like_statuses:
+      - ""
+      - active
+      - approved
+      - pending_approval
+    high_privilege_credential_kinds:
+      - entra_client_secret
+      - github_deploy_key
+      - github_pat_request
+      - github_pat_fine_grained
+  rules:
+    - id: expired_active
+      severity: critical
+      when: expires_at != null && expires_at < evaluated_at && status in active_like_statuses
+      title: Credential has expired while still marked active
+      evidence: Expired credential remains active-like at source.
+    - id: expired_inactive
+      severity: high
+      when: expires_at != null && expires_at < evaluated_at && !(status in active_like_statuses)
+      title: Credential has expired
+      evidence: Expired credential is still present in inventory.
+    - id: high_privilege_missing_provenance
+      severity: critical
+      when: credential_kind in high_privilege_credential_kinds && created_by_external_id == "" && approved_by_external_id == ""
+      title: High-privilege credential has no creator or approver
+      evidence: No provenance recorded at source.
+    - id: expiring_within_7_days
+      severity: high
+      when: expires_at != null && expires_at >= evaluated_at && expires_at <= evaluated_at + duration("168h")
+      title: Credential expires within 7 days
+      evidence: Credential is near expiration.
+    - id: missing_creator
+      severity: high
+      when: created_by_external_id == ""
+      title: Creator attribution is missing
+      evidence: No creator recorded at source.
+    - id: unused_over_90_days
+      severity: high
+      when: last_used_at != null && last_used_at <= evaluated_at - duration("2160h")
+      title: Credential has not been used in over 90 days
+      evidence: Last-used evidence is stale.
+    - id: expiring_within_30_days
+      severity: medium
+      when: expires_at != null && expires_at > evaluated_at + duration("168h") && expires_at <= evaluated_at + duration("720h")
+      title: Credential expires within 30 days
+      evidence: Credential should be rotated soon.
+  aggregation:
+    risk_level:
+      strategy: max_severity
+      default: low

--- a/internal/riskpolicy/policies/identity.v1.yaml
+++ b/internal/riskpolicy/policies/identity.v1.yaml
@@ -1,0 +1,40 @@
+api_version: risk.open-sspm.io/v1
+kind: RiskPolicyPack
+metadata:
+  id: builtin-identity-risk
+  version: 1.0.0
+  domain: identity
+spec:
+  inputs:
+    schema: identity_risk_input.v1
+  rules:
+    - id: linked_critical_credential
+      severity: critical
+      when: has_critical_credential
+      title: Linked credential is critical
+    - id: missing_accountable_owner
+      severity: high
+      when: owner_presence == "unknown"
+      title: No accountable owner
+    - id: linked_high_risk_credential
+      severity: high
+      when: has_high_risk_credential
+      title: Linked credential is high risk
+    - id: linked_expired_credential
+      severity: high
+      when: has_expired_credential
+      title: Linked credential is expired
+    - id: unreviewed_risky_principal
+      severity: high
+      when: governance_state != "reviewed" && (has_high_risk_credential || has_expired_credential || has_stale_evidence)
+      title: Unreviewed principal has risky evidence
+    - id: stale_or_unused_evidence
+      severity: medium
+      when: has_expiring_credential || has_unused_credential || has_stale_evidence
+      title: Principal has stale or aging evidence
+  aggregation:
+    risk_level:
+      strategy: max_severity
+      default: low
+    risk_reason_count:
+      strategy: count_matching_rules

--- a/internal/riskpolicy/policies/saas.v1.yaml
+++ b/internal/riskpolicy/policies/saas.v1.yaml
@@ -1,0 +1,89 @@
+api_version: risk.open-sspm.io/v1
+kind: RiskPolicyPack
+metadata:
+  id: builtin-saas-risk
+  version: 1.0.0
+  domain: saas
+spec:
+  inputs:
+    schema: saas_app_risk_input.v1
+  constants:
+    high_business_criticalities:
+      - high
+      - critical
+    sensitive_data_classifications:
+      - confidential
+      - restricted
+  suggestions:
+    business_criticality:
+      - id: high_usage_critical
+        level: critical
+        when: actors_30d >= 200
+      - id: high_usage_or_privileged
+        level: high
+        when: actors_30d >= 50 || has_privileged_scope
+      - id: moderate_usage
+        level: medium
+        when: actors_30d >= 10
+      - id: default_business_low
+        level: low
+        when: "true"
+    data_classification:
+      - id: privileged_scopes_restricted
+        level: restricted
+        when: has_privileged_scope
+      - id: confidential_scopes_confidential
+        level: confidential
+        when: has_confidential_scope
+      - id: default_data_internal
+        level: internal
+        when: "true"
+  scoring:
+    base: 0
+    max: 100
+    rules:
+      - id: unmanaged_app
+        points: 45
+        when: managed_state != "managed"
+        signal:
+          severity: high
+          title: App is not managed by a fresh connector binding
+      - id: privileged_scopes
+        points: 20
+        when: has_privileged_scope
+        signal:
+          severity: high
+          title: App has privileged OAuth scopes
+      - id: missing_owner
+        points: 15
+        when: owner_identity_id == 0
+        signal:
+          severity: high
+          title: App has no accountable owner
+      - id: high_actor_count
+        points: 20
+        when: actors_30d >= 50
+        signal:
+          severity: medium
+          title: App has broad recent usage
+      - id: unmanaged_high_business_app
+        points: 15
+        when: managed_state != "managed" && effective_business_criticality in high_business_criticalities
+        signal:
+          severity: high
+          title: Unmanaged app appears business critical
+      - id: unmanaged_sensitive_data_app
+        points: 15
+        when: managed_state != "managed" && effective_data_classification in sensitive_data_classifications
+        signal:
+          severity: high
+          title: Unmanaged app may access sensitive data
+  levels:
+    - level: critical
+      when: score >= 80
+    - level: high
+      when: score >= 60
+    - level: medium
+      when: score >= 30
+    - level: low
+      when: "true"

--- a/internal/riskpolicy/policies/saas_apps.v1.yaml
+++ b/internal/riskpolicy/policies/saas_apps.v1.yaml
@@ -1,0 +1,39 @@
+api_version: risk.open-sspm.io/v1
+kind: RiskPolicyPack
+metadata:
+  id: builtin-saas-app-overrides
+  version: 1.0.0
+  domain: saas
+spec:
+  scoped_rules:
+    - id: github_app_policy
+      scope:
+        app:
+          canonical_key: github
+      suggestions:
+        business_criticality: high
+      rules:
+        - id: github_missing_owner
+          severity: critical
+          score_delta: 20
+          when: owner_identity_id == 0
+          title: GitHub app has no accountable owner
+    - id: source_control_app_policy
+      scope:
+        app:
+          category: source_control
+      suggestions:
+        business_criticality: high
+      rules:
+        - id: source_control_missing_owner
+          severity: high
+          score_delta: 15
+          when: owner_identity_id == 0
+          title: Source control app has no accountable owner
+    - id: finance_app_policy
+      scope:
+        app:
+          category: finance
+      suggestions:
+        business_criticality: high
+        data_classification: restricted

--- a/internal/riskpolicy/policy_test.go
+++ b/internal/riskpolicy/policy_test.go
@@ -118,6 +118,93 @@ spec:
 	}
 }
 
+func TestLoadDocumentsRejectsNonBooleanCEL(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadDocuments(map[string][]byte{
+		"bad.yaml": []byte(`
+api_version: risk.open-sspm.io/v1
+kind: RiskPolicyPack
+metadata:
+  id: bad
+  version: 1.0.0
+  domain: saas
+spec:
+  inputs:
+    schema: saas_app_risk_input.v1
+  suggestions:
+    business_criticality:
+      - id: non_bool
+        level: high
+        when: actors_30d
+`),
+	})
+	if err == nil {
+		t.Fatal("LoadDocuments() error = nil, want non-boolean CEL error")
+	}
+	if !strings.Contains(err.Error(), "must return bool") {
+		t.Fatalf("LoadDocuments() error = %v, want bool type error", err)
+	}
+}
+
+func TestLoadDocumentsRejectsInvalidSuggestionLevels(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadDocuments(map[string][]byte{
+		"bad.yaml": []byte(`
+api_version: risk.open-sspm.io/v1
+kind: RiskPolicyPack
+metadata:
+  id: bad
+  version: 1.0.0
+  domain: saas
+spec:
+  inputs:
+    schema: saas_app_risk_input.v1
+  suggestions:
+    business_criticality:
+      - id: invalid_business_criticality
+        level: severe
+        when: "true"
+`),
+	})
+	if err == nil {
+		t.Fatal("LoadDocuments() error = nil, want invalid suggestion level error")
+	}
+	if !strings.Contains(err.Error(), "severe") {
+		t.Fatalf("LoadDocuments() error = %v, want invalid level in error", err)
+	}
+}
+
+func TestLoadDocumentsRejectsInvalidScopedSuggestionLevels(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadDocuments(map[string][]byte{
+		"bad.yaml": []byte(`
+api_version: risk.open-sspm.io/v1
+kind: RiskPolicyPack
+metadata:
+  id: bad
+  version: 1.0.0
+  domain: saas
+spec:
+  scoped_rules:
+    - id: invalid_scoped_suggestion
+      scope:
+        app:
+          canonical_key: github
+      suggestions:
+        data_classification: restriced
+`),
+	})
+	if err == nil {
+		t.Fatal("LoadDocuments() error = nil, want invalid scoped suggestion level error")
+	}
+	if !strings.Contains(err.Error(), "restriced") {
+		t.Fatalf("LoadDocuments() error = %v, want invalid scoped suggestion in error", err)
+	}
+}
+
 func TestSeverityOrdering(t *testing.T) {
 	t.Parallel()
 

--- a/internal/riskpolicy/policy_test.go
+++ b/internal/riskpolicy/policy_test.go
@@ -205,11 +205,58 @@ spec:
 	}
 }
 
+func TestLoadDocumentsAllowsScopedRulesToReuseInnerRuleIDs(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadDocuments(map[string][]byte{
+		"ok.yaml": []byte(`
+api_version: risk.open-sspm.io/v1
+kind: RiskPolicyPack
+metadata:
+  id: ok
+  version: 1.0.0
+  domain: saas
+spec:
+  scoped_rules:
+    - id: github_policy
+      scope:
+        app:
+          canonical_key: github
+      rules:
+        - id: missing_owner
+          severity: high
+          when: owner_identity_id == 0
+          title: GitHub app has no accountable owner
+    - id: finance_policy
+      scope:
+        app:
+          category: finance
+      rules:
+        - id: missing_owner
+          severity: high
+          when: owner_identity_id == 0
+          title: Finance app has no accountable owner
+`),
+	})
+	if err != nil {
+		t.Fatalf("LoadDocuments() error = %v, want nil", err)
+	}
+}
+
 func TestSeverityOrdering(t *testing.T) {
 	t.Parallel()
 
 	if got := MaxSeverity("low", "critical", "medium"); got != "critical" {
 		t.Fatalf("MaxSeverity() = %q, want critical", got)
+	}
+	if got := MaxSeverity(); got != "" {
+		t.Fatalf("MaxSeverity() = %q, want empty", got)
+	}
+	if got := MaxSeverity("urgent", ""); got != "" {
+		t.Fatalf("MaxSeverity(invalid) = %q, want empty", got)
+	}
+	if got := MaxSeverity("low"); got != "low" {
+		t.Fatalf("MaxSeverity(low) = %q, want low", got)
 	}
 	if ValidSeverity("urgent") {
 		t.Fatal("ValidSeverity(\"urgent\") = true, want false")

--- a/internal/riskpolicy/policy_test.go
+++ b/internal/riskpolicy/policy_test.go
@@ -1,0 +1,133 @@
+package riskpolicy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadBuiltinPolicies(t *testing.T) {
+	t.Parallel()
+
+	registry, err := LoadBuiltin()
+	if err != nil {
+		t.Fatalf("LoadBuiltin() error = %v", err)
+	}
+	if got, want := registry.PackCount(), 4; got != want {
+		t.Fatalf("PackCount() = %d, want %d", got, want)
+	}
+	if got := registry.CompiledExpressionCount(); got == 0 {
+		t.Fatal("CompiledExpressionCount() = 0, want compiled expressions")
+	}
+
+	byID := make(map[string]PolicyPack)
+	for _, pack := range registry.Packs() {
+		byID[pack.Metadata.ID] = pack
+	}
+	for _, id := range []string{
+		"builtin-credential-risk",
+		"builtin-saas-risk",
+		"builtin-identity-risk",
+		"builtin-saas-app-overrides",
+	} {
+		if _, ok := byID[id]; !ok {
+			t.Fatalf("missing built-in policy pack %q", id)
+		}
+	}
+}
+
+func TestLoadDocumentsRejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadDocuments(map[string][]byte{
+		"bad.yaml": []byte(`
+api_version: risk.open-sspm.io/v1
+kind: RiskPolicyPack
+metadata:
+  id: bad
+  version: 1.0.0
+  domain: credential
+spec:
+  inputs:
+    schema: credential_risk_input.v1
+  unexpected: true
+`),
+	})
+	if err == nil {
+		t.Fatal("LoadDocuments() error = nil, want unknown field error")
+	}
+	if !strings.Contains(err.Error(), "field unexpected not found") {
+		t.Fatalf("LoadDocuments() error = %v, want unknown field error", err)
+	}
+}
+
+func TestLoadDocumentsRejectsInvalidSeverity(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadDocuments(map[string][]byte{
+		"bad.yaml": []byte(`
+api_version: risk.open-sspm.io/v1
+kind: RiskPolicyPack
+metadata:
+  id: bad
+  version: 1.0.0
+  domain: credential
+spec:
+  inputs:
+    schema: credential_risk_input.v1
+  rules:
+    - id: invalid_severity
+      severity: urgent
+      when: "true"
+      title: Invalid severity
+`),
+	})
+	if err == nil {
+		t.Fatal("LoadDocuments() error = nil, want invalid severity error")
+	}
+	if !strings.Contains(err.Error(), "severity") {
+		t.Fatalf("LoadDocuments() error = %v, want severity error", err)
+	}
+}
+
+func TestLoadDocumentsRejectsInvalidCEL(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadDocuments(map[string][]byte{
+		"bad.yaml": []byte(`
+api_version: risk.open-sspm.io/v1
+kind: RiskPolicyPack
+metadata:
+  id: bad
+  version: 1.0.0
+  domain: credential
+spec:
+  inputs:
+    schema: credential_risk_input.v1
+  rules:
+    - id: invalid_cel
+      severity: high
+      when: unknown_field == "x"
+      title: Invalid CEL
+`),
+	})
+	if err == nil {
+		t.Fatal("LoadDocuments() error = nil, want CEL compile error")
+	}
+	if !strings.Contains(err.Error(), "invalid_cel") {
+		t.Fatalf("LoadDocuments() error = %v, want rule id in error", err)
+	}
+}
+
+func TestSeverityOrdering(t *testing.T) {
+	t.Parallel()
+
+	if got := MaxSeverity("low", "critical", "medium"); got != "critical" {
+		t.Fatalf("MaxSeverity() = %q, want critical", got)
+	}
+	if ValidSeverity("urgent") {
+		t.Fatal("ValidSeverity(\"urgent\") = true, want false")
+	}
+	if got := SeverityRank("HIGH"); got != 3 {
+		t.Fatalf("SeverityRank(\"HIGH\") = %d, want 3", got)
+	}
+}

--- a/internal/riskpolicy/severity.go
+++ b/internal/riskpolicy/severity.go
@@ -34,7 +34,7 @@ func ValidSeverity(value string) bool {
 
 func MaxSeverity(values ...string) string {
 	maxRank := 0
-	maxSeverity := SeverityLow
+	maxSeverity := ""
 	for _, value := range values {
 		rank := SeverityRank(value)
 		if rank > maxRank {

--- a/internal/riskpolicy/severity.go
+++ b/internal/riskpolicy/severity.go
@@ -1,0 +1,46 @@
+package riskpolicy
+
+import "strings"
+
+const (
+	SeverityLow      = "low"
+	SeverityMedium   = "medium"
+	SeverityHigh     = "high"
+	SeverityCritical = "critical"
+)
+
+func NormalizeSeverity(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func SeverityRank(value string) int {
+	switch NormalizeSeverity(value) {
+	case SeverityLow:
+		return 1
+	case SeverityMedium:
+		return 2
+	case SeverityHigh:
+		return 3
+	case SeverityCritical:
+		return 4
+	default:
+		return 0
+	}
+}
+
+func ValidSeverity(value string) bool {
+	return SeverityRank(value) > 0
+}
+
+func MaxSeverity(values ...string) string {
+	maxRank := 0
+	maxSeverity := SeverityLow
+	for _, value := range values {
+		rank := SeverityRank(value)
+		if rank > maxRank {
+			maxRank = rank
+			maxSeverity = NormalizeSeverity(value)
+		}
+	}
+	return maxSeverity
+}

--- a/internal/riskpolicy/types.go
+++ b/internal/riskpolicy/types.go
@@ -1,0 +1,122 @@
+package riskpolicy
+
+const (
+	APIVersion = "risk.open-sspm.io/v1"
+	Kind       = "RiskPolicyPack"
+)
+
+type Domain string
+
+const (
+	DomainCredential Domain = "credential"
+	DomainSaaS       Domain = "saas"
+	DomainIdentity   Domain = "identity"
+)
+
+type PolicyPack struct {
+	APIVersion string         `yaml:"api_version"`
+	Kind       string         `yaml:"kind"`
+	Metadata   PolicyMetadata `yaml:"metadata"`
+	Spec       PolicySpec     `yaml:"spec"`
+}
+
+type PolicyMetadata struct {
+	ID      string `yaml:"id"`
+	Version string `yaml:"version"`
+	Domain  Domain `yaml:"domain"`
+}
+
+type PolicySpec struct {
+	Inputs      Inputs              `yaml:"inputs"`
+	Constants   map[string][]string `yaml:"constants"`
+	Suggestions Suggestions         `yaml:"suggestions"`
+	Scoring     Scoring             `yaml:"scoring"`
+	Levels      []LevelRule         `yaml:"levels"`
+	Rules       []Rule              `yaml:"rules"`
+	Aggregation Aggregation         `yaml:"aggregation"`
+	ScopedRules []ScopedRule        `yaml:"scoped_rules"`
+}
+
+type Inputs struct {
+	Schema string `yaml:"schema"`
+}
+
+type Suggestions struct {
+	BusinessCriticality []SuggestionRule `yaml:"business_criticality"`
+	DataClassification  []SuggestionRule `yaml:"data_classification"`
+}
+
+type SuggestionRule struct {
+	ID    string `yaml:"id"`
+	Level string `yaml:"level"`
+	When  string `yaml:"when"`
+}
+
+type Scoring struct {
+	Base  int           `yaml:"base"`
+	Max   int           `yaml:"max"`
+	Rules []ScoringRule `yaml:"rules"`
+}
+
+type ScoringRule struct {
+	ID     string `yaml:"id"`
+	Points int    `yaml:"points"`
+	When   string `yaml:"when"`
+	Signal Signal `yaml:"signal"`
+}
+
+type Signal struct {
+	Severity string `yaml:"severity"`
+	Title    string `yaml:"title"`
+	Evidence string `yaml:"evidence"`
+}
+
+type LevelRule struct {
+	Level string `yaml:"level"`
+	When  string `yaml:"when"`
+}
+
+type Rule struct {
+	ID         string `yaml:"id"`
+	Severity   string `yaml:"severity"`
+	ScoreDelta int    `yaml:"score_delta"`
+	When       string `yaml:"when"`
+	Title      string `yaml:"title"`
+	Evidence   string `yaml:"evidence"`
+}
+
+type Aggregation struct {
+	RiskLevel       AggregationStrategy `yaml:"risk_level"`
+	RiskReasonCount AggregationStrategy `yaml:"risk_reason_count"`
+}
+
+type AggregationStrategy struct {
+	Strategy string `yaml:"strategy"`
+	Default  string `yaml:"default"`
+}
+
+type ScopedRule struct {
+	ID          string            `yaml:"id"`
+	Scope       Scope             `yaml:"scope"`
+	Rules       []Rule            `yaml:"rules"`
+	Suggestions ScopedSuggestions `yaml:"suggestions"`
+}
+
+type Scope struct {
+	App AppScope `yaml:"app"`
+}
+
+type AppScope struct {
+	CanonicalKey  string   `yaml:"canonical_key"`
+	PrimaryDomain string   `yaml:"primary_domain"`
+	DomainMatches []string `yaml:"domain_matches"`
+	VendorName    string   `yaml:"vendor_name"`
+	SourceKind    string   `yaml:"source_kind"`
+	SourceName    string   `yaml:"source_name"`
+	Category      string   `yaml:"category"`
+}
+
+type ScopedSuggestions struct {
+	BusinessCriticality string `yaml:"business_criticality"`
+	DataClassification  string `yaml:"data_classification"`
+}

--- a/internal/riskpolicy/validate.go
+++ b/internal/riskpolicy/validate.go
@@ -28,8 +28,8 @@ func validatePolicyPack(name string, pack PolicyPack) error {
 	}
 
 	ruleIDs := make(map[string]string)
-	validateSuggestions(&errs, "spec.suggestions.business_criticality", pack.Spec.Suggestions.BusinessCriticality, ruleIDs)
-	validateSuggestions(&errs, "spec.suggestions.data_classification", pack.Spec.Suggestions.DataClassification, ruleIDs)
+	validateSuggestions(&errs, "spec.suggestions.business_criticality", pack.Spec.Suggestions.BusinessCriticality, ruleIDs, validBusinessCriticality)
+	validateSuggestions(&errs, "spec.suggestions.data_classification", pack.Spec.Suggestions.DataClassification, ruleIDs, validDataClassification)
 	validateScoring(&errs, pack.Spec.Scoring, ruleIDs)
 	validateLevelRules(&errs, "spec.levels", pack.Spec.Levels)
 	validateRules(&errs, "spec.rules", pack.Spec.Rules, ruleIDs)
@@ -51,12 +51,14 @@ func validDomain(domain Domain) bool {
 	}
 }
 
-func validateSuggestions(errs *[]error, path string, rules []SuggestionRule, ruleIDs map[string]string) {
+func validateSuggestions(errs *[]error, path string, rules []SuggestionRule, ruleIDs map[string]string, validLevel func(string) bool) {
 	for i, rule := range rules {
 		currentPath := fmt.Sprintf("%s[%d]", path, i)
 		validateID(errs, currentPath+".id", rule.ID, ruleIDs)
 		if rule.Level == "" {
 			*errs = append(*errs, fmt.Errorf("%s.level is required", currentPath))
+		} else if !validLevel(rule.Level) {
+			*errs = append(*errs, fmt.Errorf("%s.level %q is invalid", currentPath, rule.Level))
 		}
 		if rule.When == "" {
 			*errs = append(*errs, fmt.Errorf("%s.when is required", currentPath))
@@ -147,7 +149,35 @@ func validateScopedRules(errs *[]error, scopedRules []ScopedRule, ruleIDs map[st
 		if !scopedRule.Scope.App.hasSelector() {
 			*errs = append(*errs, fmt.Errorf("%s.scope.app must include at least one selector", path))
 		}
+		validateScopedSuggestions(errs, path+".suggestions", scopedRule.Suggestions)
 		validateRules(errs, path+".rules", scopedRule.Rules, ruleIDs)
+	}
+}
+
+func validateScopedSuggestions(errs *[]error, path string, suggestions ScopedSuggestions) {
+	if suggestions.BusinessCriticality != "" && !validBusinessCriticality(suggestions.BusinessCriticality) {
+		*errs = append(*errs, fmt.Errorf("%s.business_criticality %q is invalid", path, suggestions.BusinessCriticality))
+	}
+	if suggestions.DataClassification != "" && !validDataClassification(suggestions.DataClassification) {
+		*errs = append(*errs, fmt.Errorf("%s.data_classification %q is invalid", path, suggestions.DataClassification))
+	}
+}
+
+func validBusinessCriticality(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "unknown", "low", "medium", "high", "critical":
+		return true
+	default:
+		return false
+	}
+}
+
+func validDataClassification(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "unknown", "public", "internal", "confidential", "restricted":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/riskpolicy/validate.go
+++ b/internal/riskpolicy/validate.go
@@ -1,0 +1,174 @@
+package riskpolicy
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+func validatePolicyPack(name string, pack PolicyPack) error {
+	var errs []error
+	if pack.APIVersion != APIVersion {
+		errs = append(errs, fmt.Errorf("api_version must be %q", APIVersion))
+	}
+	if pack.Kind != Kind {
+		errs = append(errs, fmt.Errorf("kind must be %q", Kind))
+	}
+	if pack.Metadata.ID == "" {
+		errs = append(errs, errors.New("metadata.id is required"))
+	}
+	if pack.Metadata.Version == "" {
+		errs = append(errs, errors.New("metadata.version is required"))
+	}
+	if !validDomain(pack.Metadata.Domain) {
+		errs = append(errs, fmt.Errorf("metadata.domain %q is not supported", pack.Metadata.Domain))
+	}
+	if pack.Spec.Inputs.Schema == "" && len(pack.Spec.ScopedRules) == 0 {
+		errs = append(errs, errors.New("spec.inputs.schema is required"))
+	}
+
+	ruleIDs := make(map[string]string)
+	validateSuggestions(&errs, "spec.suggestions.business_criticality", pack.Spec.Suggestions.BusinessCriticality, ruleIDs)
+	validateSuggestions(&errs, "spec.suggestions.data_classification", pack.Spec.Suggestions.DataClassification, ruleIDs)
+	validateScoring(&errs, pack.Spec.Scoring, ruleIDs)
+	validateLevelRules(&errs, "spec.levels", pack.Spec.Levels)
+	validateRules(&errs, "spec.rules", pack.Spec.Rules, ruleIDs)
+	validateAggregation(&errs, pack.Spec.Aggregation)
+	validateScopedRules(&errs, pack.Spec.ScopedRules, ruleIDs)
+
+	if err := errors.Join(errs...); err != nil {
+		return fmt.Errorf("%s: validate policy: %w", name, err)
+	}
+	return nil
+}
+
+func validDomain(domain Domain) bool {
+	switch domain {
+	case DomainCredential, DomainSaaS, DomainIdentity:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateSuggestions(errs *[]error, path string, rules []SuggestionRule, ruleIDs map[string]string) {
+	for i, rule := range rules {
+		currentPath := fmt.Sprintf("%s[%d]", path, i)
+		validateID(errs, currentPath+".id", rule.ID, ruleIDs)
+		if rule.Level == "" {
+			*errs = append(*errs, fmt.Errorf("%s.level is required", currentPath))
+		}
+		if rule.When == "" {
+			*errs = append(*errs, fmt.Errorf("%s.when is required", currentPath))
+		}
+	}
+}
+
+func validateScoring(errs *[]error, scoring Scoring, ruleIDs map[string]string) {
+	if scoring.Max == 0 && len(scoring.Rules) == 0 {
+		return
+	}
+	if scoring.Max <= 0 {
+		*errs = append(*errs, errors.New("spec.scoring.max must be greater than zero"))
+	}
+	if scoring.Base < 0 {
+		*errs = append(*errs, errors.New("spec.scoring.base must be non-negative"))
+	}
+	if scoring.Max > 0 && scoring.Base > scoring.Max {
+		*errs = append(*errs, errors.New("spec.scoring.base must not exceed spec.scoring.max"))
+	}
+	for i, rule := range scoring.Rules {
+		path := fmt.Sprintf("spec.scoring.rules[%d]", i)
+		validateID(errs, path+".id", rule.ID, ruleIDs)
+		if rule.Points == 0 {
+			*errs = append(*errs, fmt.Errorf("%s.points must be non-zero", path))
+		}
+		if rule.When == "" {
+			*errs = append(*errs, fmt.Errorf("%s.when is required", path))
+		}
+		if rule.Signal.Severity != "" && !ValidSeverity(rule.Signal.Severity) {
+			*errs = append(*errs, fmt.Errorf("%s.signal.severity %q is invalid", path, rule.Signal.Severity))
+		}
+		if rule.Signal.Severity != "" && rule.Signal.Title == "" {
+			*errs = append(*errs, fmt.Errorf("%s.signal.title is required when signal.severity is set", path))
+		}
+	}
+}
+
+func validateLevelRules(errs *[]error, path string, rules []LevelRule) {
+	for i, rule := range rules {
+		currentPath := fmt.Sprintf("%s[%d]", path, i)
+		if !ValidSeverity(rule.Level) {
+			*errs = append(*errs, fmt.Errorf("%s.level %q is invalid", currentPath, rule.Level))
+		}
+		if rule.When == "" {
+			*errs = append(*errs, fmt.Errorf("%s.when is required", currentPath))
+		}
+	}
+	if len(rules) > 0 && strings.TrimSpace(rules[len(rules)-1].When) != "true" {
+		*errs = append(*errs, fmt.Errorf("%s must end with a deterministic fallback where when is true", path))
+	}
+}
+
+func validateRules(errs *[]error, path string, rules []Rule, ruleIDs map[string]string) {
+	for i, rule := range rules {
+		currentPath := fmt.Sprintf("%s[%d]", path, i)
+		validateID(errs, currentPath+".id", rule.ID, ruleIDs)
+		if !ValidSeverity(rule.Severity) {
+			*errs = append(*errs, fmt.Errorf("%s.severity %q is invalid", currentPath, rule.Severity))
+		}
+		if rule.When == "" {
+			*errs = append(*errs, fmt.Errorf("%s.when is required", currentPath))
+		}
+		if rule.Title == "" {
+			*errs = append(*errs, fmt.Errorf("%s.title is required", currentPath))
+		}
+	}
+}
+
+func validateAggregation(errs *[]error, aggregation Aggregation) {
+	if aggregation.RiskLevel.Strategy != "" {
+		if aggregation.RiskLevel.Strategy != "max_severity" {
+			*errs = append(*errs, fmt.Errorf("spec.aggregation.risk_level.strategy %q is not supported", aggregation.RiskLevel.Strategy))
+		}
+		if aggregation.RiskLevel.Default != "" && !ValidSeverity(aggregation.RiskLevel.Default) {
+			*errs = append(*errs, fmt.Errorf("spec.aggregation.risk_level.default %q is invalid", aggregation.RiskLevel.Default))
+		}
+	}
+	if aggregation.RiskReasonCount.Strategy != "" && aggregation.RiskReasonCount.Strategy != "count_matching_rules" {
+		*errs = append(*errs, fmt.Errorf("spec.aggregation.risk_reason_count.strategy %q is not supported", aggregation.RiskReasonCount.Strategy))
+	}
+}
+
+func validateScopedRules(errs *[]error, scopedRules []ScopedRule, ruleIDs map[string]string) {
+	for i, scopedRule := range scopedRules {
+		path := fmt.Sprintf("spec.scoped_rules[%d]", i)
+		validateID(errs, path+".id", scopedRule.ID, ruleIDs)
+		if !scopedRule.Scope.App.hasSelector() {
+			*errs = append(*errs, fmt.Errorf("%s.scope.app must include at least one selector", path))
+		}
+		validateRules(errs, path+".rules", scopedRule.Rules, ruleIDs)
+	}
+}
+
+func (scope AppScope) hasSelector() bool {
+	return scope.CanonicalKey != "" ||
+		scope.PrimaryDomain != "" ||
+		len(scope.DomainMatches) > 0 ||
+		scope.VendorName != "" ||
+		scope.SourceKind != "" ||
+		scope.SourceName != "" ||
+		scope.Category != ""
+}
+
+func validateID(errs *[]error, path, id string, seen map[string]string) {
+	if id == "" {
+		*errs = append(*errs, fmt.Errorf("%s is required", path))
+		return
+	}
+	if previousPath := seen[id]; previousPath != "" {
+		*errs = append(*errs, fmt.Errorf("%s duplicates id %q from %s", path, id, previousPath))
+		return
+	}
+	seen[id] = path
+}

--- a/internal/riskpolicy/validate.go
+++ b/internal/riskpolicy/validate.go
@@ -150,7 +150,8 @@ func validateScopedRules(errs *[]error, scopedRules []ScopedRule, ruleIDs map[st
 			*errs = append(*errs, fmt.Errorf("%s.scope.app must include at least one selector", path))
 		}
 		validateScopedSuggestions(errs, path+".suggestions", scopedRule.Suggestions)
-		validateRules(errs, path+".rules", scopedRule.Rules, ruleIDs)
+		scopedRuleIDs := make(map[string]string, len(scopedRule.Rules))
+		validateRules(errs, path+".rules", scopedRule.Rules, scopedRuleIDs)
 	}
 }
 

--- a/justfile
+++ b/justfile
@@ -94,6 +94,10 @@ sync-discovery:
 validate-rules:
     go run ./cmd/open-sspm validate-rules
 
+# Validate risk policy packs
+validate-risk-policies:
+    go run ./cmd/open-sspm validate-risk-policies
+
 #
 # UI / CSS
 #


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the `internal/riskpolicy` package, migrating risk evaluation logic from code into embedded YAML policy packs that are parsed, validated, and compiled to CEL expressions at load time. A new `validate-risk-policies` CLI command exercises the full load/compile path without touching the database.

- **P1 – `validate.go`**: `validateScopedRules` passes the same global `ruleIDs` dedup map into each scoped rule's `validateRules` call, so two scoped rules that legitimately share the same inner rule ID will be rejected as duplicates — but `cel.go` compiles them under the composite key `scopedRule.ID + \"/\" + rule.ID`, so they would compile and run correctly. The dedup check in `validateID` should use the composite key for scoped-rule inner IDs to match the CEL behaviour.

<h3>Confidence Score: 4/5</h3>

Safe to merge for current YAML policies, but the validation/CEL ID-namespacing inconsistency will silently block valid future policies

One P1 logic gap: the global dedup map in validateScopedRules conflicts with composite-key namespacing in CEL compilation, making it impossible to share inner rule IDs across scoped rules. Existing policies use unique IDs so tests pass today, but the contract is wrong. Everything else is solid.

internal/riskpolicy/validate.go — specifically validateScopedRules and the ruleIDs map threading

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/riskpolicy/validate.go | Comprehensive validation logic; has a P1 logic gap where scoped-rule inner IDs share the global dedup map while CEL uses composite keys, causing false-positive rejections of valid multi-scoped policies |
| internal/riskpolicy/cel.go | CEL compilation is clean; correctly uses composite scopedRule.ID+rule.ID keys, validates bool return type, and builds domain-specific CEL environments |
| internal/riskpolicy/loader.go | Loader correctly uses KnownFields, rejects multi-document YAML, guards against duplicate pack IDs, and provides nil-safe Registry methods |
| internal/riskpolicy/severity.go | Severity helpers are clean; MaxSeverity has a P2 ambiguity when called with no/invalid inputs returning low unconditionally |
| internal/riskpolicy/policy_test.go | Good test coverage for happy path, unknown fields, invalid severity, invalid CEL, non-bool CEL, invalid suggestion levels, and scoped suggestion levels |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[embed FS policies/*.yaml] --> B[LoadBuiltin]
    B --> C[decodePolicyPack yaml.KnownFields]
    C --> D[normalizePolicyPack]
    D --> E[compilePack]
    E --> F{validatePolicyPack}
    F -->|error| G[return error]
    F -->|ok| H[newEnv domain CEL vars + constants]
    H --> I[compile each rule check bool return type]
    I -->|error| G
    I -->|ok| J[CompiledPack added to Registry]
    J --> K[Registry ready PackCount / ExpressionCount]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/riskpolicy/validate.go`, line 1306-1315 ([link](https://github.com/open-sspm/open-sspm/blob/3fb178438e6db30b56fa51cd9d2525f977b93db7/internal/riskpolicy/validate.go#L1306-L1315)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Scoped-rule IDs share the global uniqueness map, contradicting CEL's composite keys**

   `validateScopedRules` passes the top-level `ruleIDs` map down into `validateRules` for each scoped rule, so inner rule IDs are checked for global uniqueness across all scoped rules. However `cel.go` compiles scoped-rule expressions under the composite key `scopedRule.ID + "/" + rule.ID`. This means two scoped rules that legitimately share the same inner rule ID (e.g., both have `missing_owner`) would be rejected by validation even though CEL would treat them as distinct and successfully compile both. Any future policy author reusing a common rule name across scopes will hit a false-positive validation error with no obvious explanation.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/riskpolicy/validate.go
   Line: 1306-1315

   Comment:
   **Scoped-rule IDs share the global uniqueness map, contradicting CEL's composite keys**

   `validateScopedRules` passes the top-level `ruleIDs` map down into `validateRules` for each scoped rule, so inner rule IDs are checked for global uniqueness across all scoped rules. However `cel.go` compiles scoped-rule expressions under the composite key `scopedRule.ID + "/" + rule.ID`. This means two scoped rules that legitimately share the same inner rule ID (e.g., both have `missing_owner`) would be rejected by validation even though CEL would treat them as distinct and successfully compile both. Any future policy author reusing a common rule name across scopes will hit a false-positive validation error with no obvious explanation.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `internal/riskpolicy/severity.go`, line 1016-1027 ([link](https://github.com/open-sspm/open-sspm/blob/3fb178438e6db30b56fa51cd9d2525f977b93db7/internal/riskpolicy/severity.go#L1016-L1027)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`MaxSeverity` silently returns `"low"` when called with no arguments or all-invalid values**

   `maxSeverity` is pre-seeded to `SeverityLow` and `maxRank` starts at `0`. If the function is called with an empty variadic list, or with severities that all produce `SeverityRank == 0` (unknown values), it returns `"low"` as if a valid maximum was found. A caller can't distinguish "the highest valid severity was low" from "no valid severities were provided". Returning an empty string or a sentinel value when nothing matches would make the API more honest and prevent silent mis-scorings.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/riskpolicy/severity.go
   Line: 1016-1027

   Comment:
   **`MaxSeverity` silently returns `"low"` when called with no arguments or all-invalid values**

   `maxSeverity` is pre-seeded to `SeverityLow` and `maxRank` starts at `0`. If the function is called with an empty variadic list, or with severities that all produce `SeverityRank == 0` (unknown values), it returns `"low"` as if a valid maximum was found. A caller can't distinguish "the highest valid severity was low" from "no valid severities were provided". Returning an empty string or a sentinel value when nothing matches would make the API more honest and prevent silent mis-scorings.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/riskpolicy/validate.go
Line: 1306-1315

Comment:
**Scoped-rule IDs share the global uniqueness map, contradicting CEL's composite keys**

`validateScopedRules` passes the top-level `ruleIDs` map down into `validateRules` for each scoped rule, so inner rule IDs are checked for global uniqueness across all scoped rules. However `cel.go` compiles scoped-rule expressions under the composite key `scopedRule.ID + "/" + rule.ID`. This means two scoped rules that legitimately share the same inner rule ID (e.g., both have `missing_owner`) would be rejected by validation even though CEL would treat them as distinct and successfully compile both. Any future policy author reusing a common rule name across scopes will hit a false-positive validation error with no obvious explanation.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/riskpolicy/severity.go
Line: 1016-1027

Comment:
**`MaxSeverity` silently returns `"low"` when called with no arguments or all-invalid values**

`maxSeverity` is pre-seeded to `SeverityLow` and `maxRank` starts at `0`. If the function is called with an empty variadic list, or with severities that all produce `SeverityRank == 0` (unknown values), it returns `"low"` as if a valid maximum was found. A caller can't distinguish "the highest valid severity was low" from "no valid severities were provided". Returning an empty string or a sentinel value when nothing matches would make the API more honest and prevent silent mis-scorings.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Validate risk policy CEL and suggestion ..."](https://github.com/open-sspm/open-sspm/commit/3fb178438e6db30b56fa51cd9d2525f977b93db7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29645640)</sub>

<!-- /greptile_comment -->