### PR TITLE
feat: ruleset separate yaml files m2

### DIFF
--- a/internal/http/handlers/base.go
+++ b/internal/http/handlers/base.go
@@ -22,6 +22,7 @@ import (
 	"github.com/open-sspm/open-sspm/internal/http/authn"
 	"github.com/open-sspm/open-sspm/internal/http/viewmodels"
 	"github.com/open-sspm/open-sspm/internal/mailer"
+	"github.com/open-sspm/open-sspm/internal/riskpolicy"
 )
 
 const (
@@ -46,6 +47,8 @@ type Handlers struct {
 	Syncer   SyncRunner
 	Registry *registry.ConnectorRegistry
 	Mailer   mailer.Mailer
+
+	RiskPolicies *riskpolicy.Registry
 
 	oktaAppStatusesCache oktaAppStatusesCache
 }

--- a/internal/http/handlers/programmatic_access.go
+++ b/internal/http/handlers/programmatic_access.go
@@ -19,6 +19,7 @@ import (
 	"github.com/open-sspm/open-sspm/internal/http/querystate"
 	"github.com/open-sspm/open-sspm/internal/http/viewmodels"
 	"github.com/open-sspm/open-sspm/internal/http/views"
+	"github.com/open-sspm/open-sspm/internal/riskpolicy"
 )
 
 func (h *Handlers) HandleAppAssets(c *echo.Context) error {
@@ -619,8 +620,12 @@ func (h *Handlers) HandleCredentialShow(c *echo.Context) error {
 	if displayName == "" {
 		displayName = strings.TrimSpace(credential.ExternalID)
 	}
-	riskLevel := strings.TrimSpace(credential.RiskLevel)
-	riskFindings := credentialRiskFindingsFor(credential.Status, credential.CredentialKind, credential.CreatedByExternalID, credential.ApprovedByExternalID, credential.ExpiresAtSource, credential.LastUsedAtSource, now)
+	credentialRisk, err := h.evaluateCredentialRisk(credential, now)
+	if err != nil {
+		return h.RenderError(c, err)
+	}
+	riskLevel := credentialRisk.RiskLevel
+	riskFindings := credentialRiskFindingsFromSignals(credentialRisk.Signals, credential.ExpiresAtSource, credential.LastUsedAtSource, now)
 	linkResolver := newIdentityLinkResolver(h, ctx)
 
 	data := viewmodels.CredentialShowViewData{
@@ -791,92 +796,74 @@ func pgTimestamptz(ts time.Time) pgtype.Timestamptz {
 	return pgtype.Timestamptz{Time: ts.UTC(), Valid: true}
 }
 
-func credentialRiskFindingsFor(statusValue, credentialKindValue, createdByValue, approvedByValue string, expiresAt, lastUsedAt pgtype.Timestamptz, now time.Time) []viewmodels.CredentialRiskFinding {
-	now = now.UTC()
-	findings := make([]viewmodels.CredentialRiskFinding, 0, 4)
-
-	status := strings.ToLower(strings.TrimSpace(statusValue))
-	credentialKind := strings.ToLower(strings.TrimSpace(credentialKindValue))
-	createdByExternalID := strings.TrimSpace(createdByValue)
-	approvedByExternalID := strings.TrimSpace(approvedByValue)
-
-	if expiresAt.Valid && expiresAt.Time.UTC().Before(now) {
-		evidence := "Expired " + relativeDateLabelAt(now, expiresAt.Time)
-		if isCredentialStatusActiveLike(status) {
-			findings = append(findings, viewmodels.CredentialRiskFinding{
-				Severity: "critical",
-				Title:    "Credential has expired while still marked active",
-				Evidence: evidence,
-			})
-		} else {
-			findings = append(findings, viewmodels.CredentialRiskFinding{
-				Severity: "critical",
-				Title:    "Credential has expired",
-				Evidence: evidence,
-			})
+func (h *Handlers) evaluateCredentialRisk(credential gen.GetCredentialArtifactByIDRow, now time.Time) (riskpolicy.CredentialResult, error) {
+	registry := h.RiskPolicies
+	if registry == nil {
+		var err error
+		registry, err = riskpolicy.BuiltinRegistry()
+		if err != nil {
+			return riskpolicy.CredentialResult{}, err
 		}
 	}
+	return registry.EvaluateCredential(credentialPolicyInput(credential, now))
+}
 
-	if isHighPrivilegeCredentialKind(credentialKind) && createdByExternalID == "" && approvedByExternalID == "" {
+func credentialPolicyInput(credential gen.GetCredentialArtifactByIDRow, now time.Time) riskpolicy.CredentialInput {
+	return riskpolicy.CredentialInput{
+		SourceKind:            credential.SourceKind,
+		SourceName:            credential.SourceName,
+		CredentialKind:        credential.CredentialKind,
+		Status:                credential.Status,
+		ExpiresAt:             timestamptzTimePtr(credential.ExpiresAtSource),
+		LastUsedAt:            timestamptzTimePtr(credential.LastUsedAtSource),
+		CreatedAt:             timestamptzTimePtr(credential.CreatedAtSource),
+		CreatedByExternalID:   credential.CreatedByExternalID,
+		CreatedByDisplayName:  credential.CreatedByDisplayName,
+		ApprovedByExternalID:  credential.ApprovedByExternalID,
+		ApprovedByDisplayName: credential.ApprovedByDisplayName,
+		AssetRefKind:          credential.AssetRefKind,
+		AssetRefExternalID:    credential.AssetRefExternalID,
+		ScopeJSON:             credential.ScopeJson,
+		EvaluatedAt:           now,
+	}
+}
+
+func timestamptzTimePtr(value pgtype.Timestamptz) *time.Time {
+	if !value.Valid {
+		return nil
+	}
+	t := value.Time.UTC()
+	return &t
+}
+
+func credentialRiskFindingsFromSignals(signals []riskpolicy.RiskSignal, expiresAt, lastUsedAt pgtype.Timestamptz, now time.Time) []viewmodels.CredentialRiskFinding {
+	findings := make([]viewmodels.CredentialRiskFinding, 0, len(signals))
+	for _, signal := range signals {
 		findings = append(findings, viewmodels.CredentialRiskFinding{
-			Severity: "high",
-			Title:    "High-privilege credential has no creator or approver",
-			Evidence: "No provenance recorded at source",
+			Severity: signal.Severity,
+			Title:    signal.Title,
+			Evidence: credentialSignalEvidence(signal, expiresAt, lastUsedAt, now),
 		})
 	}
-
-	if expiresAt.Valid {
-		expiresAtTime := expiresAt.Time.UTC()
-		if !expiresAtTime.Before(now) && !expiresAtTime.After(now.Add(7*24*time.Hour)) {
-			findings = append(findings, viewmodels.CredentialRiskFinding{
-				Severity: "high",
-				Title:    "Credential expires within 7 days",
-				Evidence: "Expires " + relativeDateLabelAt(now, expiresAtTime),
-			})
-		} else if !expiresAtTime.Before(now) && !expiresAtTime.After(now.Add(30*24*time.Hour)) {
-			findings = append(findings, viewmodels.CredentialRiskFinding{
-				Severity: "medium",
-				Title:    "Credential expires within 30 days",
-				Evidence: "Expires " + relativeDateLabelAt(now, expiresAtTime),
-			})
-		}
-	}
-
-	if createdByExternalID == "" {
-		findings = append(findings, viewmodels.CredentialRiskFinding{
-			Severity: "medium",
-			Title:    "Creator attribution is missing",
-			Evidence: "No provenance recorded at source",
-		})
-	}
-
-	if lastUsedAt.Valid && lastUsedAt.Time.UTC().Before(now.Add(-90*24*time.Hour)) {
-		findings = append(findings, viewmodels.CredentialRiskFinding{
-			Severity: "medium",
-			Title:    "Credential has not been used in over 90 days",
-			Evidence: "Last used " + relativeDateLabelAt(now, lastUsedAt.Time),
-		})
-	}
-
 	return findings
 }
 
-func isCredentialStatusActiveLike(status string) bool {
-	switch strings.ToLower(strings.TrimSpace(status)) {
-	case "", "active", "approved", "pending_approval":
-		return true
-	default:
-		return false
+func credentialSignalEvidence(signal riskpolicy.RiskSignal, expiresAt, lastUsedAt pgtype.Timestamptz, now time.Time) string {
+	switch signal.ID {
+	case "expired_active", "expired_inactive":
+		if expiresAt.Valid {
+			return "Expired " + relativeDateLabelAt(now.UTC(), expiresAt.Time.UTC())
+		}
+	case "expiring_within_7_days", "expiring_within_30_days":
+		if expiresAt.Valid {
+			return "Expires " + relativeDateLabelAt(now.UTC(), expiresAt.Time.UTC())
+		}
+	case "unused_over_90_days":
+		if lastUsedAt.Valid {
+			return "Last used " + relativeDateLabelAt(now.UTC(), lastUsedAt.Time.UTC())
+		}
 	}
-}
-
-func isHighPrivilegeCredentialKind(kind string) bool {
-	switch strings.ToLower(strings.TrimSpace(kind)) {
-	case "entra_client_secret", "github_deploy_key", "github_pat_request", "github_pat_fine_grained":
-		return true
-	default:
-		return false
-	}
+	return strings.TrimSpace(signal.Evidence)
 }
 
 type identityLinkResolver struct {

--- a/internal/http/handlers/programmatic_access_test.go
+++ b/internal/http/handlers/programmatic_access_test.go
@@ -43,22 +43,18 @@ func TestCredentialRiskReasons(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 2, 7, 12, 0, 0, 0, time.UTC)
-	credential := gen.CredentialArtifact{
+	credential := gen.GetCredentialArtifactByIDRow{
 		Status:           "active",
 		CredentialKind:   "github_pat_fine_grained",
 		ExpiresAtSource:  timestamptz(now.Add(2 * 24 * time.Hour)),
 		LastUsedAtSource: timestamptz(now.Add(-120 * 24 * time.Hour)),
 	}
 
-	findings := credentialRiskFindingsFor(
-		credential.Status,
-		credential.CredentialKind,
-		credential.CreatedByExternalID,
-		credential.ApprovedByExternalID,
-		credential.ExpiresAtSource,
-		credential.LastUsedAtSource,
-		now,
-	)
+	result, err := (&Handlers{}).evaluateCredentialRisk(credential, now)
+	if err != nil {
+		t.Fatalf("evaluateCredentialRisk() error = %v", err)
+	}
+	findings := credentialRiskFindingsFromSignals(result.Signals, credential.ExpiresAtSource, credential.LastUsedAtSource, now)
 	if len(findings) < 3 {
 		t.Fatalf("expected multiple findings, got %v", findings)
 	}
@@ -74,15 +70,18 @@ func TestCredentialRiskReasonsUseFutureAwareExpiryLabel(t *testing.T) {
 
 	now := time.Date(2026, 2, 7, 12, 0, 0, 0, time.UTC)
 
-	findings := credentialRiskFindingsFor(
-		"active",
-		"entra_client_secret",
-		"owner@example.com",
-		"",
-		timestamptz(now.Add(4*24*time.Hour)),
-		pgtype.Timestamptz{},
-		now,
-	)
+	credential := gen.GetCredentialArtifactByIDRow{
+		Status:              "active",
+		CredentialKind:      "entra_client_secret",
+		CreatedByExternalID: "owner@example.com",
+		ExpiresAtSource:     timestamptz(now.Add(4 * 24 * time.Hour)),
+	}
+
+	result, err := (&Handlers{}).evaluateCredentialRisk(credential, now)
+	if err != nil {
+		t.Fatalf("evaluateCredentialRisk() error = %v", err)
+	}
+	findings := credentialRiskFindingsFromSignals(result.Signals, credential.ExpiresAtSource, credential.LastUsedAtSource, now)
 
 	for _, finding := range findings {
 		if finding.Title == "Credential expires within 7 days" {

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/open-sspm/open-sspm/internal/http/authn"
 	"github.com/open-sspm/open-sspm/internal/http/handlers"
 	"github.com/open-sspm/open-sspm/internal/mailer"
+	"github.com/open-sspm/open-sspm/internal/riskpolicy"
 )
 
 // EchoServer is the HTTP server wrapper.
@@ -57,14 +58,20 @@ func NewEchoServer(
 	sessions.Cookie.SameSite = http.SameSiteLaxMode
 	sessions.Cookie.Secure = cfg.AuthCookieSecure
 
+	riskPolicies, err := riskpolicy.BuiltinRegistry()
+	if err != nil {
+		return nil, err
+	}
+
 	h := &handlers.Handlers{
-		Cfg:      cfg,
-		Q:        q,
-		Pool:     pool,
-		Sessions: sessions,
-		Syncer:   syncer,
-		Registry: reg,
-		Mailer:   mailAdapter,
+		Cfg:          cfg,
+		Q:            q,
+		Pool:         pool,
+		Sessions:     sessions,
+		Syncer:       syncer,
+		Registry:     reg,
+		Mailer:       mailAdapter,
+		RiskPolicies: riskPolicies,
 	}
 	es := &EchoServer{h: h, e: newEcho(cfg)}
 	es.e.Use(middleware.RequestIDWithConfig(middleware.RequestIDConfig{

--- a/internal/riskpolicy/cel.go
+++ b/internal/riskpolicy/cel.go
@@ -10,6 +10,7 @@ type CompiledExpression struct {
 	RuleID     string
 	Expression string
 	ast        *cel.Ast
+	program    cel.Program
 }
 
 func compilePack(name string, pack PolicyPack) (CompiledPack, error) {
@@ -33,10 +34,15 @@ func compilePack(name string, pack PolicyPack) (CompiledPack, error) {
 		if !ast.OutputType().IsExactType(cel.BoolType) {
 			return fmt.Errorf("%s: %s: compile %q: expression must return bool, got %s", name, ruleID, expression, ast.OutputType())
 		}
+		program, err := env.Program(ast, cel.EvalOptions(cel.OptOptimize))
+		if err != nil {
+			return fmt.Errorf("%s: %s: create CEL program for %q: %w", name, ruleID, expression, err)
+		}
 		compiled.expressions = append(compiled.expressions, CompiledExpression{
 			RuleID:     ruleID,
 			Expression: expression,
 			ast:        ast,
+			program:    program,
 		})
 		return nil
 	}

--- a/internal/riskpolicy/evaluator.go
+++ b/internal/riskpolicy/evaluator.go
@@ -1,0 +1,211 @@
+package riskpolicy
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type RiskSignal struct {
+	ID                string
+	Domain            Domain
+	Severity          string
+	ScoreDelta        int
+	Title             string
+	Evidence          string
+	PolicyPackID      string
+	PolicyPackVersion string
+}
+
+type CredentialInput struct {
+	SourceKind            string
+	SourceName            string
+	CredentialKind        string
+	Status                string
+	ExpiresAt             *time.Time
+	LastUsedAt            *time.Time
+	CreatedAt             *time.Time
+	CreatedByExternalID   string
+	CreatedByDisplayName  string
+	ApprovedByExternalID  string
+	ApprovedByDisplayName string
+	AssetRefKind          string
+	AssetRefExternalID    string
+	ScopeJSON             any
+	EvaluatedAt           time.Time
+}
+
+type CredentialResult struct {
+	RiskLevel string
+	RiskRank  int
+	Signals   []RiskSignal
+}
+
+func EvaluateCredential(input CredentialInput) (CredentialResult, error) {
+	registry, err := BuiltinRegistry()
+	if err != nil {
+		return CredentialResult{}, err
+	}
+	return registry.EvaluateCredential(input)
+}
+
+func (r *Registry) EvaluateCredential(input CredentialInput) (CredentialResult, error) {
+	if r == nil {
+		return CredentialResult{}, errors.New("risk policy registry is nil")
+	}
+
+	input = normalizeCredentialInput(input)
+	result := CredentialResult{
+		Signals: make([]RiskSignal, 0, 4),
+	}
+	defaultLevel := SeverityLow
+	foundPack := false
+
+	for _, pack := range r.packs {
+		if pack.Policy.Metadata.Domain != DomainCredential {
+			continue
+		}
+		foundPack = true
+		if pack.Policy.Spec.Aggregation.RiskLevel.Default != "" {
+			defaultLevel = MaxSeverity(defaultLevel, pack.Policy.Spec.Aggregation.RiskLevel.Default)
+		}
+
+		activation := credentialActivation(input, pack.Policy.Spec.Constants)
+		for _, rule := range pack.Policy.Spec.Rules {
+			matched, err := pack.evaluateBool(rule.ID, activation)
+			if err != nil {
+				return CredentialResult{}, err
+			}
+			if !matched {
+				continue
+			}
+
+			signal := RiskSignal{
+				ID:                rule.ID,
+				Domain:            DomainCredential,
+				Severity:          rule.Severity,
+				ScoreDelta:        rule.ScoreDelta,
+				Title:             rule.Title,
+				Evidence:          rule.Evidence,
+				PolicyPackID:      pack.Policy.Metadata.ID,
+				PolicyPackVersion: pack.Policy.Metadata.Version,
+			}
+			result.Signals = append(result.Signals, signal)
+			result.RiskLevel = MaxSeverity(result.RiskLevel, rule.Severity)
+		}
+	}
+
+	if !foundPack {
+		return CredentialResult{}, errors.New("credential risk policy pack not found")
+	}
+	if result.RiskLevel == "" {
+		result.RiskLevel = defaultLevel
+	}
+	result.RiskRank = SeverityRank(result.RiskLevel)
+	return result, nil
+}
+
+func (pack CompiledPack) evaluateBool(ruleID string, activation map[string]any) (bool, error) {
+	for _, expression := range pack.expressions {
+		if expression.RuleID != ruleID {
+			continue
+		}
+		value, _, err := expression.program.Eval(activation)
+		if err != nil {
+			return false, fmt.Errorf("%s: %s: evaluate %q: %w", pack.Policy.Metadata.ID, ruleID, expression.Expression, err)
+		}
+		matched, ok := value.Value().(bool)
+		if !ok {
+			return false, fmt.Errorf("%s: %s: evaluate %q: expected bool result, got %T", pack.Policy.Metadata.ID, ruleID, expression.Expression, value.Value())
+		}
+		return matched, nil
+	}
+	return false, fmt.Errorf("%s: compiled expression %q not found", pack.Policy.Metadata.ID, ruleID)
+}
+
+func normalizeCredentialInput(input CredentialInput) CredentialInput {
+	input.SourceKind = strings.ToLower(strings.TrimSpace(input.SourceKind))
+	input.SourceName = strings.TrimSpace(input.SourceName)
+	input.CredentialKind = strings.ToLower(strings.TrimSpace(input.CredentialKind))
+	input.Status = strings.ToLower(strings.TrimSpace(input.Status))
+	input.CreatedByExternalID = strings.TrimSpace(input.CreatedByExternalID)
+	input.CreatedByDisplayName = strings.TrimSpace(input.CreatedByDisplayName)
+	input.ApprovedByExternalID = strings.TrimSpace(input.ApprovedByExternalID)
+	input.ApprovedByDisplayName = strings.TrimSpace(input.ApprovedByDisplayName)
+	input.AssetRefKind = strings.ToLower(strings.TrimSpace(input.AssetRefKind))
+	input.AssetRefExternalID = strings.TrimSpace(input.AssetRefExternalID)
+	input.ExpiresAt = normalizeTimePtr(input.ExpiresAt)
+	input.LastUsedAt = normalizeTimePtr(input.LastUsedAt)
+	input.CreatedAt = normalizeTimePtr(input.CreatedAt)
+	if input.EvaluatedAt.IsZero() {
+		input.EvaluatedAt = time.Now()
+	}
+	input.EvaluatedAt = input.EvaluatedAt.UTC()
+	input.ScopeJSON = normalizeScopeJSON(input.ScopeJSON)
+	return input
+}
+
+func credentialActivation(input CredentialInput, constants map[string][]string) map[string]any {
+	activation := map[string]any{
+		"source_kind":              input.SourceKind,
+		"source_name":              input.SourceName,
+		"credential_kind":          input.CredentialKind,
+		"status":                   input.Status,
+		"expires_at":               nullableTime(input.ExpiresAt),
+		"last_used_at":             nullableTime(input.LastUsedAt),
+		"created_at":               nullableTime(input.CreatedAt),
+		"created_by_external_id":   input.CreatedByExternalID,
+		"created_by_display_name":  input.CreatedByDisplayName,
+		"approved_by_external_id":  input.ApprovedByExternalID,
+		"approved_by_display_name": input.ApprovedByDisplayName,
+		"asset_ref_kind":           input.AssetRefKind,
+		"asset_ref_external_id":    input.AssetRefExternalID,
+		"scope_json":               input.ScopeJSON,
+		"evaluated_at":             input.EvaluatedAt,
+	}
+	for name, values := range constants {
+		activation[name] = cloneSlice(values)
+	}
+	return activation
+}
+
+func normalizeTimePtr(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	normalized := value.UTC()
+	return &normalized
+}
+
+func nullableTime(value *time.Time) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func normalizeScopeJSON(value any) any {
+	switch v := value.(type) {
+	case nil:
+		return map[string]any{}
+	case []byte:
+		return decodeScopeJSON(v)
+	case json.RawMessage:
+		return decodeScopeJSON(v)
+	default:
+		return value
+	}
+}
+
+func decodeScopeJSON(data []byte) any {
+	if len(data) == 0 {
+		return map[string]any{}
+	}
+	var decoded any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return map[string]any{}
+	}
+	return decoded
+}

--- a/internal/riskpolicy/evaluator.go
+++ b/internal/riskpolicy/evaluator.go
@@ -56,7 +56,10 @@ func (r *Registry) EvaluateCredential(input CredentialInput) (CredentialResult, 
 		return CredentialResult{}, errors.New("risk policy registry is nil")
 	}
 
-	input = normalizeCredentialInput(input)
+	input, err := normalizeCredentialInput(input)
+	if err != nil {
+		return CredentialResult{}, err
+	}
 	result := CredentialResult{
 		Signals: make([]RiskSignal, 0, 4),
 	}
@@ -125,7 +128,7 @@ func (pack CompiledPack) evaluateBool(ruleID string, activation map[string]any) 
 	return false, fmt.Errorf("%s: compiled expression %q not found", pack.Policy.Metadata.ID, ruleID)
 }
 
-func normalizeCredentialInput(input CredentialInput) CredentialInput {
+func normalizeCredentialInput(input CredentialInput) (CredentialInput, error) {
 	input.SourceKind = strings.ToLower(strings.TrimSpace(input.SourceKind))
 	input.SourceName = strings.TrimSpace(input.SourceName)
 	input.CredentialKind = strings.ToLower(strings.TrimSpace(input.CredentialKind))
@@ -143,8 +146,12 @@ func normalizeCredentialInput(input CredentialInput) CredentialInput {
 		input.EvaluatedAt = time.Now()
 	}
 	input.EvaluatedAt = input.EvaluatedAt.UTC()
-	input.ScopeJSON = normalizeScopeJSON(input.ScopeJSON)
-	return input
+	scopeJSON, err := normalizeScopeJSON(input.ScopeJSON)
+	if err != nil {
+		return CredentialInput{}, err
+	}
+	input.ScopeJSON = scopeJSON
+	return input, nil
 }
 
 func credentialActivation(input CredentialInput, constants map[string][]string) map[string]any {
@@ -186,26 +193,26 @@ func nullableTime(value *time.Time) any {
 	return *value
 }
 
-func normalizeScopeJSON(value any) any {
+func normalizeScopeJSON(value any) (any, error) {
 	switch v := value.(type) {
 	case nil:
-		return map[string]any{}
+		return map[string]any{}, nil
 	case []byte:
 		return decodeScopeJSON(v)
 	case json.RawMessage:
 		return decodeScopeJSON(v)
 	default:
-		return value
+		return value, nil
 	}
 }
 
-func decodeScopeJSON(data []byte) any {
+func decodeScopeJSON(data []byte) (any, error) {
 	if len(data) == 0 {
-		return map[string]any{}
+		return map[string]any{}, nil
 	}
 	var decoded any
 	if err := json.Unmarshal(data, &decoded); err != nil {
-		return map[string]any{}
+		return nil, fmt.Errorf("decode credential scope_json: %w", err)
 	}
-	return decoded
+	return decoded, nil
 }

--- a/internal/riskpolicy/evaluator_test.go
+++ b/internal/riskpolicy/evaluator_test.go
@@ -1,0 +1,208 @@
+package riskpolicy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/open-sspm/open-sspm/internal/testdb"
+)
+
+func TestEvaluateCredentialGoldenCases(t *testing.T) {
+	t.Parallel()
+
+	registry, err := LoadBuiltin()
+	if err != nil {
+		t.Fatalf("LoadBuiltin() error = %v", err)
+	}
+	for _, tc := range credentialGoldenCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := registry.EvaluateCredential(tc.input)
+			if err != nil {
+				t.Fatalf("EvaluateCredential() error = %v", err)
+			}
+			if result.RiskLevel != tc.wantLevel {
+				t.Fatalf("RiskLevel = %q, want %q; signals=%+v", result.RiskLevel, tc.wantLevel, result.Signals)
+			}
+			if result.RiskRank != SeverityRank(tc.wantLevel) {
+				t.Fatalf("RiskRank = %d, want %d", result.RiskRank, SeverityRank(tc.wantLevel))
+			}
+			gotSignalIDs := make([]string, 0, len(result.Signals))
+			for _, signal := range result.Signals {
+				gotSignalIDs = append(gotSignalIDs, signal.ID)
+				if signal.Domain != DomainCredential {
+					t.Fatalf("signal domain = %q, want credential", signal.Domain)
+				}
+				if signal.PolicyPackID == "" || signal.PolicyPackVersion == "" {
+					t.Fatalf("signal missing source policy metadata: %+v", signal)
+				}
+			}
+			if !sameStrings(gotSignalIDs, tc.wantSignalIDs) {
+				t.Fatalf("signal IDs = %v, want %v", gotSignalIDs, tc.wantSignalIDs)
+			}
+		})
+	}
+}
+
+func TestEvaluateCredentialMatchesSQLFunction(t *testing.T) {
+	t.Parallel()
+
+	registry, err := LoadBuiltin()
+	if err != nil {
+		t.Fatalf("LoadBuiltin() error = %v", err)
+	}
+
+	testdb.WithDatabase(t, testdb.Options{NamePrefix: "opensspm_riskpolicy"}, func(ctx context.Context, pool *pgxpool.Pool, migrator *migrate.Migrate) {
+		testdb.MigrateUp(t, migrator)
+
+		for _, tc := range credentialGoldenCases() {
+			t.Run(tc.name, func(t *testing.T) {
+				result, err := registry.EvaluateCredential(tc.input)
+				if err != nil {
+					t.Fatalf("EvaluateCredential() error = %v", err)
+				}
+
+				var sqlLevel string
+				err = pool.QueryRow(ctx, `
+					SELECT credential_artifact_risk_level($1, $2, $3, $4, $5, $6, $7)
+				`,
+					tc.input.Status,
+					tc.input.CredentialKind,
+					nullableTime(tc.input.ExpiresAt),
+					nullableTime(tc.input.LastUsedAt),
+					tc.input.CreatedByExternalID,
+					tc.input.ApprovedByExternalID,
+					tc.input.EvaluatedAt,
+				).Scan(&sqlLevel)
+				if err != nil {
+					t.Fatalf("credential_artifact_risk_level() error = %v", err)
+				}
+				if result.RiskLevel != sqlLevel {
+					t.Fatalf("policy RiskLevel = %q, SQL risk_level = %q", result.RiskLevel, sqlLevel)
+				}
+			})
+		}
+	})
+}
+
+type credentialGoldenCase struct {
+	name          string
+	input         CredentialInput
+	wantLevel     string
+	wantSignalIDs []string
+}
+
+func credentialGoldenCases() []credentialGoldenCase {
+	now := time.Date(2026, 2, 7, 12, 0, 0, 0, time.UTC)
+	return []credentialGoldenCase{
+		{
+			name: "expired active credential",
+			input: CredentialInput{
+				Status:         "active",
+				CredentialKind: "vault_token",
+				ExpiresAt:      timePtr(now.Add(-24 * time.Hour)),
+				EvaluatedAt:    now,
+			},
+			wantLevel:     SeverityCritical,
+			wantSignalIDs: []string{"expired_active", "missing_creator"},
+		},
+		{
+			name: "expired inactive credential",
+			input: CredentialInput{
+				Status:         "revoked",
+				CredentialKind: "vault_token",
+				ExpiresAt:      timePtr(now.Add(-24 * time.Hour)),
+				EvaluatedAt:    now,
+			},
+			wantLevel:     SeverityHigh,
+			wantSignalIDs: []string{"expired_inactive", "missing_creator"},
+		},
+		{
+			name: "high privilege missing provenance",
+			input: CredentialInput{
+				Status:         "active",
+				CredentialKind: "github_pat_fine_grained",
+				EvaluatedAt:    now,
+			},
+			wantLevel:     SeverityCritical,
+			wantSignalIDs: []string{"high_privilege_missing_provenance", "missing_creator"},
+		},
+		{
+			name: "expiring within seven days",
+			input: CredentialInput{
+				Status:              "active",
+				CredentialKind:      "vault_token",
+				CreatedByExternalID: "alice",
+				ExpiresAt:           timePtr(now.Add(2 * 24 * time.Hour)),
+				EvaluatedAt:         now,
+			},
+			wantLevel:     SeverityHigh,
+			wantSignalIDs: []string{"expiring_within_7_days"},
+		},
+		{
+			name: "missing creator",
+			input: CredentialInput{
+				Status:         "active",
+				CredentialKind: "vault_token",
+				EvaluatedAt:    now,
+			},
+			wantLevel:     SeverityHigh,
+			wantSignalIDs: []string{"missing_creator"},
+		},
+		{
+			name: "unused over ninety days",
+			input: CredentialInput{
+				Status:              "active",
+				CredentialKind:      "vault_token",
+				CreatedByExternalID: "alice",
+				LastUsedAt:          timePtr(now.Add(-91 * 24 * time.Hour)),
+				EvaluatedAt:         now,
+			},
+			wantLevel:     SeverityHigh,
+			wantSignalIDs: []string{"unused_over_90_days"},
+		},
+		{
+			name: "expiring within thirty days",
+			input: CredentialInput{
+				Status:              "active",
+				CredentialKind:      "vault_token",
+				CreatedByExternalID: "alice",
+				ExpiresAt:           timePtr(now.Add(14 * 24 * time.Hour)),
+				EvaluatedAt:         now,
+			},
+			wantLevel:     SeverityMedium,
+			wantSignalIDs: []string{"expiring_within_30_days"},
+		},
+		{
+			name: "ordinary credential",
+			input: CredentialInput{
+				Status:              "active",
+				CredentialKind:      "vault_token",
+				CreatedByExternalID: "alice",
+				EvaluatedAt:         now,
+			},
+			wantLevel: SeverityLow,
+		},
+	}
+}
+
+func timePtr(value time.Time) *time.Time {
+	value = value.UTC()
+	return &value
+}
+
+func sameStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/riskpolicy/evaluator_test.go
+++ b/internal/riskpolicy/evaluator_test.go
@@ -41,10 +41,29 @@ func TestEvaluateCredentialGoldenCases(t *testing.T) {
 					t.Fatalf("signal missing source policy metadata: %+v", signal)
 				}
 			}
-			if !sameStrings(gotSignalIDs, tc.wantSignalIDs) {
+			if !sameStringSet(gotSignalIDs, tc.wantSignalIDs) {
 				t.Fatalf("signal IDs = %v, want %v", gotSignalIDs, tc.wantSignalIDs)
 			}
 		})
+	}
+}
+
+func TestEvaluateCredentialRejectsMalformedScopeJSON(t *testing.T) {
+	t.Parallel()
+
+	registry, err := LoadBuiltin()
+	if err != nil {
+		t.Fatalf("LoadBuiltin() error = %v", err)
+	}
+
+	_, err = registry.EvaluateCredential(CredentialInput{
+		CredentialKind:      "vault_token",
+		CreatedByExternalID: "alice",
+		ScopeJSON:           []byte(`{"broken":`),
+		EvaluatedAt:         time.Date(2026, 2, 7, 12, 0, 0, 0, time.UTC),
+	})
+	if err == nil {
+		t.Fatal("EvaluateCredential() error = nil, want malformed scope_json error")
 	}
 }
 
@@ -195,12 +214,17 @@ func timePtr(value time.Time) *time.Time {
 	return &value
 }
 
-func sameStrings(got, want []string) bool {
+func sameStringSet(got, want []string) bool {
 	if len(got) != len(want) {
 		return false
 	}
-	for i := range got {
-		if got[i] != want[i] {
+	counts := make(map[string]int, len(got))
+	for _, value := range got {
+		counts[value]++
+	}
+	for _, value := range want {
+		counts[value]--
+		if counts[value] < 0 {
 			return false
 		}
 	}

--- a/internal/riskpolicy/loader.go
+++ b/internal/riskpolicy/loader.go
@@ -8,12 +8,19 @@ import (
 	"io/fs"
 	"sort"
 	"strings"
+	"sync"
 
 	"gopkg.in/yaml.v3"
 )
 
 //go:embed policies/*.yaml
 var builtinPolicyFS embed.FS
+
+var (
+	builtinRegistryOnce sync.Once
+	builtinRegistry     *Registry
+	builtinRegistryErr  error
+)
 
 type Registry struct {
 	packs []CompiledPack
@@ -38,6 +45,13 @@ func LoadBuiltin() (*Registry, error) {
 		docs[name] = data
 	}
 	return LoadDocuments(docs)
+}
+
+func BuiltinRegistry() (*Registry, error) {
+	builtinRegistryOnce.Do(func() {
+		builtinRegistry, builtinRegistryErr = LoadBuiltin()
+	})
+	return builtinRegistry, builtinRegistryErr
 }
 
 func LoadDocuments(docs map[string][]byte) (*Registry, error) {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the hardcoded Go credential risk function with a CEL (Common Expression Language) policy engine that loads rules from embedded YAML files. CEL programs are now pre-compiled once at startup via a `sync.Once` singleton (`BuiltinRegistry`), and the handler layer has been cleanly separated into signal detection (CEL evaluation) and evidence formatting.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are P2 style/quality suggestions that do not block correctness.

The refactor is well-structured: CEL programs compile eagerly at startup, the singleton is safe under concurrency, the handler falls back gracefully, and golden-case + SQL-parity tests provide strong coverage. The two findings (silent JSON error swallowing and order-sensitive test helper) are minor quality concerns that don't affect current behavior.

internal/riskpolicy/evaluator.go (decodeScopeJSON silent error swallow), internal/riskpolicy/evaluator_test.go (order-sensitive sameStrings)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/riskpolicy/evaluator.go | New file: implements CEL-based credential risk evaluation; silently swallows JSON decode errors in decodeScopeJSON which could produce incorrect risk results for credentials with malformed scope data. |
| internal/riskpolicy/loader.go | Adds sync.Once singleton BuiltinRegistry() and preserves existing LoadDocuments/LoadBuiltin loading logic; error is permanently cached after first failure, which is appropriate for embedded YAML files. |
| internal/riskpolicy/cel.go | Pre-compiles CEL programs at load time with OptOptimize, eliminating per-request compilation overhead; clean change. |
| internal/http/handlers/programmatic_access.go | Replaces hardcoded Go risk logic with CEL evaluation; adds fallback to BuiltinRegistry() when h.RiskPolicies is nil (for test ergonomics); separates signal detection from evidence formatting cleanly. |
| internal/http/server.go | Initializes RiskPolicies from BuiltinRegistry() at startup and injects into Handlers; server fails fast if policy loading fails. |
| internal/riskpolicy/evaluator_test.go | New golden-case and SQL-parity tests; sameStrings helper does order-sensitive comparison that couples test expectations to YAML rule ordering. |
| internal/http/handlers/programmatic_access_test.go | Test updated to use the new evaluateCredentialRisk path; straightforward migration, no issues. |
| internal/http/handlers/base.go | Adds RiskPolicies *riskpolicy.Registry field to Handlers struct; clean change. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant S as NewEchoServer
    participant L as loader.go
    participant H as HandleCredentialShow
    participant E as evaluator.go
    participant CEL as CEL Engine

    S->>L: BuiltinRegistry() [sync.Once]
    L->>L: LoadBuiltin() – embed YAML files
    L->>CEL: compilePack() – pre-compile programs
    L-->>S: *Registry

    S->>H: inject h.RiskPolicies

    H->>E: evaluateCredentialRisk(credential, now)
    E->>E: normalizeCredentialInput()
    E->>E: credentialActivation()
    loop each rule in pack.Spec.Rules
        E->>CEL: program.Eval(activation)
        CEL-->>E: bool result
    end
    E-->>H: CredentialResult{RiskLevel, Signals}
    H->>H: credentialRiskFindingsFromSignals(signals, ...)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/riskpolicy/evaluator.go
Line: 202-211

Comment:
**Silent JSON decode failure in `decodeScopeJSON`**

When the DB column contains malformed JSON, `json.Unmarshal` fails and the function silently returns an empty `map[string]any{}`. Any CEL rule that evaluates `scope_json` field accesses will then silently operate on empty data rather than returning an error, potentially producing incorrect (under-reported) risk signals with no indication that the input was bad.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/riskpolicy/evaluator_test.go
Line: 193-207

Comment:
**Order-sensitive signal ID comparison**

`sameStrings` compares signal IDs by position, and the golden cases encode explicit orderings (e.g. `["expired_active", "missing_creator"]`). Signal order is determined by rule declaration order in the YAML policy files — reordering rules there will silently break these tests without any hint as to why. Consider either sorting both slices before comparison, or using a set-equality check, so the tests stay green under YAML restructuring.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: ruleset separate yaml files m2"](https://github.com/open-sspm/open-sspm/commit/1dc76e76786e83484105c02d9f8a333957106db6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29650408)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->