### PR TITLE
feat: risk eval config m3

### DIFF
--- a/cmd/open-sspm/read_models.go
+++ b/cmd/open-sspm/read_models.go
@@ -37,8 +37,11 @@ func rebuildStoredReadModels(ctx context.Context, pool *pgxpool.Pool, q *gen.Que
 
 	switch action {
 	case startupReadModelsActionRefreshConnectorState:
-		slog.Info("refreshing connector source state on startup")
-		return projector.RefreshConnectorSourceState(ctx)
+		slog.Info("refreshing connector source state and SaaS risk read models on startup")
+		if err := projector.RefreshConnectorSourceState(ctx); err != nil {
+			return err
+		}
+		return projector.RefreshAllSaaSAppRiskReadModels(ctx)
 	case startupReadModelsActionRebuildAll:
 		reason := "forced"
 		if needsRebuild {

--- a/db/migrations/000048_saas_app_risk_read_models.down.sql
+++ b/db/migrations/000048_saas_app_risk_read_models.down.sql
@@ -1,0 +1,145 @@
+CREATE OR REPLACE VIEW discovery_app_read_models_v AS
+WITH primary_bindings AS (
+  SELECT DISTINCT ON (b.saas_app_id)
+    b.saas_app_id,
+    lower(trim(b.connector_kind)) AS connector_kind,
+    trim(b.connector_source_name) AS connector_source_name
+  FROM saas_app_bindings b
+  WHERE b.is_primary
+  ORDER BY b.saas_app_id, b.id ASC
+),
+posture_base AS (
+  SELECT
+    sa.id,
+    sa.canonical_key,
+    sa.display_name,
+    sa.primary_domain,
+    sa.vendor_name,
+    sa.first_seen_at,
+    sa.last_seen_at,
+    sa.created_at,
+    sa.updated_at,
+    COALESCE(go.owner_identity_id, 0)::bigint AS owner_identity_id,
+    COALESCE(owner.display_name, '')::text AS owner_display_name,
+    COALESCE(owner.primary_email, '')::text AS owner_primary_email,
+    COALESCE(go.review_owner_identity_id, 0)::bigint AS review_owner_identity_id,
+    COALESCE(review_owner.display_name, '')::text AS review_owner_display_name,
+    COALESCE(review_owner.primary_email, '')::text AS review_owner_primary_email,
+    sa.actors_30d::bigint AS actors_30d,
+    sa.has_privileged_scope::boolean AS has_privileged_scope,
+    sa.has_confidential_scope::boolean AS has_confidential_scope,
+    COALESCE(pb.connector_kind, '')::text AS bound_connector_kind,
+    COALESCE(pb.connector_source_name, '')::text AS bound_connector_source_name,
+    COALESCE(css.enabled, false)::boolean AS connector_enabled,
+    COALESCE(css.configured, false)::boolean AS connector_configured,
+    css.last_success_at::timestamptz AS last_success_at,
+    css.fresh_until_at::timestamptz AS fresh_until_at,
+    CASE
+      WHEN sa.actors_30d >= 200 THEN 'critical'
+      WHEN sa.actors_30d >= 50 OR sa.has_privileged_scope THEN 'high'
+      WHEN sa.actors_30d >= 10 THEN 'medium'
+      ELSE 'low'
+    END AS suggested_business_criticality,
+    CASE
+      WHEN sa.has_privileged_scope THEN 'restricted'
+      WHEN sa.has_confidential_scope THEN 'confidential'
+      ELSE 'internal'
+    END AS suggested_data_classification,
+    CASE lower(trim(COALESCE(go.business_criticality, '')))
+      WHEN 'low' THEN 'low'
+      WHEN 'medium' THEN 'medium'
+      WHEN 'high' THEN 'high'
+      WHEN 'critical' THEN 'critical'
+      ELSE CASE
+        WHEN sa.actors_30d >= 200 THEN 'critical'
+        WHEN sa.actors_30d >= 50 OR sa.has_privileged_scope THEN 'high'
+        WHEN sa.actors_30d >= 10 THEN 'medium'
+        ELSE 'low'
+      END
+    END AS effective_business_criticality,
+    CASE lower(trim(COALESCE(go.data_classification, '')))
+      WHEN 'public' THEN 'public'
+      WHEN 'internal' THEN 'internal'
+      WHEN 'confidential' THEN 'confidential'
+      WHEN 'restricted' THEN 'restricted'
+      ELSE CASE
+        WHEN sa.has_privileged_scope THEN 'restricted'
+        WHEN sa.has_confidential_scope THEN 'confidential'
+        ELSE 'internal'
+      END
+    END AS effective_data_classification,
+    COALESCE(go.governance_state, 'unreviewed')::text AS governance_state,
+    COALESCE(go.review_disposition, 'unreviewed')::text AS review_disposition,
+    COALESCE(go.ticket_ref, '')::text AS ticket_ref,
+    COALESCE(go.notes, '')::text AS notes,
+    go.follow_up_due_date::date AS follow_up_due_date,
+    COALESCE(go.follow_up_due_date < CURRENT_DATE, false)::boolean AS is_follow_up_overdue,
+    COALESCE(go.replacement_saas_app_id, 0)::bigint AS replacement_saas_app_id,
+    COALESCE(NULLIF(trim(replacement.display_name), ''), replacement.canonical_key, '')::text AS replacement_display_name,
+    COALESCE(replacement.primary_domain, '')::text AS replacement_primary_domain
+  FROM saas_apps sa
+  LEFT JOIN governance_subject_overrides go
+    ON go.subject_kind = 'saas_app'
+   AND go.subject_id = sa.id
+  LEFT JOIN identities owner
+    ON owner.id = go.owner_identity_id
+  LEFT JOIN identities review_owner
+    ON review_owner.id = go.review_owner_identity_id
+  LEFT JOIN saas_apps replacement
+    ON replacement.id = go.replacement_saas_app_id
+  LEFT JOIN primary_bindings pb
+    ON pb.saas_app_id = sa.id
+  LEFT JOIN connector_source_state css
+    ON css.source_kind = CASE COALESCE(pb.connector_kind, '')
+      WHEN 'aws_identity_center' THEN 'aws'
+      ELSE COALESCE(pb.connector_kind, '')
+    END
+   AND lower(trim(css.source_name)) = lower(COALESCE(pb.connector_source_name, ''))
+),
+posture_state AS (
+  SELECT
+    pb.*,
+    CASE
+      WHEN pb.bound_connector_kind = '' OR pb.bound_connector_source_name = '' THEN 'unmanaged'
+      WHEN NOT pb.connector_configured THEN 'unmanaged'
+      WHEN NOT pb.connector_enabled THEN 'unmanaged'
+      WHEN pb.last_success_at IS NULL THEN 'unmanaged'
+      WHEN pb.fresh_until_at IS NULL THEN 'unmanaged'
+      WHEN pb.fresh_until_at < now() THEN 'unmanaged'
+      ELSE 'managed'
+    END AS managed_state,
+    CASE
+      WHEN pb.bound_connector_kind = '' OR pb.bound_connector_source_name = '' THEN 'no_binding'
+      WHEN NOT pb.connector_configured THEN 'connector_not_configured'
+      WHEN NOT pb.connector_enabled THEN 'connector_disabled'
+      WHEN pb.last_success_at IS NULL THEN 'stale_sync'
+      WHEN pb.fresh_until_at IS NULL THEN 'stale_sync'
+      WHEN pb.fresh_until_at < now() THEN 'stale_sync'
+      ELSE 'active_binding_fresh_sync'
+    END AS managed_reason
+  FROM posture_base pb
+),
+scored AS (
+  SELECT
+    ps.*,
+    LEAST(100,
+      CASE WHEN ps.managed_state <> 'managed' THEN 45 ELSE 0 END
+      + CASE WHEN ps.has_privileged_scope THEN 20 ELSE 0 END
+      + CASE WHEN ps.owner_identity_id = 0 THEN 15 ELSE 0 END
+      + CASE WHEN ps.actors_30d >= 50 THEN 10 ELSE 0 END
+      + CASE WHEN ps.managed_state <> 'managed' AND ps.effective_business_criticality IN ('high', 'critical') THEN 10 ELSE 0 END
+      + CASE WHEN ps.managed_state <> 'managed' AND ps.effective_data_classification IN ('confidential', 'restricted') THEN 5 ELSE 0 END
+    )::int AS risk_score
+  FROM posture_state ps
+)
+SELECT
+  scored.*,
+  CASE
+    WHEN scored.risk_score >= 80 THEN 'critical'
+    WHEN scored.risk_score >= 60 THEN 'high'
+    WHEN scored.risk_score >= 30 THEN 'medium'
+    ELSE 'low'
+  END AS risk_level
+FROM scored;
+
+DROP TABLE IF EXISTS saas_app_risk_read_models;

--- a/db/migrations/000048_saas_app_risk_read_models.up.sql
+++ b/db/migrations/000048_saas_app_risk_read_models.up.sql
@@ -1,0 +1,190 @@
+CREATE TABLE IF NOT EXISTS saas_app_risk_read_models (
+  saas_app_id BIGINT PRIMARY KEY REFERENCES saas_apps(id) ON DELETE CASCADE,
+  risk_score INT NOT NULL DEFAULT 0,
+  risk_level TEXT NOT NULL DEFAULT 'low',
+  risk_rank INT NOT NULL DEFAULT 1,
+  suggested_business_criticality TEXT NOT NULL DEFAULT 'low',
+  suggested_data_classification TEXT NOT NULL DEFAULT 'internal',
+  effective_business_criticality TEXT NOT NULL DEFAULT 'low',
+  effective_data_classification TEXT NOT NULL DEFAULT 'internal',
+  policy_packs_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  projection_refreshed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT saas_app_risk_read_models_score_check CHECK (risk_score >= 0 AND risk_score <= 100),
+  CONSTRAINT saas_app_risk_read_models_level_check CHECK (risk_level IN ('low', 'medium', 'high', 'critical')),
+  CONSTRAINT saas_app_risk_read_models_rank_check CHECK (risk_rank >= 1),
+  CONSTRAINT saas_app_risk_read_models_suggested_business_check CHECK (
+    suggested_business_criticality IN ('low', 'medium', 'high', 'critical')
+  ),
+  CONSTRAINT saas_app_risk_read_models_suggested_data_check CHECK (
+    suggested_data_classification IN ('public', 'internal', 'confidential', 'restricted')
+  ),
+  CONSTRAINT saas_app_risk_read_models_effective_business_check CHECK (
+    effective_business_criticality IN ('low', 'medium', 'high', 'critical')
+  ),
+  CONSTRAINT saas_app_risk_read_models_effective_data_check CHECK (
+    effective_data_classification IN ('public', 'internal', 'confidential', 'restricted')
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_saas_app_risk_read_models_level_score
+  ON saas_app_risk_read_models (risk_level, risk_score DESC, saas_app_id);
+
+CREATE INDEX IF NOT EXISTS idx_saas_app_risk_read_models_score
+  ON saas_app_risk_read_models (risk_score DESC, saas_app_id);
+
+CREATE OR REPLACE VIEW discovery_app_read_models_v AS
+WITH primary_bindings AS (
+  SELECT DISTINCT ON (b.saas_app_id)
+    b.saas_app_id,
+    lower(trim(b.connector_kind)) AS connector_kind,
+    trim(b.connector_source_name) AS connector_source_name
+  FROM saas_app_bindings b
+  WHERE b.is_primary
+  ORDER BY b.saas_app_id, b.id ASC
+),
+posture_base AS (
+  SELECT
+    sa.id,
+    sa.canonical_key,
+    sa.display_name,
+    sa.primary_domain,
+    sa.vendor_name,
+    sa.first_seen_at,
+    sa.last_seen_at,
+    sa.created_at,
+    sa.updated_at,
+    COALESCE(go.owner_identity_id, 0)::bigint AS owner_identity_id,
+    COALESCE(owner.display_name, '')::text AS owner_display_name,
+    COALESCE(owner.primary_email, '')::text AS owner_primary_email,
+    COALESCE(go.review_owner_identity_id, 0)::bigint AS review_owner_identity_id,
+    COALESCE(review_owner.display_name, '')::text AS review_owner_display_name,
+    COALESCE(review_owner.primary_email, '')::text AS review_owner_primary_email,
+    sa.actors_30d::bigint AS actors_30d,
+    sa.has_privileged_scope::boolean AS has_privileged_scope,
+    sa.has_confidential_scope::boolean AS has_confidential_scope,
+    COALESCE(pb.connector_kind, '')::text AS bound_connector_kind,
+    COALESCE(pb.connector_source_name, '')::text AS bound_connector_source_name,
+    COALESCE(css.enabled, false)::boolean AS connector_enabled,
+    COALESCE(css.configured, false)::boolean AS connector_configured,
+    css.last_success_at::timestamptz AS last_success_at,
+    css.fresh_until_at::timestamptz AS fresh_until_at,
+    COALESCE(risk.suggested_business_criticality, 'low')::text AS suggested_business_criticality,
+    COALESCE(risk.suggested_data_classification, 'internal')::text AS suggested_data_classification,
+    COALESCE(
+      risk.effective_business_criticality,
+      CASE lower(trim(COALESCE(go.business_criticality, '')))
+        WHEN 'low' THEN 'low'
+        WHEN 'medium' THEN 'medium'
+        WHEN 'high' THEN 'high'
+        WHEN 'critical' THEN 'critical'
+        ELSE 'low'
+      END
+    )::text AS effective_business_criticality,
+    COALESCE(
+      risk.effective_data_classification,
+      CASE lower(trim(COALESCE(go.data_classification, '')))
+        WHEN 'public' THEN 'public'
+        WHEN 'internal' THEN 'internal'
+        WHEN 'confidential' THEN 'confidential'
+        WHEN 'restricted' THEN 'restricted'
+        ELSE 'internal'
+      END
+    )::text AS effective_data_classification,
+    COALESCE(go.governance_state, 'unreviewed')::text AS governance_state,
+    COALESCE(go.review_disposition, 'unreviewed')::text AS review_disposition,
+    COALESCE(go.ticket_ref, '')::text AS ticket_ref,
+    COALESCE(go.notes, '')::text AS notes,
+    go.follow_up_due_date::date AS follow_up_due_date,
+    COALESCE(go.follow_up_due_date < CURRENT_DATE, false)::boolean AS is_follow_up_overdue,
+    COALESCE(go.replacement_saas_app_id, 0)::bigint AS replacement_saas_app_id,
+    COALESCE(NULLIF(trim(replacement.display_name), ''), replacement.canonical_key, '')::text AS replacement_display_name,
+    COALESCE(replacement.primary_domain, '')::text AS replacement_primary_domain,
+    COALESCE(risk.risk_score, 0)::int AS risk_score,
+    COALESCE(risk.risk_level, 'low')::text AS risk_level
+  FROM saas_apps sa
+  LEFT JOIN governance_subject_overrides go
+    ON go.subject_kind = 'saas_app'
+   AND go.subject_id = sa.id
+  LEFT JOIN identities owner
+    ON owner.id = go.owner_identity_id
+  LEFT JOIN identities review_owner
+    ON review_owner.id = go.review_owner_identity_id
+  LEFT JOIN saas_apps replacement
+    ON replacement.id = go.replacement_saas_app_id
+  LEFT JOIN primary_bindings pb
+    ON pb.saas_app_id = sa.id
+  LEFT JOIN connector_source_state css
+    ON css.source_kind = CASE COALESCE(pb.connector_kind, '')
+      WHEN 'aws_identity_center' THEN 'aws'
+      ELSE COALESCE(pb.connector_kind, '')
+    END
+   AND lower(trim(css.source_name)) = lower(COALESCE(pb.connector_source_name, ''))
+  LEFT JOIN saas_app_risk_read_models risk
+    ON risk.saas_app_id = sa.id
+),
+posture_state AS (
+  SELECT
+    pb.*,
+    CASE
+      WHEN pb.bound_connector_kind = '' OR pb.bound_connector_source_name = '' THEN 'unmanaged'
+      WHEN NOT pb.connector_configured THEN 'unmanaged'
+      WHEN NOT pb.connector_enabled THEN 'unmanaged'
+      WHEN pb.last_success_at IS NULL THEN 'unmanaged'
+      WHEN pb.fresh_until_at IS NULL THEN 'unmanaged'
+      WHEN pb.fresh_until_at < now() THEN 'unmanaged'
+      ELSE 'managed'
+    END AS managed_state,
+    CASE
+      WHEN pb.bound_connector_kind = '' OR pb.bound_connector_source_name = '' THEN 'no_binding'
+      WHEN NOT pb.connector_configured THEN 'connector_not_configured'
+      WHEN NOT pb.connector_enabled THEN 'connector_disabled'
+      WHEN pb.last_success_at IS NULL THEN 'stale_sync'
+      WHEN pb.fresh_until_at IS NULL THEN 'stale_sync'
+      WHEN pb.fresh_until_at < now() THEN 'stale_sync'
+      ELSE 'active_binding_fresh_sync'
+    END AS managed_reason
+  FROM posture_base pb
+)
+SELECT
+  ps.id,
+  ps.canonical_key,
+  ps.display_name,
+  ps.primary_domain,
+  ps.vendor_name,
+  ps.first_seen_at,
+  ps.last_seen_at,
+  ps.created_at,
+  ps.updated_at,
+  ps.owner_identity_id,
+  ps.owner_display_name,
+  ps.owner_primary_email,
+  ps.review_owner_identity_id,
+  ps.review_owner_display_name,
+  ps.review_owner_primary_email,
+  ps.actors_30d,
+  ps.has_privileged_scope,
+  ps.has_confidential_scope,
+  ps.bound_connector_kind,
+  ps.bound_connector_source_name,
+  ps.connector_enabled,
+  ps.connector_configured,
+  ps.last_success_at,
+  ps.fresh_until_at,
+  ps.suggested_business_criticality,
+  ps.suggested_data_classification,
+  ps.effective_business_criticality,
+  ps.effective_data_classification,
+  ps.governance_state,
+  ps.review_disposition,
+  ps.ticket_ref,
+  ps.notes,
+  ps.follow_up_due_date,
+  ps.is_follow_up_overdue,
+  ps.replacement_saas_app_id,
+  ps.replacement_display_name,
+  ps.replacement_primary_domain,
+  ps.managed_state,
+  ps.managed_reason,
+  ps.risk_score,
+  ps.risk_level
+FROM posture_state ps;

--- a/db/queries/read_models.sql
+++ b/db/queries/read_models.sql
@@ -64,6 +64,14 @@ SELECT (
   )
   OR EXISTS (
     SELECT 1
+    FROM saas_apps sa
+    LEFT JOIN saas_app_risk_read_models risk
+      ON risk.saas_app_id = sa.id
+    WHERE risk.saas_app_id IS NULL
+      OR risk.projection_refreshed_at IS NULL
+  )
+  OR EXISTS (
+    SELECT 1
     FROM app_assets aa
     WHERE aa.projection_refreshed_at IS NULL
   )
@@ -92,6 +100,153 @@ SELECT (
     )
   )
 )::bool AS needs_rebuild;
+
+-- name: ListAllSaaSAppRiskInputs :many
+SELECT
+  pr.id::bigint AS saas_app_id,
+  pr.canonical_key::text AS canonical_key,
+  pr.display_name::text AS display_name,
+  pr.primary_domain::text AS primary_domain,
+  pr.vendor_name::text AS vendor_name,
+  pr.bound_connector_kind::text AS source_kind,
+  pr.bound_connector_source_name::text AS source_name,
+  pr.actors_30d::bigint AS actors_30d,
+  pr.has_privileged_scope::boolean AS has_privileged_scope,
+  pr.has_confidential_scope::boolean AS has_confidential_scope,
+  pr.managed_state::text AS managed_state,
+  pr.managed_reason::text AS managed_reason,
+  pr.owner_identity_id::bigint AS owner_identity_id,
+  pr.governance_state::text AS governance_state,
+  pr.review_disposition::text AS review_disposition,
+  pr.follow_up_due_date::date AS follow_up_due_date,
+  COALESCE(NULLIF(trim(go.business_criticality), ''), 'unknown')::text AS configured_business_criticality,
+  COALESCE(NULLIF(trim(go.data_classification), ''), 'unknown')::text AS configured_data_classification,
+  pr.connector_configured::boolean AS connector_binding_configured,
+  pr.connector_enabled::boolean AS connector_binding_enabled,
+  COALESCE(pr.fresh_until_at < now(), false)::boolean AS connector_binding_stale,
+  (pr.managed_state = 'managed')::boolean AS connector_binding_healthy
+FROM discovery_app_read_models_v pr
+LEFT JOIN governance_subject_overrides go
+  ON go.subject_kind = 'saas_app'
+ AND go.subject_id = pr.id
+ORDER BY pr.id ASC;
+
+-- name: ListSaaSAppRiskInputsBySource :many
+SELECT
+  pr.id::bigint AS saas_app_id,
+  pr.canonical_key::text AS canonical_key,
+  pr.display_name::text AS display_name,
+  pr.primary_domain::text AS primary_domain,
+  pr.vendor_name::text AS vendor_name,
+  pr.bound_connector_kind::text AS source_kind,
+  pr.bound_connector_source_name::text AS source_name,
+  pr.actors_30d::bigint AS actors_30d,
+  pr.has_privileged_scope::boolean AS has_privileged_scope,
+  pr.has_confidential_scope::boolean AS has_confidential_scope,
+  pr.managed_state::text AS managed_state,
+  pr.managed_reason::text AS managed_reason,
+  pr.owner_identity_id::bigint AS owner_identity_id,
+  pr.governance_state::text AS governance_state,
+  pr.review_disposition::text AS review_disposition,
+  pr.follow_up_due_date::date AS follow_up_due_date,
+  COALESCE(NULLIF(trim(go.business_criticality), ''), 'unknown')::text AS configured_business_criticality,
+  COALESCE(NULLIF(trim(go.data_classification), ''), 'unknown')::text AS configured_data_classification,
+  pr.connector_configured::boolean AS connector_binding_configured,
+  pr.connector_enabled::boolean AS connector_binding_enabled,
+  COALESCE(pr.fresh_until_at < now(), false)::boolean AS connector_binding_stale,
+  (pr.managed_state = 'managed')::boolean AS connector_binding_healthy
+FROM discovery_app_read_models_v pr
+LEFT JOIN governance_subject_overrides go
+  ON go.subject_kind = 'saas_app'
+ AND go.subject_id = pr.id
+WHERE EXISTS (
+  SELECT 1
+  FROM saas_app_sources sas
+  WHERE sas.saas_app_id = pr.id
+    AND lower(trim(sas.source_kind)) = lower(trim(sqlc.arg(source_kind)::text))
+    AND lower(trim(sas.source_name)) = lower(trim(sqlc.arg(source_name)::text))
+)
+ORDER BY pr.id ASC;
+
+-- name: GetSaaSAppRiskInputByID :one
+SELECT
+  pr.id::bigint AS saas_app_id,
+  pr.canonical_key::text AS canonical_key,
+  pr.display_name::text AS display_name,
+  pr.primary_domain::text AS primary_domain,
+  pr.vendor_name::text AS vendor_name,
+  pr.bound_connector_kind::text AS source_kind,
+  pr.bound_connector_source_name::text AS source_name,
+  pr.actors_30d::bigint AS actors_30d,
+  pr.has_privileged_scope::boolean AS has_privileged_scope,
+  pr.has_confidential_scope::boolean AS has_confidential_scope,
+  pr.managed_state::text AS managed_state,
+  pr.managed_reason::text AS managed_reason,
+  pr.owner_identity_id::bigint AS owner_identity_id,
+  pr.governance_state::text AS governance_state,
+  pr.review_disposition::text AS review_disposition,
+  pr.follow_up_due_date::date AS follow_up_due_date,
+  COALESCE(NULLIF(trim(go.business_criticality), ''), 'unknown')::text AS configured_business_criticality,
+  COALESCE(NULLIF(trim(go.data_classification), ''), 'unknown')::text AS configured_data_classification,
+  pr.connector_configured::boolean AS connector_binding_configured,
+  pr.connector_enabled::boolean AS connector_binding_enabled,
+  COALESCE(pr.fresh_until_at < now(), false)::boolean AS connector_binding_stale,
+  (pr.managed_state = 'managed')::boolean AS connector_binding_healthy
+FROM discovery_app_read_models_v pr
+LEFT JOIN governance_subject_overrides go
+  ON go.subject_kind = 'saas_app'
+ AND go.subject_id = pr.id
+WHERE pr.id = sqlc.arg(saas_app_id)::bigint;
+
+-- name: UpsertSaaSAppRiskReadModelsBulk :execrows
+WITH input AS (
+  SELECT
+    i,
+    (sqlc.arg(saas_app_ids)::bigint[])[i] AS saas_app_id,
+    (sqlc.arg(risk_scores)::int[])[i] AS risk_score,
+    (sqlc.arg(risk_levels)::text[])[i] AS risk_level,
+    (sqlc.arg(risk_ranks)::int[])[i] AS risk_rank,
+    (sqlc.arg(suggested_business_criticalities)::text[])[i] AS suggested_business_criticality,
+    (sqlc.arg(suggested_data_classifications)::text[])[i] AS suggested_data_classification,
+    (sqlc.arg(effective_business_criticalities)::text[])[i] AS effective_business_criticality,
+    (sqlc.arg(effective_data_classifications)::text[])[i] AS effective_data_classification,
+    (sqlc.arg(policy_packs_jsons)::jsonb[])[i] AS policy_packs_json
+  FROM generate_subscripts(sqlc.arg(saas_app_ids)::bigint[], 1) AS s(i)
+)
+INSERT INTO saas_app_risk_read_models (
+  saas_app_id,
+  risk_score,
+  risk_level,
+  risk_rank,
+  suggested_business_criticality,
+  suggested_data_classification,
+  effective_business_criticality,
+  effective_data_classification,
+  policy_packs_json,
+  projection_refreshed_at
+)
+SELECT
+  input.saas_app_id,
+  input.risk_score,
+  input.risk_level,
+  input.risk_rank,
+  input.suggested_business_criticality,
+  input.suggested_data_classification,
+  input.effective_business_criticality,
+  input.effective_data_classification,
+  input.policy_packs_json,
+  now()
+FROM input
+ON CONFLICT (saas_app_id) DO UPDATE SET
+  risk_score = EXCLUDED.risk_score,
+  risk_level = EXCLUDED.risk_level,
+  risk_rank = EXCLUDED.risk_rank,
+  suggested_business_criticality = EXCLUDED.suggested_business_criticality,
+  suggested_data_classification = EXCLUDED.suggested_data_classification,
+  effective_business_criticality = EXCLUDED.effective_business_criticality,
+  effective_data_classification = EXCLUDED.effective_data_classification,
+  policy_packs_json = EXCLUDED.policy_packs_json,
+  projection_refreshed_at = now();
 
 -- name: RefreshAllSaaSAppReadModels :execrows
 WITH actor_stats AS (

--- a/db/queries/read_models.sql
+++ b/db/queries/read_models.sql
@@ -68,7 +68,6 @@ SELECT (
     LEFT JOIN saas_app_risk_read_models risk
       ON risk.saas_app_id = sa.id
     WHERE risk.saas_app_id IS NULL
-      OR risk.projection_refreshed_at IS NULL
   )
   OR EXISTS (
     SELECT 1
@@ -126,6 +125,8 @@ SELECT
   COALESCE(pr.fresh_until_at < now(), false)::boolean AS connector_binding_stale,
   (pr.managed_state = 'managed')::boolean AS connector_binding_healthy
 FROM discovery_app_read_models_v pr
+-- Re-read governance overrides directly because the risk evaluator needs raw
+-- configured values; discovery_app_read_models_v exposes resolved effective values.
 LEFT JOIN governance_subject_overrides go
   ON go.subject_kind = 'saas_app'
  AND go.subject_id = pr.id
@@ -156,6 +157,8 @@ SELECT
   COALESCE(pr.fresh_until_at < now(), false)::boolean AS connector_binding_stale,
   (pr.managed_state = 'managed')::boolean AS connector_binding_healthy
 FROM discovery_app_read_models_v pr
+-- Re-read governance overrides directly because the risk evaluator needs raw
+-- configured values; discovery_app_read_models_v exposes resolved effective values.
 LEFT JOIN governance_subject_overrides go
   ON go.subject_kind = 'saas_app'
  AND go.subject_id = pr.id
@@ -193,6 +196,8 @@ SELECT
   COALESCE(pr.fresh_until_at < now(), false)::boolean AS connector_binding_stale,
   (pr.managed_state = 'managed')::boolean AS connector_binding_healthy
 FROM discovery_app_read_models_v pr
+-- Re-read governance overrides directly because the risk evaluator needs raw
+-- configured values; discovery_app_read_models_v exposes resolved effective values.
 LEFT JOIN governance_subject_overrides go
   ON go.subject_kind = 'saas_app'
  AND go.subject_id = pr.id

--- a/db/queries/saas_apps.sql
+++ b/db/queries/saas_apps.sql
@@ -236,7 +236,7 @@ SELECT
   pr.ticket_ref::text AS ticket_ref,
   pr.actors_30d::bigint AS actors_30d
 FROM discovery_app_read_models_v pr
-WHERE pr.risk_score >= 60
+WHERE pr.risk_level IN ('high', 'critical')
   AND EXISTS (
     SELECT 1
     FROM saas_app_sources sas

--- a/internal/connectors/registry/helpers.go
+++ b/internal/connectors/registry/helpers.go
@@ -551,6 +551,9 @@ func refreshPostSuccessReadModelsInTx(ctx context.Context, q *gen.Queries, sourc
 	if err := refreshConnectorSourceStateInTx(ctx, q); err != nil {
 		return err
 	}
+	if err := refreshSaaSAppRiskReadModelsInTx(ctx, q, sourceKind, sourceName); err != nil {
+		return err
+	}
 	return refreshNonHumanPrincipalReadModelsInTx(ctx, q, sourceKind, sourceName)
 }
 
@@ -560,6 +563,14 @@ func refreshConnectorSourceStateInTx(ctx context.Context, q *gen.Queries) error 
 		return nil
 	}
 	return projector.RefreshConnectorSourceState(ctx)
+}
+
+func refreshSaaSAppRiskReadModelsInTx(ctx context.Context, q *gen.Queries, sourceKind, sourceName string) error {
+	projector := readmodels.ProjectorFromContext(ctx, q)
+	if projector == nil {
+		return nil
+	}
+	return projector.RefreshSaaSAppRiskReadModelsBySource(ctx, sourceKind, sourceName)
 }
 
 func refreshNonHumanPrincipalReadModelsInTx(ctx context.Context, q *gen.Queries, sourceKind, sourceName string) error {

--- a/internal/db/gen/models.go
+++ b/internal/db/gen/models.go
@@ -241,8 +241,8 @@ type DiscoveryAppReadModelsV struct {
 	FreshUntilAt                 pgtype.Timestamptz `json:"fresh_until_at"`
 	SuggestedBusinessCriticality string             `json:"suggested_business_criticality"`
 	SuggestedDataClassification  string             `json:"suggested_data_classification"`
-	EffectiveBusinessCriticality interface{}        `json:"effective_business_criticality"`
-	EffectiveDataClassification  interface{}        `json:"effective_data_classification"`
+	EffectiveBusinessCriticality string             `json:"effective_business_criticality"`
+	EffectiveDataClassification  string             `json:"effective_data_classification"`
 	GovernanceState              string             `json:"governance_state"`
 	ReviewDisposition            string             `json:"review_disposition"`
 	TicketRef                    string             `json:"ticket_ref"`
@@ -695,6 +695,19 @@ type SaasAppReviewDecision struct {
 	ReplacementSaasAppID  pgtype.Int8        `json:"replacement_saas_app_id"`
 	ChangedByAuthUserID   pgtype.Int8        `json:"changed_by_auth_user_id"`
 	ChangedAt             pgtype.Timestamptz `json:"changed_at"`
+}
+
+type SaasAppRiskReadModel struct {
+	SaasAppID                    int64              `json:"saas_app_id"`
+	RiskScore                    int32              `json:"risk_score"`
+	RiskLevel                    string             `json:"risk_level"`
+	RiskRank                     int32              `json:"risk_rank"`
+	SuggestedBusinessCriticality string             `json:"suggested_business_criticality"`
+	SuggestedDataClassification  string             `json:"suggested_data_classification"`
+	EffectiveBusinessCriticality string             `json:"effective_business_criticality"`
+	EffectiveDataClassification  string             `json:"effective_data_classification"`
+	PolicyPacksJson              []byte             `json:"policy_packs_json"`
+	ProjectionRefreshedAt        pgtype.Timestamptz `json:"projection_refreshed_at"`
 }
 
 type SaasAppSource struct {

--- a/internal/db/gen/programmatic_access_integration_test.go
+++ b/internal/db/gen/programmatic_access_integration_test.go
@@ -604,6 +604,7 @@ func TestDiscoveryAppReadModelReadsReviewGovernance(t *testing.T) {
 		if _, err := q.RefreshAllSaaSAppReadModels(ctx); err != nil {
 			t.Fatalf("RefreshAllSaaSAppReadModels(): %v", err)
 		}
+		upsertSaaSAppRiskReadModel(t, ctx, pool, saasAppID, 65, "high")
 
 		row, err := q.GetSaaSAppByID(ctx, saasAppID)
 		if err != nil {
@@ -630,6 +631,76 @@ func TestDiscoveryAppReadModelReadsReviewGovernance(t *testing.T) {
 		}
 		if row.RiskLevel != "high" {
 			t.Fatalf("risk_level=%q want high", row.RiskLevel)
+		}
+	})
+}
+
+func TestListSaaSAppHotspotsUsesStoredPolicyRiskLevel(t *testing.T) {
+	t.Parallel()
+
+	withEntityCategoryTestDatabase(t, func(ctx context.Context, pool *pgxpool.Pool, q *Queries, migrator *migrate.Migrate) {
+		migrateUp(t, migrator)
+
+		evaluatedAt := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+		runID := insertSyncRun(t, ctx, pool, "github", "acme")
+
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO connector_source_state (
+				source_kind,
+				source_name,
+				enabled,
+				configured,
+				discovery_enabled,
+				last_success_at,
+				fresh_until_at,
+				updated_at
+			)
+			VALUES ($1, $2, true, true, true, $3, $4, now())
+			ON CONFLICT (source_kind, source_name) DO UPDATE SET
+				enabled = EXCLUDED.enabled,
+				configured = EXCLUDED.configured,
+				discovery_enabled = EXCLUDED.discovery_enabled,
+				last_success_at = EXCLUDED.last_success_at,
+				fresh_until_at = EXCLUDED.fresh_until_at,
+				updated_at = now()
+		`, "github", "acme", evaluatedAt.Add(-30*time.Minute), evaluatedAt.Add(2*time.Hour)); err != nil {
+			t.Fatalf("insert connector_source_state: %v", err)
+		}
+
+		criticalID := insertSaaSApp(t, ctx, pool, "critical-policy-hotspot", "Critical Policy Hotspot", "critical.example.com", "Example", evaluatedAt.Add(-72*time.Hour), evaluatedAt.Add(-2*time.Hour))
+		highID := insertSaaSApp(t, ctx, pool, "high-policy-hotspot", "High Policy Hotspot", "high.example.com", "Example", evaluatedAt.Add(-48*time.Hour), evaluatedAt.Add(-time.Hour))
+		mediumOldThresholdID := insertSaaSApp(t, ctx, pool, "medium-policy-not-hotspot", "Medium Policy Not Hotspot", "medium.example.com", "Example", evaluatedAt.Add(-24*time.Hour), evaluatedAt)
+
+		insertSaaSAppSource(t, ctx, pool, criticalID, runID, "github", "acme", "critical-policy-hotspot", "Critical Policy Hotspot", "critical.example.com", evaluatedAt.Add(-2*time.Hour))
+		insertSaaSAppSource(t, ctx, pool, highID, runID, "github", "acme", "high-policy-hotspot", "High Policy Hotspot", "high.example.com", evaluatedAt.Add(-time.Hour))
+		insertSaaSAppSource(t, ctx, pool, mediumOldThresholdID, runID, "github", "acme", "medium-policy-not-hotspot", "Medium Policy Not Hotspot", "medium.example.com", evaluatedAt)
+
+		if _, err := q.RefreshAllSaaSAppReadModels(ctx); err != nil {
+			t.Fatalf("RefreshAllSaaSAppReadModels(): %v", err)
+		}
+		upsertSaaSAppRiskReadModel(t, ctx, pool, criticalID, 85, "critical")
+		upsertSaaSAppRiskReadModel(t, ctx, pool, highID, 60, "high")
+		upsertSaaSAppRiskReadModel(t, ctx, pool, mediumOldThresholdID, 70, "medium")
+
+		rows, err := q.ListSaaSAppHotspots(ctx, ListSaaSAppHotspotsParams{
+			LimitRows: 10,
+		})
+		if err != nil {
+			t.Fatalf("ListSaaSAppHotspots(): %v", err)
+		}
+
+		gotByID := map[int64]string{}
+		for _, row := range rows {
+			gotByID[row.ID] = row.RiskLevel
+		}
+		if gotByID[criticalID] != "critical" {
+			t.Fatalf("critical hotspot risk_level=%q want critical; rows=%v", gotByID[criticalID], gotByID)
+		}
+		if gotByID[highID] != "high" {
+			t.Fatalf("high hotspot risk_level=%q want high; rows=%v", gotByID[highID], gotByID)
+		}
+		if _, ok := gotByID[mediumOldThresholdID]; ok {
+			t.Fatalf("medium policy app was returned as hotspot; rows=%v", gotByID)
 		}
 	})
 }
@@ -1010,6 +1081,54 @@ func insertSaaSAppSource(t *testing.T, ctx context.Context, pool *pgxpool.Pool, 
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $7, $8, now(), now())
 	`, saasAppID, sourceKind, sourceName, sourceAppID, sourceAppName, sourceAppDomain, runID, observedAt.UTC()); err != nil {
 		t.Fatalf("insert saas app source %s/%s: %v", sourceKind, sourceAppID, err)
+	}
+}
+
+func upsertSaaSAppRiskReadModel(t *testing.T, ctx context.Context, pool *pgxpool.Pool, saasAppID int64, riskScore int, riskLevel string) {
+	t.Helper()
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO saas_app_risk_read_models (
+			saas_app_id,
+			risk_score,
+			risk_level,
+			risk_rank,
+			suggested_business_criticality,
+			suggested_data_classification,
+			effective_business_criticality,
+			effective_data_classification,
+			policy_packs_json,
+			projection_refreshed_at
+		)
+		VALUES (
+			$1,
+			$2,
+			$3,
+			CASE $3
+				WHEN 'critical' THEN 4
+				WHEN 'high' THEN 3
+				WHEN 'medium' THEN 2
+				ELSE 1
+			END,
+			'low',
+			'internal',
+			'low',
+			'internal',
+			'[]'::jsonb,
+			now()
+		)
+		ON CONFLICT (saas_app_id) DO UPDATE SET
+			risk_score = EXCLUDED.risk_score,
+			risk_level = EXCLUDED.risk_level,
+			risk_rank = EXCLUDED.risk_rank,
+			suggested_business_criticality = EXCLUDED.suggested_business_criticality,
+			suggested_data_classification = EXCLUDED.suggested_data_classification,
+			effective_business_criticality = EXCLUDED.effective_business_criticality,
+			effective_data_classification = EXCLUDED.effective_data_classification,
+			policy_packs_json = EXCLUDED.policy_packs_json,
+			projection_refreshed_at = now()
+	`, saasAppID, riskScore, riskLevel); err != nil {
+		t.Fatalf("upsert saas app risk read model %d: %v", saasAppID, err)
 	}
 }
 

--- a/internal/db/gen/read_models.sql.go
+++ b/internal/db/gen/read_models.sql.go
@@ -76,6 +76,8 @@ type GetSaaSAppRiskInputByIDRow struct {
 	ConnectorBindingHealthy       bool        `json:"connector_binding_healthy"`
 }
 
+// Re-read governance overrides directly because the risk evaluator needs raw
+// configured values; discovery_app_read_models_v exposes resolved effective values.
 func (q *Queries) GetSaaSAppRiskInputByID(ctx context.Context, saasAppID int64) (GetSaaSAppRiskInputByIDRow, error) {
 	row := q.db.QueryRow(ctx, getSaaSAppRiskInputByID, saasAppID)
 	var i GetSaaSAppRiskInputByIDRow
@@ -162,6 +164,8 @@ type ListAllSaaSAppRiskInputsRow struct {
 	ConnectorBindingHealthy       bool        `json:"connector_binding_healthy"`
 }
 
+// Re-read governance overrides directly because the risk evaluator needs raw
+// configured values; discovery_app_read_models_v exposes resolved effective values.
 func (q *Queries) ListAllSaaSAppRiskInputs(ctx context.Context) ([]ListAllSaaSAppRiskInputsRow, error) {
 	rows, err := q.db.Query(ctx, listAllSaaSAppRiskInputs)
 	if err != nil {
@@ -325,6 +329,8 @@ type ListSaaSAppRiskInputsBySourceRow struct {
 	ConnectorBindingHealthy       bool        `json:"connector_binding_healthy"`
 }
 
+// Re-read governance overrides directly because the risk evaluator needs raw
+// configured values; discovery_app_read_models_v exposes resolved effective values.
 func (q *Queries) ListSaaSAppRiskInputsBySource(ctx context.Context, arg ListSaaSAppRiskInputsBySourceParams) ([]ListSaaSAppRiskInputsBySourceRow, error) {
 	rows, err := q.db.Query(ctx, listSaaSAppRiskInputsBySource, arg.SourceKind, arg.SourceName)
 	if err != nil {
@@ -1005,7 +1011,6 @@ SELECT (
     LEFT JOIN saas_app_risk_read_models risk
       ON risk.saas_app_id = sa.id
     WHERE risk.saas_app_id IS NULL
-      OR risk.projection_refreshed_at IS NULL
   )
   OR EXISTS (
     SELECT 1

--- a/internal/db/gen/read_models.sql.go
+++ b/internal/db/gen/read_models.sql.go
@@ -20,6 +20,191 @@ func (q *Queries) DeleteConnectorSourceStateAll(ctx context.Context) error {
 	return err
 }
 
+const getSaaSAppRiskInputByID = `-- name: GetSaaSAppRiskInputByID :one
+SELECT
+  pr.id::bigint AS saas_app_id,
+  pr.canonical_key::text AS canonical_key,
+  pr.display_name::text AS display_name,
+  pr.primary_domain::text AS primary_domain,
+  pr.vendor_name::text AS vendor_name,
+  pr.bound_connector_kind::text AS source_kind,
+  pr.bound_connector_source_name::text AS source_name,
+  pr.actors_30d::bigint AS actors_30d,
+  pr.has_privileged_scope::boolean AS has_privileged_scope,
+  pr.has_confidential_scope::boolean AS has_confidential_scope,
+  pr.managed_state::text AS managed_state,
+  pr.managed_reason::text AS managed_reason,
+  pr.owner_identity_id::bigint AS owner_identity_id,
+  pr.governance_state::text AS governance_state,
+  pr.review_disposition::text AS review_disposition,
+  pr.follow_up_due_date::date AS follow_up_due_date,
+  COALESCE(NULLIF(trim(go.business_criticality), ''), 'unknown')::text AS configured_business_criticality,
+  COALESCE(NULLIF(trim(go.data_classification), ''), 'unknown')::text AS configured_data_classification,
+  pr.connector_configured::boolean AS connector_binding_configured,
+  pr.connector_enabled::boolean AS connector_binding_enabled,
+  COALESCE(pr.fresh_until_at < now(), false)::boolean AS connector_binding_stale,
+  (pr.managed_state = 'managed')::boolean AS connector_binding_healthy
+FROM discovery_app_read_models_v pr
+LEFT JOIN governance_subject_overrides go
+  ON go.subject_kind = 'saas_app'
+ AND go.subject_id = pr.id
+WHERE pr.id = $1::bigint
+`
+
+type GetSaaSAppRiskInputByIDRow struct {
+	SaasAppID                     int64       `json:"saas_app_id"`
+	CanonicalKey                  string      `json:"canonical_key"`
+	DisplayName                   string      `json:"display_name"`
+	PrimaryDomain                 string      `json:"primary_domain"`
+	VendorName                    string      `json:"vendor_name"`
+	SourceKind                    string      `json:"source_kind"`
+	SourceName                    string      `json:"source_name"`
+	Actors30d                     int64       `json:"actors_30d"`
+	HasPrivilegedScope            bool        `json:"has_privileged_scope"`
+	HasConfidentialScope          bool        `json:"has_confidential_scope"`
+	ManagedState                  string      `json:"managed_state"`
+	ManagedReason                 string      `json:"managed_reason"`
+	OwnerIdentityID               int64       `json:"owner_identity_id"`
+	GovernanceState               string      `json:"governance_state"`
+	ReviewDisposition             string      `json:"review_disposition"`
+	FollowUpDueDate               pgtype.Date `json:"follow_up_due_date"`
+	ConfiguredBusinessCriticality string      `json:"configured_business_criticality"`
+	ConfiguredDataClassification  string      `json:"configured_data_classification"`
+	ConnectorBindingConfigured    bool        `json:"connector_binding_configured"`
+	ConnectorBindingEnabled       bool        `json:"connector_binding_enabled"`
+	ConnectorBindingStale         bool        `json:"connector_binding_stale"`
+	ConnectorBindingHealthy       bool        `json:"connector_binding_healthy"`
+}
+
+func (q *Queries) GetSaaSAppRiskInputByID(ctx context.Context, saasAppID int64) (GetSaaSAppRiskInputByIDRow, error) {
+	row := q.db.QueryRow(ctx, getSaaSAppRiskInputByID, saasAppID)
+	var i GetSaaSAppRiskInputByIDRow
+	err := row.Scan(
+		&i.SaasAppID,
+		&i.CanonicalKey,
+		&i.DisplayName,
+		&i.PrimaryDomain,
+		&i.VendorName,
+		&i.SourceKind,
+		&i.SourceName,
+		&i.Actors30d,
+		&i.HasPrivilegedScope,
+		&i.HasConfidentialScope,
+		&i.ManagedState,
+		&i.ManagedReason,
+		&i.OwnerIdentityID,
+		&i.GovernanceState,
+		&i.ReviewDisposition,
+		&i.FollowUpDueDate,
+		&i.ConfiguredBusinessCriticality,
+		&i.ConfiguredDataClassification,
+		&i.ConnectorBindingConfigured,
+		&i.ConnectorBindingEnabled,
+		&i.ConnectorBindingStale,
+		&i.ConnectorBindingHealthy,
+	)
+	return i, err
+}
+
+const listAllSaaSAppRiskInputs = `-- name: ListAllSaaSAppRiskInputs :many
+SELECT
+  pr.id::bigint AS saas_app_id,
+  pr.canonical_key::text AS canonical_key,
+  pr.display_name::text AS display_name,
+  pr.primary_domain::text AS primary_domain,
+  pr.vendor_name::text AS vendor_name,
+  pr.bound_connector_kind::text AS source_kind,
+  pr.bound_connector_source_name::text AS source_name,
+  pr.actors_30d::bigint AS actors_30d,
+  pr.has_privileged_scope::boolean AS has_privileged_scope,
+  pr.has_confidential_scope::boolean AS has_confidential_scope,
+  pr.managed_state::text AS managed_state,
+  pr.managed_reason::text AS managed_reason,
+  pr.owner_identity_id::bigint AS owner_identity_id,
+  pr.governance_state::text AS governance_state,
+  pr.review_disposition::text AS review_disposition,
+  pr.follow_up_due_date::date AS follow_up_due_date,
+  COALESCE(NULLIF(trim(go.business_criticality), ''), 'unknown')::text AS configured_business_criticality,
+  COALESCE(NULLIF(trim(go.data_classification), ''), 'unknown')::text AS configured_data_classification,
+  pr.connector_configured::boolean AS connector_binding_configured,
+  pr.connector_enabled::boolean AS connector_binding_enabled,
+  COALESCE(pr.fresh_until_at < now(), false)::boolean AS connector_binding_stale,
+  (pr.managed_state = 'managed')::boolean AS connector_binding_healthy
+FROM discovery_app_read_models_v pr
+LEFT JOIN governance_subject_overrides go
+  ON go.subject_kind = 'saas_app'
+ AND go.subject_id = pr.id
+ORDER BY pr.id ASC
+`
+
+type ListAllSaaSAppRiskInputsRow struct {
+	SaasAppID                     int64       `json:"saas_app_id"`
+	CanonicalKey                  string      `json:"canonical_key"`
+	DisplayName                   string      `json:"display_name"`
+	PrimaryDomain                 string      `json:"primary_domain"`
+	VendorName                    string      `json:"vendor_name"`
+	SourceKind                    string      `json:"source_kind"`
+	SourceName                    string      `json:"source_name"`
+	Actors30d                     int64       `json:"actors_30d"`
+	HasPrivilegedScope            bool        `json:"has_privileged_scope"`
+	HasConfidentialScope          bool        `json:"has_confidential_scope"`
+	ManagedState                  string      `json:"managed_state"`
+	ManagedReason                 string      `json:"managed_reason"`
+	OwnerIdentityID               int64       `json:"owner_identity_id"`
+	GovernanceState               string      `json:"governance_state"`
+	ReviewDisposition             string      `json:"review_disposition"`
+	FollowUpDueDate               pgtype.Date `json:"follow_up_due_date"`
+	ConfiguredBusinessCriticality string      `json:"configured_business_criticality"`
+	ConfiguredDataClassification  string      `json:"configured_data_classification"`
+	ConnectorBindingConfigured    bool        `json:"connector_binding_configured"`
+	ConnectorBindingEnabled       bool        `json:"connector_binding_enabled"`
+	ConnectorBindingStale         bool        `json:"connector_binding_stale"`
+	ConnectorBindingHealthy       bool        `json:"connector_binding_healthy"`
+}
+
+func (q *Queries) ListAllSaaSAppRiskInputs(ctx context.Context) ([]ListAllSaaSAppRiskInputsRow, error) {
+	rows, err := q.db.Query(ctx, listAllSaaSAppRiskInputs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListAllSaaSAppRiskInputsRow
+	for rows.Next() {
+		var i ListAllSaaSAppRiskInputsRow
+		if err := rows.Scan(
+			&i.SaasAppID,
+			&i.CanonicalKey,
+			&i.DisplayName,
+			&i.PrimaryDomain,
+			&i.VendorName,
+			&i.SourceKind,
+			&i.SourceName,
+			&i.Actors30d,
+			&i.HasPrivilegedScope,
+			&i.HasConfidentialScope,
+			&i.ManagedState,
+			&i.ManagedReason,
+			&i.OwnerIdentityID,
+			&i.GovernanceState,
+			&i.ReviewDisposition,
+			&i.FollowUpDueDate,
+			&i.ConfiguredBusinessCriticality,
+			&i.ConfiguredDataClassification,
+			&i.ConnectorBindingConfigured,
+			&i.ConnectorBindingEnabled,
+			&i.ConnectorBindingStale,
+			&i.ConnectorBindingHealthy,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listLatestSuccessfulSyncRunsBySource = `-- name: ListLatestSuccessfulSyncRunsBySource :many
 WITH normalized AS (
   SELECT
@@ -62,6 +247,117 @@ func (q *Queries) ListLatestSuccessfulSyncRunsBySource(ctx context.Context) ([]L
 	for rows.Next() {
 		var i ListLatestSuccessfulSyncRunsBySourceRow
 		if err := rows.Scan(&i.SourceKind, &i.SourceName, &i.LastSuccessAt); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listSaaSAppRiskInputsBySource = `-- name: ListSaaSAppRiskInputsBySource :many
+SELECT
+  pr.id::bigint AS saas_app_id,
+  pr.canonical_key::text AS canonical_key,
+  pr.display_name::text AS display_name,
+  pr.primary_domain::text AS primary_domain,
+  pr.vendor_name::text AS vendor_name,
+  pr.bound_connector_kind::text AS source_kind,
+  pr.bound_connector_source_name::text AS source_name,
+  pr.actors_30d::bigint AS actors_30d,
+  pr.has_privileged_scope::boolean AS has_privileged_scope,
+  pr.has_confidential_scope::boolean AS has_confidential_scope,
+  pr.managed_state::text AS managed_state,
+  pr.managed_reason::text AS managed_reason,
+  pr.owner_identity_id::bigint AS owner_identity_id,
+  pr.governance_state::text AS governance_state,
+  pr.review_disposition::text AS review_disposition,
+  pr.follow_up_due_date::date AS follow_up_due_date,
+  COALESCE(NULLIF(trim(go.business_criticality), ''), 'unknown')::text AS configured_business_criticality,
+  COALESCE(NULLIF(trim(go.data_classification), ''), 'unknown')::text AS configured_data_classification,
+  pr.connector_configured::boolean AS connector_binding_configured,
+  pr.connector_enabled::boolean AS connector_binding_enabled,
+  COALESCE(pr.fresh_until_at < now(), false)::boolean AS connector_binding_stale,
+  (pr.managed_state = 'managed')::boolean AS connector_binding_healthy
+FROM discovery_app_read_models_v pr
+LEFT JOIN governance_subject_overrides go
+  ON go.subject_kind = 'saas_app'
+ AND go.subject_id = pr.id
+WHERE EXISTS (
+  SELECT 1
+  FROM saas_app_sources sas
+  WHERE sas.saas_app_id = pr.id
+    AND lower(trim(sas.source_kind)) = lower(trim($1::text))
+    AND lower(trim(sas.source_name)) = lower(trim($2::text))
+)
+ORDER BY pr.id ASC
+`
+
+type ListSaaSAppRiskInputsBySourceParams struct {
+	SourceKind string `json:"source_kind"`
+	SourceName string `json:"source_name"`
+}
+
+type ListSaaSAppRiskInputsBySourceRow struct {
+	SaasAppID                     int64       `json:"saas_app_id"`
+	CanonicalKey                  string      `json:"canonical_key"`
+	DisplayName                   string      `json:"display_name"`
+	PrimaryDomain                 string      `json:"primary_domain"`
+	VendorName                    string      `json:"vendor_name"`
+	SourceKind                    string      `json:"source_kind"`
+	SourceName                    string      `json:"source_name"`
+	Actors30d                     int64       `json:"actors_30d"`
+	HasPrivilegedScope            bool        `json:"has_privileged_scope"`
+	HasConfidentialScope          bool        `json:"has_confidential_scope"`
+	ManagedState                  string      `json:"managed_state"`
+	ManagedReason                 string      `json:"managed_reason"`
+	OwnerIdentityID               int64       `json:"owner_identity_id"`
+	GovernanceState               string      `json:"governance_state"`
+	ReviewDisposition             string      `json:"review_disposition"`
+	FollowUpDueDate               pgtype.Date `json:"follow_up_due_date"`
+	ConfiguredBusinessCriticality string      `json:"configured_business_criticality"`
+	ConfiguredDataClassification  string      `json:"configured_data_classification"`
+	ConnectorBindingConfigured    bool        `json:"connector_binding_configured"`
+	ConnectorBindingEnabled       bool        `json:"connector_binding_enabled"`
+	ConnectorBindingStale         bool        `json:"connector_binding_stale"`
+	ConnectorBindingHealthy       bool        `json:"connector_binding_healthy"`
+}
+
+func (q *Queries) ListSaaSAppRiskInputsBySource(ctx context.Context, arg ListSaaSAppRiskInputsBySourceParams) ([]ListSaaSAppRiskInputsBySourceRow, error) {
+	rows, err := q.db.Query(ctx, listSaaSAppRiskInputsBySource, arg.SourceKind, arg.SourceName)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListSaaSAppRiskInputsBySourceRow
+	for rows.Next() {
+		var i ListSaaSAppRiskInputsBySourceRow
+		if err := rows.Scan(
+			&i.SaasAppID,
+			&i.CanonicalKey,
+			&i.DisplayName,
+			&i.PrimaryDomain,
+			&i.VendorName,
+			&i.SourceKind,
+			&i.SourceName,
+			&i.Actors30d,
+			&i.HasPrivilegedScope,
+			&i.HasConfidentialScope,
+			&i.ManagedState,
+			&i.ManagedReason,
+			&i.OwnerIdentityID,
+			&i.GovernanceState,
+			&i.ReviewDisposition,
+			&i.FollowUpDueDate,
+			&i.ConfiguredBusinessCriticality,
+			&i.ConfiguredDataClassification,
+			&i.ConnectorBindingConfigured,
+			&i.ConnectorBindingEnabled,
+			&i.ConnectorBindingStale,
+			&i.ConnectorBindingHealthy,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -705,6 +1001,14 @@ SELECT (
   )
   OR EXISTS (
     SELECT 1
+    FROM saas_apps sa
+    LEFT JOIN saas_app_risk_read_models risk
+      ON risk.saas_app_id = sa.id
+    WHERE risk.saas_app_id IS NULL
+      OR risk.projection_refreshed_at IS NULL
+  )
+  OR EXISTS (
+    SELECT 1
     FROM app_assets aa
     WHERE aa.projection_refreshed_at IS NULL
   )
@@ -793,4 +1097,85 @@ func (q *Queries) UpsertConnectorSourceState(ctx context.Context, arg UpsertConn
 		arg.FreshUntilAt,
 	)
 	return err
+}
+
+const upsertSaaSAppRiskReadModelsBulk = `-- name: UpsertSaaSAppRiskReadModelsBulk :execrows
+WITH input AS (
+  SELECT
+    i,
+    ($1::bigint[])[i] AS saas_app_id,
+    ($2::int[])[i] AS risk_score,
+    ($3::text[])[i] AS risk_level,
+    ($4::int[])[i] AS risk_rank,
+    ($5::text[])[i] AS suggested_business_criticality,
+    ($6::text[])[i] AS suggested_data_classification,
+    ($7::text[])[i] AS effective_business_criticality,
+    ($8::text[])[i] AS effective_data_classification,
+    ($9::jsonb[])[i] AS policy_packs_json
+  FROM generate_subscripts($1::bigint[], 1) AS s(i)
+)
+INSERT INTO saas_app_risk_read_models (
+  saas_app_id,
+  risk_score,
+  risk_level,
+  risk_rank,
+  suggested_business_criticality,
+  suggested_data_classification,
+  effective_business_criticality,
+  effective_data_classification,
+  policy_packs_json,
+  projection_refreshed_at
+)
+SELECT
+  input.saas_app_id,
+  input.risk_score,
+  input.risk_level,
+  input.risk_rank,
+  input.suggested_business_criticality,
+  input.suggested_data_classification,
+  input.effective_business_criticality,
+  input.effective_data_classification,
+  input.policy_packs_json,
+  now()
+FROM input
+ON CONFLICT (saas_app_id) DO UPDATE SET
+  risk_score = EXCLUDED.risk_score,
+  risk_level = EXCLUDED.risk_level,
+  risk_rank = EXCLUDED.risk_rank,
+  suggested_business_criticality = EXCLUDED.suggested_business_criticality,
+  suggested_data_classification = EXCLUDED.suggested_data_classification,
+  effective_business_criticality = EXCLUDED.effective_business_criticality,
+  effective_data_classification = EXCLUDED.effective_data_classification,
+  policy_packs_json = EXCLUDED.policy_packs_json,
+  projection_refreshed_at = now()
+`
+
+type UpsertSaaSAppRiskReadModelsBulkParams struct {
+	SaasAppIds                     []int64  `json:"saas_app_ids"`
+	RiskScores                     []int32  `json:"risk_scores"`
+	RiskLevels                     []string `json:"risk_levels"`
+	RiskRanks                      []int32  `json:"risk_ranks"`
+	SuggestedBusinessCriticalities []string `json:"suggested_business_criticalities"`
+	SuggestedDataClassifications   []string `json:"suggested_data_classifications"`
+	EffectiveBusinessCriticalities []string `json:"effective_business_criticalities"`
+	EffectiveDataClassifications   []string `json:"effective_data_classifications"`
+	PolicyPacksJsons               [][]byte `json:"policy_packs_jsons"`
+}
+
+func (q *Queries) UpsertSaaSAppRiskReadModelsBulk(ctx context.Context, arg UpsertSaaSAppRiskReadModelsBulkParams) (int64, error) {
+	result, err := q.db.Exec(ctx, upsertSaaSAppRiskReadModelsBulk,
+		arg.SaasAppIds,
+		arg.RiskScores,
+		arg.RiskLevels,
+		arg.RiskRanks,
+		arg.SuggestedBusinessCriticalities,
+		arg.SuggestedDataClassifications,
+		arg.EffectiveBusinessCriticalities,
+		arg.EffectiveDataClassifications,
+		arg.PolicyPacksJsons,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }

--- a/internal/db/gen/saas_apps.sql.go
+++ b/internal/db/gen/saas_apps.sql.go
@@ -301,7 +301,7 @@ SELECT
   pr.ticket_ref::text AS ticket_ref,
   pr.actors_30d::bigint AS actors_30d
 FROM discovery_app_read_models_v pr
-WHERE pr.risk_score >= 60
+WHERE pr.risk_level IN ('high', 'critical')
   AND EXISTS (
     SELECT 1
     FROM saas_app_sources sas

--- a/internal/http/handlers/command_integration_test.go
+++ b/internal/http/handlers/command_integration_test.go
@@ -748,6 +748,12 @@ func refreshCommandSearchSourceReadModels(t *testing.T, ctx context.Context, q *
 	if err := projector.RefreshAppAssetSource(ctx, sourceKind, sourceName); err != nil {
 		t.Fatalf("RefreshAppAssetSource(%s/%s): %v", sourceKind, sourceName, err)
 	}
+	if err := projector.RefreshConnectorSourceState(ctx); err != nil {
+		t.Fatalf("RefreshConnectorSourceState(): %v", err)
+	}
+	if err := projector.RefreshSaaSAppRiskReadModelsBySource(ctx, sourceKind, sourceName); err != nil {
+		t.Fatalf("RefreshSaaSAppRiskReadModelsBySource(%s/%s): %v", sourceKind, sourceName, err)
+	}
 	if err := projector.RefreshNonHumanPrincipalSourceReadModels(ctx, sourceKind, sourceName); err != nil {
 		t.Fatalf("RefreshNonHumanPrincipalSourceReadModels(%s/%s): %v", sourceKind, sourceName, err)
 	}

--- a/internal/http/handlers/discovery.go
+++ b/internal/http/handlers/discovery.go
@@ -21,6 +21,7 @@ import (
 	"github.com/open-sspm/open-sspm/internal/http/querystate"
 	"github.com/open-sspm/open-sspm/internal/http/viewmodels"
 	"github.com/open-sspm/open-sspm/internal/http/views"
+	"github.com/open-sspm/open-sspm/internal/readmodels"
 )
 
 const (
@@ -447,7 +448,7 @@ func (h *Handlers) persistDiscoveryGovernanceUpdate(ctx context.Context, appID i
 		}); err != nil {
 			return err
 		}
-		return nil
+		return readmodels.NewProjector(nil, qtx, readmodels.RefreshConfigFromConfig(h.Cfg)).RefreshSaaSAppRiskReadModelByID(ctx, appID)
 	})
 }
 

--- a/internal/http/handlers/discovery_integration_test.go
+++ b/internal/http/handlers/discovery_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/open-sspm/open-sspm/internal/connectors/configstore"
 	"github.com/open-sspm/open-sspm/internal/db/gen"
 	"github.com/open-sspm/open-sspm/internal/http/authn"
+	"github.com/open-sspm/open-sspm/internal/readmodels"
 )
 
 func TestHandleDiscoveryAppShowUsesLivePostureWithoutPersisting(t *testing.T) {
@@ -100,7 +101,7 @@ func TestHandleDiscoveryAppShowManagedBindingsAcrossConnectorKinds(t *testing.T)
 			body := renderDiscoveryAppShow(t, h, appID)
 			assertContains(t, body, "GitHub Actions")
 			assertContains(t, body, "Primary binding has fresh sync")
-			assertContains(t, body, "Score 15")
+			assertContains(t, body, "Score 35")
 		})
 
 		t.Run("datadog binding discovered from okta is managed when datadog is fresh", func(t *testing.T) {
@@ -238,7 +239,7 @@ func TestHandleDiscoveryAppShowDisabledConnectorIsUnmanaged(t *testing.T) {
 		body := renderDiscoveryAppShow(t, h, appID)
 		assertContains(t, body, "Disabled GitHub App")
 		assertContains(t, body, "Bound connector is disabled")
-		assertContains(t, body, "Score 60")
+		assertContains(t, body, "Score 90")
 	})
 }
 
@@ -966,6 +967,14 @@ func upsertDiscoveryPrimaryBinding(t *testing.T, ctx context.Context, q *gen.Que
 	}); err != nil {
 		t.Fatalf("UpsertSaaSAppBinding %s/%s: %v", connectorKind, sourceName, err)
 	}
+
+	projector := readmodels.NewProjector(nil, q, readmodels.RefreshConfig{})
+	if err := projector.RefreshConnectorSourceState(ctx); err != nil {
+		t.Fatalf("RefreshConnectorSourceState(): %v", err)
+	}
+	if err := projector.RefreshSaaSAppRiskReadModelByID(ctx, appID); err != nil {
+		t.Fatalf("RefreshSaaSAppRiskReadModelByID(%d): %v", appID, err)
+	}
 }
 
 func setSyncRunFinishedAt(t *testing.T, ctx context.Context, pool *pgxpool.Pool, runID int64, finishedAt time.Time) {
@@ -980,6 +989,10 @@ func setSyncRunFinishedAt(t *testing.T, ctx context.Context, pool *pgxpool.Pool,
 		t.Fatalf("update sync_runs finished_at: %v", err)
 	}
 	refreshCommandSearchSourceState(t, ctx, pool)
+	projector := readmodels.NewProjector(pool, gen.New(pool), readmodels.RefreshConfig{})
+	if err := projector.RefreshAllSaaSAppRiskReadModels(ctx); err != nil {
+		t.Fatalf("RefreshAllSaaSAppRiskReadModels(): %v", err)
+	}
 }
 
 func getDiscoveryAppByIDForTest(t *testing.T, ctx context.Context, q *gen.Queries, h *Handlers, appID int64) gen.GetSaaSAppByIDRow {

--- a/internal/http/handlers/settings.go
+++ b/internal/http/handlers/settings.go
@@ -221,7 +221,11 @@ func (h *Handlers) handleConnectorToggle(c *echo.Context, kind string) error {
 		if _, err := qtx.UpdateConnectorConfigEnabled(ctx, gen.UpdateConnectorConfigEnabledParams{Kind: kind, Enabled: enabled}); err != nil {
 			return err
 		}
-		return readmodels.NewProjector(nil, qtx, readmodels.RefreshConfigFromConfig(h.Cfg)).RefreshConnectorSourceState(ctx)
+		projector := readmodels.NewProjector(nil, qtx, readmodels.RefreshConfigFromConfig(h.Cfg))
+		if err := projector.RefreshConnectorSourceState(ctx); err != nil {
+			return err
+		}
+		return projector.RefreshAllSaaSAppRiskReadModels(ctx)
 	}); err != nil {
 		return h.RenderError(c, err)
 	}
@@ -261,7 +265,11 @@ func (h *Handlers) handleConnectorSave(c *echo.Context, kind string) error {
 		if err := configStore.SaveConnectorConfigTx(ctx, qtx, kind, mergedConfig); err != nil {
 			return err
 		}
-		return readmodels.NewProjector(nil, qtx, readmodels.RefreshConfigFromConfig(h.Cfg)).RefreshConnectorSourceState(ctx)
+		projector := readmodels.NewProjector(nil, qtx, readmodels.RefreshConfigFromConfig(h.Cfg))
+		if err := projector.RefreshConnectorSourceState(ctx); err != nil {
+			return err
+		}
+		return projector.RefreshAllSaaSAppRiskReadModels(ctx)
 	}); err != nil {
 		if errors.Is(err, configstore.ErrConnectorSecretKeyRequired) {
 			return h.renderConnectorsPage(c, kind, "", connectorAlert(err))

--- a/internal/readmodels/projector.go
+++ b/internal/readmodels/projector.go
@@ -2,6 +2,7 @@ package readmodels
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/open-sspm/open-sspm/internal/connectors/configstore"
 	"github.com/open-sspm/open-sspm/internal/db/gen"
+	"github.com/open-sspm/open-sspm/internal/riskpolicy"
 )
 
 type Projector struct {
@@ -72,6 +74,24 @@ func (p *Projector) RefreshDiscoverySource(ctx context.Context, sourceKind, sour
 	})
 }
 
+func (p *Projector) RefreshSaaSAppRiskReadModelsBySource(ctx context.Context, sourceKind, sourceName string) error {
+	return p.withQueries(ctx, func(q *gen.Queries) error {
+		return refreshSaaSAppRiskReadModelsBySource(ctx, q, sourceKind, sourceName)
+	})
+}
+
+func (p *Projector) RefreshAllSaaSAppRiskReadModels(ctx context.Context) error {
+	return p.withQueries(ctx, func(q *gen.Queries) error {
+		return refreshAllSaaSAppRiskReadModels(ctx, q)
+	})
+}
+
+func (p *Projector) RefreshSaaSAppRiskReadModelByID(ctx context.Context, saasAppID int64) error {
+	return p.withQueries(ctx, func(q *gen.Queries) error {
+		return refreshSaaSAppRiskReadModelByID(ctx, q, saasAppID)
+	})
+}
+
 func (p *Projector) RefreshAppAssetSource(ctx context.Context, sourceKind, sourceName string) error {
 	return p.withQueries(ctx, func(q *gen.Queries) error {
 		return refreshAppAssetSource(ctx, q, sourceKind, sourceName)
@@ -100,6 +120,9 @@ func (p *Projector) RebuildAllReadModels(ctx context.Context) error {
 			return err
 		}
 		if err := refreshConnectorSourceState(ctx, q, p.cfg); err != nil {
+			return err
+		}
+		if err := refreshAllSaaSAppRiskReadModels(ctx, q); err != nil {
 			return err
 		}
 		_, err := q.RefreshAllNonHumanPrincipalReadModelsSafely(ctx)
@@ -199,6 +222,222 @@ func refreshDiscoverySource(ctx context.Context, q *gen.Queries, sourceKind, sou
 		SourceName: sourceName,
 	})
 	return err
+}
+
+type saasAppRiskInputRow struct {
+	saasAppID                     int64
+	canonicalKey                  string
+	displayName                   string
+	primaryDomain                 string
+	vendorName                    string
+	sourceKind                    string
+	sourceName                    string
+	actors30d                     int64
+	hasPrivilegedScope            bool
+	hasConfidentialScope          bool
+	managedState                  string
+	managedReason                 string
+	ownerIdentityID               int64
+	governanceState               string
+	reviewDisposition             string
+	followUpDueDate               pgtype.Date
+	configuredBusinessCriticality string
+	configuredDataClassification  string
+	connectorBindingConfigured    bool
+	connectorBindingEnabled       bool
+	connectorBindingStale         bool
+	connectorBindingHealthy       bool
+}
+
+func refreshAllSaaSAppRiskReadModels(ctx context.Context, q *gen.Queries) error {
+	rows, err := q.ListAllSaaSAppRiskInputs(ctx)
+	if err != nil {
+		return err
+	}
+	inputs := make([]saasAppRiskInputRow, 0, len(rows))
+	for _, row := range rows {
+		inputs = append(inputs, saasAppRiskInputRow{
+			saasAppID:                     row.SaasAppID,
+			canonicalKey:                  row.CanonicalKey,
+			displayName:                   row.DisplayName,
+			primaryDomain:                 row.PrimaryDomain,
+			vendorName:                    row.VendorName,
+			sourceKind:                    row.SourceKind,
+			sourceName:                    row.SourceName,
+			actors30d:                     row.Actors30d,
+			hasPrivilegedScope:            row.HasPrivilegedScope,
+			hasConfidentialScope:          row.HasConfidentialScope,
+			managedState:                  row.ManagedState,
+			managedReason:                 row.ManagedReason,
+			ownerIdentityID:               row.OwnerIdentityID,
+			governanceState:               row.GovernanceState,
+			reviewDisposition:             row.ReviewDisposition,
+			followUpDueDate:               row.FollowUpDueDate,
+			configuredBusinessCriticality: row.ConfiguredBusinessCriticality,
+			configuredDataClassification:  row.ConfiguredDataClassification,
+			connectorBindingConfigured:    row.ConnectorBindingConfigured,
+			connectorBindingEnabled:       row.ConnectorBindingEnabled,
+			connectorBindingStale:         row.ConnectorBindingStale,
+			connectorBindingHealthy:       row.ConnectorBindingHealthy,
+		})
+	}
+	return refreshSaaSAppRiskReadModels(ctx, q, inputs)
+}
+
+func refreshSaaSAppRiskReadModelsBySource(ctx context.Context, q *gen.Queries, sourceKind, sourceName string) error {
+	sourceKind = normalizeSourceKind(sourceKind)
+	sourceName = strings.TrimSpace(sourceName)
+	if sourceKind == "" || sourceName == "" {
+		return nil
+	}
+	rows, err := q.ListSaaSAppRiskInputsBySource(ctx, gen.ListSaaSAppRiskInputsBySourceParams{
+		SourceKind: sourceKind,
+		SourceName: sourceName,
+	})
+	if err != nil {
+		return err
+	}
+	inputs := make([]saasAppRiskInputRow, 0, len(rows))
+	for _, row := range rows {
+		inputs = append(inputs, saasAppRiskInputRow{
+			saasAppID:                     row.SaasAppID,
+			canonicalKey:                  row.CanonicalKey,
+			displayName:                   row.DisplayName,
+			primaryDomain:                 row.PrimaryDomain,
+			vendorName:                    row.VendorName,
+			sourceKind:                    row.SourceKind,
+			sourceName:                    row.SourceName,
+			actors30d:                     row.Actors30d,
+			hasPrivilegedScope:            row.HasPrivilegedScope,
+			hasConfidentialScope:          row.HasConfidentialScope,
+			managedState:                  row.ManagedState,
+			managedReason:                 row.ManagedReason,
+			ownerIdentityID:               row.OwnerIdentityID,
+			governanceState:               row.GovernanceState,
+			reviewDisposition:             row.ReviewDisposition,
+			followUpDueDate:               row.FollowUpDueDate,
+			configuredBusinessCriticality: row.ConfiguredBusinessCriticality,
+			configuredDataClassification:  row.ConfiguredDataClassification,
+			connectorBindingConfigured:    row.ConnectorBindingConfigured,
+			connectorBindingEnabled:       row.ConnectorBindingEnabled,
+			connectorBindingStale:         row.ConnectorBindingStale,
+			connectorBindingHealthy:       row.ConnectorBindingHealthy,
+		})
+	}
+	return refreshSaaSAppRiskReadModels(ctx, q, inputs)
+}
+
+func refreshSaaSAppRiskReadModelByID(ctx context.Context, q *gen.Queries, saasAppID int64) error {
+	if saasAppID <= 0 {
+		return nil
+	}
+	row, err := q.GetSaaSAppRiskInputByID(ctx, saasAppID)
+	if err != nil {
+		return err
+	}
+	return refreshSaaSAppRiskReadModels(ctx, q, []saasAppRiskInputRow{{
+		saasAppID:                     row.SaasAppID,
+		canonicalKey:                  row.CanonicalKey,
+		displayName:                   row.DisplayName,
+		primaryDomain:                 row.PrimaryDomain,
+		vendorName:                    row.VendorName,
+		sourceKind:                    row.SourceKind,
+		sourceName:                    row.SourceName,
+		actors30d:                     row.Actors30d,
+		hasPrivilegedScope:            row.HasPrivilegedScope,
+		hasConfidentialScope:          row.HasConfidentialScope,
+		managedState:                  row.ManagedState,
+		managedReason:                 row.ManagedReason,
+		ownerIdentityID:               row.OwnerIdentityID,
+		governanceState:               row.GovernanceState,
+		reviewDisposition:             row.ReviewDisposition,
+		followUpDueDate:               row.FollowUpDueDate,
+		configuredBusinessCriticality: row.ConfiguredBusinessCriticality,
+		configuredDataClassification:  row.ConfiguredDataClassification,
+		connectorBindingConfigured:    row.ConnectorBindingConfigured,
+		connectorBindingEnabled:       row.ConnectorBindingEnabled,
+		connectorBindingStale:         row.ConnectorBindingStale,
+		connectorBindingHealthy:       row.ConnectorBindingHealthy,
+	}})
+}
+
+func refreshSaaSAppRiskReadModels(ctx context.Context, q *gen.Queries, rows []saasAppRiskInputRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	registry, err := riskpolicy.BuiltinRegistry()
+	if err != nil {
+		return err
+	}
+
+	params := gen.UpsertSaaSAppRiskReadModelsBulkParams{
+		SaasAppIds:                     make([]int64, 0, len(rows)),
+		RiskScores:                     make([]int32, 0, len(rows)),
+		RiskLevels:                     make([]string, 0, len(rows)),
+		RiskRanks:                      make([]int32, 0, len(rows)),
+		SuggestedBusinessCriticalities: make([]string, 0, len(rows)),
+		SuggestedDataClassifications:   make([]string, 0, len(rows)),
+		EffectiveBusinessCriticalities: make([]string, 0, len(rows)),
+		EffectiveDataClassifications:   make([]string, 0, len(rows)),
+		PolicyPacksJsons:               make([][]byte, 0, len(rows)),
+	}
+	for _, row := range rows {
+		result, err := registry.EvaluateSaaS(saasPolicyInput(row))
+		if err != nil {
+			return err
+		}
+		policyPacksJSON, err := json.Marshal(result.PolicyPacks)
+		if err != nil {
+			return err
+		}
+
+		params.SaasAppIds = append(params.SaasAppIds, row.saasAppID)
+		params.RiskScores = append(params.RiskScores, int32(result.RiskScore))
+		params.RiskLevels = append(params.RiskLevels, result.RiskLevel)
+		params.RiskRanks = append(params.RiskRanks, int32(result.RiskRank))
+		params.SuggestedBusinessCriticalities = append(params.SuggestedBusinessCriticalities, result.SuggestedBusinessCriticality)
+		params.SuggestedDataClassifications = append(params.SuggestedDataClassifications, result.SuggestedDataClassification)
+		params.EffectiveBusinessCriticalities = append(params.EffectiveBusinessCriticalities, result.EffectiveBusinessCriticality)
+		params.EffectiveDataClassifications = append(params.EffectiveDataClassifications, result.EffectiveDataClassification)
+		params.PolicyPacksJsons = append(params.PolicyPacksJsons, policyPacksJSON)
+	}
+
+	_, err = q.UpsertSaaSAppRiskReadModelsBulk(ctx, params)
+	return err
+}
+
+func saasPolicyInput(row saasAppRiskInputRow) riskpolicy.SaaSInput {
+	return riskpolicy.SaaSInput{
+		CanonicalKey:                 row.canonicalKey,
+		DisplayName:                  row.displayName,
+		PrimaryDomain:                row.primaryDomain,
+		VendorName:                   row.vendorName,
+		SourceKind:                   row.sourceKind,
+		SourceName:                   row.sourceName,
+		Actors30d:                    row.actors30d,
+		HasPrivilegedScope:           row.hasPrivilegedScope,
+		HasConfidentialScope:         row.hasConfidentialScope,
+		ManagedState:                 row.managedState,
+		ManagedReason:                row.managedReason,
+		OwnerIdentityID:              row.ownerIdentityID,
+		GovernanceState:              row.governanceState,
+		ReviewDisposition:            row.reviewDisposition,
+		FollowUpDueDate:              datePtr(row.followUpDueDate),
+		EffectiveBusinessCriticality: row.configuredBusinessCriticality,
+		EffectiveDataClassification:  row.configuredDataClassification,
+		ConnectorBindingConfigured:   row.connectorBindingConfigured,
+		ConnectorBindingEnabled:      row.connectorBindingEnabled,
+		ConnectorBindingStale:        row.connectorBindingStale,
+		ConnectorBindingHealthy:      row.connectorBindingHealthy,
+	}
+}
+
+func datePtr(value pgtype.Date) *time.Time {
+	if !value.Valid {
+		return nil
+	}
+	t := value.Time.UTC()
+	return &t
 }
 
 func refreshAppAssetSource(ctx context.Context, q *gen.Queries, sourceKind, sourceName string) error {

--- a/internal/readmodels/projector.go
+++ b/internal/readmodels/projector.go
@@ -3,9 +3,11 @@ package readmodels
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/open-sspm/open-sspm/internal/connectors/configstore"
@@ -333,6 +335,9 @@ func refreshSaaSAppRiskReadModelByID(ctx context.Context, q *gen.Queries, saasAp
 	}
 	row, err := q.GetSaaSAppRiskInputByID(ctx, saasAppID)
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
 		return err
 	}
 	return refreshSaaSAppRiskReadModels(ctx, q, []saasAppRiskInputRow{{
@@ -408,27 +413,27 @@ func refreshSaaSAppRiskReadModels(ctx context.Context, q *gen.Queries, rows []sa
 
 func saasPolicyInput(row saasAppRiskInputRow) riskpolicy.SaaSInput {
 	return riskpolicy.SaaSInput{
-		CanonicalKey:                 row.canonicalKey,
-		DisplayName:                  row.displayName,
-		PrimaryDomain:                row.primaryDomain,
-		VendorName:                   row.vendorName,
-		SourceKind:                   row.sourceKind,
-		SourceName:                   row.sourceName,
-		Actors30d:                    row.actors30d,
-		HasPrivilegedScope:           row.hasPrivilegedScope,
-		HasConfidentialScope:         row.hasConfidentialScope,
-		ManagedState:                 row.managedState,
-		ManagedReason:                row.managedReason,
-		OwnerIdentityID:              row.ownerIdentityID,
-		GovernanceState:              row.governanceState,
-		ReviewDisposition:            row.reviewDisposition,
-		FollowUpDueDate:              datePtr(row.followUpDueDate),
-		EffectiveBusinessCriticality: row.configuredBusinessCriticality,
-		EffectiveDataClassification:  row.configuredDataClassification,
-		ConnectorBindingConfigured:   row.connectorBindingConfigured,
-		ConnectorBindingEnabled:      row.connectorBindingEnabled,
-		ConnectorBindingStale:        row.connectorBindingStale,
-		ConnectorBindingHealthy:      row.connectorBindingHealthy,
+		CanonicalKey:                  row.canonicalKey,
+		DisplayName:                   row.displayName,
+		PrimaryDomain:                 row.primaryDomain,
+		VendorName:                    row.vendorName,
+		SourceKind:                    row.sourceKind,
+		SourceName:                    row.sourceName,
+		Actors30d:                     row.actors30d,
+		HasPrivilegedScope:            row.hasPrivilegedScope,
+		HasConfidentialScope:          row.hasConfidentialScope,
+		ManagedState:                  row.managedState,
+		ManagedReason:                 row.managedReason,
+		OwnerIdentityID:               row.ownerIdentityID,
+		GovernanceState:               row.governanceState,
+		ReviewDisposition:             row.reviewDisposition,
+		FollowUpDueDate:               datePtr(row.followUpDueDate),
+		ConfiguredBusinessCriticality: row.configuredBusinessCriticality,
+		ConfiguredDataClassification:  row.configuredDataClassification,
+		ConnectorBindingConfigured:    row.connectorBindingConfigured,
+		ConnectorBindingEnabled:       row.connectorBindingEnabled,
+		ConnectorBindingStale:         row.connectorBindingStale,
+		ConnectorBindingHealthy:       row.connectorBindingHealthy,
 	}
 }
 

--- a/internal/readmodels/projector_integration_test.go
+++ b/internal/readmodels/projector_integration_test.go
@@ -136,6 +136,85 @@ func TestProjectorRefreshConnectorSourceStateDoesNotLetDiscoveryFreshnessKeepNon
 	})
 }
 
+func TestProjectorRefreshSaaSAppRiskReadModelsBySourceEvaluatesAndStoresPolicy(t *testing.T) {
+	t.Parallel()
+
+	withReadModelsTestDatabase(t, func(ctx context.Context, pool *pgxpool.Pool, q *gen.Queries, migrator *migrate.Migrate) {
+		migrateUpReadModels(t, migrator)
+
+		sourceKind := "google_workspace"
+		sourceName := "C0123"
+		now := time.Now().UTC().Truncate(time.Second)
+		runID := insertReadModelsSyncRun(t, ctx, pool, sourceKind, sourceName, now)
+		otherRunID := insertReadModelsSyncRun(t, ctx, pool, "okta", "acme.okta.com", now)
+
+		appID := upsertReadModelsSaaSApp(t, ctx, pool, q, "projector-risk-app", "Projector Risk App", "projector.example.com", "Example", now)
+		otherAppID := upsertReadModelsSaaSApp(t, ctx, pool, q, "other-risk-app", "Other Risk App", "other.example.com", "Example", now)
+		upsertReadModelsSaaSAppSource(t, ctx, q, runID, sourceKind, sourceName, "projector-risk-app", "projector-risk-app", "Projector Risk App", "projector.example.com", now)
+		upsertReadModelsSaaSAppSource(t, ctx, q, otherRunID, "okta", "acme.okta.com", "other-risk-app", "other-risk-app", "Other Risk App", "other.example.com", now)
+		upsertReadModelsPrivilegedSaaSAppEvent(t, ctx, q, runID, sourceKind, sourceName, "projector-risk-app", "projector-risk-app", "Projector Risk App", "projector.example.com", now)
+
+		projector := NewProjector(pool, nil, RefreshConfig{})
+		if err := projector.RefreshDiscoverySource(ctx, sourceKind, sourceName); err != nil {
+			t.Fatalf("RefreshDiscoverySource(): %v", err)
+		}
+		if err := projector.RefreshSaaSAppRiskReadModelsBySource(ctx, sourceKind, sourceName); err != nil {
+			t.Fatalf("RefreshSaaSAppRiskReadModelsBySource(): %v", err)
+		}
+
+		row, err := q.GetSaaSAppByID(ctx, appID)
+		if err != nil {
+			t.Fatalf("GetSaaSAppByID(): %v", err)
+		}
+		if row.RiskScore != 95 {
+			t.Fatalf("risk_score = %d, want 95", row.RiskScore)
+		}
+		if row.RiskLevel != "critical" {
+			t.Fatalf("risk_level = %q, want critical", row.RiskLevel)
+		}
+		if row.SuggestedBusinessCriticality != "high" {
+			t.Fatalf("suggested_business_criticality = %q, want high", row.SuggestedBusinessCriticality)
+		}
+		if row.SuggestedDataClassification != "restricted" {
+			t.Fatalf("suggested_data_classification = %q, want restricted", row.SuggestedDataClassification)
+		}
+
+		var effectiveBusinessCriticality, effectiveDataClassification string
+		var policyPackCount int
+		if err := pool.QueryRow(ctx, `
+			SELECT
+				effective_business_criticality,
+				effective_data_classification,
+				jsonb_array_length(policy_packs_json)
+			FROM saas_app_risk_read_models
+			WHERE saas_app_id = $1
+		`, appID).Scan(&effectiveBusinessCriticality, &effectiveDataClassification, &policyPackCount); err != nil {
+			t.Fatalf("select saas_app_risk_read_models: %v", err)
+		}
+		if effectiveBusinessCriticality != "high" {
+			t.Fatalf("effective_business_criticality = %q, want high", effectiveBusinessCriticality)
+		}
+		if effectiveDataClassification != "restricted" {
+			t.Fatalf("effective_data_classification = %q, want restricted", effectiveDataClassification)
+		}
+		if policyPackCount == 0 {
+			t.Fatalf("policy_packs_json length = 0, want policy metadata")
+		}
+
+		var otherRiskRows int
+		if err := pool.QueryRow(ctx, `
+			SELECT count(*)
+			FROM saas_app_risk_read_models
+			WHERE saas_app_id = $1
+		`, otherAppID).Scan(&otherRiskRows); err != nil {
+			t.Fatalf("select other saas_app_risk_read_models count: %v", err)
+		}
+		if otherRiskRows != 0 {
+			t.Fatalf("other source risk rows = %d, want 0", otherRiskRows)
+		}
+	})
+}
+
 func withReadModelsTestDatabase(t *testing.T, fn func(context.Context, *pgxpool.Pool, *gen.Queries, *migrate.Migrate)) {
 	t.Helper()
 
@@ -224,6 +303,89 @@ func upsertReadModelsAppAsset(t *testing.T, ctx context.Context, q *gen.Queries,
 		t.Fatalf("GetAppAssetBySourceAndKindAndExternalID(): %v", err)
 	}
 	return appAsset.ID
+}
+
+func upsertReadModelsSaaSApp(t *testing.T, ctx context.Context, pool *pgxpool.Pool, q *gen.Queries, canonicalKey, displayName, primaryDomain, vendorName string, observedAt time.Time) int64 {
+	t.Helper()
+
+	observed := pgtype.Timestamptz{Time: observedAt.UTC(), Valid: true}
+	if _, err := q.UpsertSaaSAppsBulk(ctx, gen.UpsertSaaSAppsBulkParams{
+		CanonicalKeys:  []string{canonicalKey},
+		DisplayNames:   []string{displayName},
+		PrimaryDomains: []string{primaryDomain},
+		VendorNames:    []string{vendorName},
+		FirstSeenAts:   []pgtype.Timestamptz{observed},
+		LastSeenAts:    []pgtype.Timestamptz{observed},
+	}); err != nil {
+		t.Fatalf("UpsertSaaSAppsBulk(%s): %v", canonicalKey, err)
+	}
+
+	var id int64
+	if err := pool.QueryRow(ctx, `
+		SELECT id
+		FROM saas_apps
+		WHERE canonical_key = $1
+	`, canonicalKey).Scan(&id); err != nil {
+		t.Fatalf("select saas app %s: %v", canonicalKey, err)
+	}
+	return id
+}
+
+func upsertReadModelsSaaSAppSource(t *testing.T, ctx context.Context, q *gen.Queries, runID int64, sourceKind, sourceName, canonicalKey, sourceAppID, sourceAppName, sourceAppDomain string, observedAt time.Time) {
+	t.Helper()
+
+	observed := pgtype.Timestamptz{Time: observedAt.UTC(), Valid: true}
+	if _, err := q.UpsertSaaSAppSourcesBulkBySource(ctx, gen.UpsertSaaSAppSourcesBulkBySourceParams{
+		SeenInRunID:      runID,
+		SourceKind:       sourceKind,
+		SourceName:       sourceName,
+		CanonicalKeys:    []string{canonicalKey},
+		SourceAppIds:     []string{sourceAppID},
+		SourceAppNames:   []string{sourceAppName},
+		SourceAppDomains: []string{sourceAppDomain},
+		SeenAts:          []pgtype.Timestamptz{observed},
+	}); err != nil {
+		t.Fatalf("UpsertSaaSAppSourcesBulkBySource(%s): %v", canonicalKey, err)
+	}
+	if _, err := q.PromoteSaaSAppSourcesSeenInRunBySource(ctx, gen.PromoteSaaSAppSourcesSeenInRunBySourceParams{
+		LastObservedRunID: runID,
+		SourceKind:        sourceKind,
+		SourceName:        sourceName,
+	}); err != nil {
+		t.Fatalf("PromoteSaaSAppSourcesSeenInRunBySource(%s): %v", canonicalKey, err)
+	}
+}
+
+func upsertReadModelsPrivilegedSaaSAppEvent(t *testing.T, ctx context.Context, q *gen.Queries, runID int64, sourceKind, sourceName, canonicalKey, sourceAppID, sourceAppName, sourceAppDomain string, observedAt time.Time) {
+	t.Helper()
+
+	observed := pgtype.Timestamptz{Time: observedAt.UTC(), Valid: true}
+	if _, err := q.UpsertSaaSAppEventsBulkBySource(ctx, gen.UpsertSaaSAppEventsBulkBySourceParams{
+		SeenInRunID:       runID,
+		SourceKind:        sourceKind,
+		SourceName:        sourceName,
+		CanonicalKeys:     []string{canonicalKey},
+		SignalKinds:       []string{"oauth_grant"},
+		EventExternalIds:  []string{sourceAppID + ":grant"},
+		SourceAppIds:      []string{sourceAppID},
+		SourceAppNames:    []string{sourceAppName},
+		SourceAppDomains:  []string{sourceAppDomain},
+		ActorExternalIds:  []string{"actor-1"},
+		ActorEmails:       []string{"actor@example.com"},
+		ActorDisplayNames: []string{"Actor Example"},
+		ObservedAts:       []pgtype.Timestamptz{observed},
+		ScopesJsons:       [][]byte{[]byte(`["files.readwrite.all"]`)},
+		RawJsons:          [][]byte{[]byte(`{}`)},
+	}); err != nil {
+		t.Fatalf("UpsertSaaSAppEventsBulkBySource(%s): %v", canonicalKey, err)
+	}
+	if _, err := q.PromoteSaaSAppEventsSeenInRunBySource(ctx, gen.PromoteSaaSAppEventsSeenInRunBySourceParams{
+		LastObservedRunID: runID,
+		SourceKind:        sourceKind,
+		SourceName:        sourceName,
+	}); err != nil {
+		t.Fatalf("PromoteSaaSAppEventsSeenInRunBySource(%s): %v", canonicalKey, err)
+	}
 }
 
 func fetchConnectorSourceStateTimes(t *testing.T, ctx context.Context, pool *pgxpool.Pool, sourceKind, sourceName string) (time.Time, time.Time) {

--- a/internal/riskpolicy/evaluator.go
+++ b/internal/riskpolicy/evaluator.go
@@ -19,6 +19,11 @@ type RiskSignal struct {
 	PolicyPackVersion string
 }
 
+type PolicyPackRef struct {
+	ID      string `json:"id"`
+	Version string `json:"version"`
+}
+
 type CredentialInput struct {
 	SourceKind            string
 	SourceName            string

--- a/internal/riskpolicy/loader.go
+++ b/internal/riskpolicy/loader.go
@@ -221,7 +221,7 @@ func normalizeAggregation(aggregation *Aggregation) {
 func normalizeAppScope(scope *AppScope) {
 	scope.CanonicalKey = strings.ToLower(strings.TrimSpace(scope.CanonicalKey))
 	scope.PrimaryDomain = strings.ToLower(strings.TrimSpace(scope.PrimaryDomain))
-	scope.VendorName = strings.TrimSpace(scope.VendorName)
+	scope.VendorName = strings.ToLower(strings.TrimSpace(scope.VendorName))
 	scope.SourceKind = strings.ToLower(strings.TrimSpace(scope.SourceKind))
 	scope.SourceName = strings.TrimSpace(scope.SourceName)
 	scope.Category = strings.ToLower(strings.TrimSpace(scope.Category))

--- a/internal/riskpolicy/policies/saas_apps.v1.yaml
+++ b/internal/riskpolicy/policies/saas_apps.v1.yaml
@@ -6,10 +6,12 @@ metadata:
   domain: saas
 spec:
   scoped_rules:
-    - id: github_app_policy
+    - id: github_domain_policy
       scope:
         app:
-          canonical_key: github
+          domain_matches:
+            - github.com
+            - "*.github.com"
       suggestions:
         business_criticality: high
       rules:
@@ -18,22 +20,15 @@ spec:
           score_delta: 20
           when: owner_identity_id == 0
           title: GitHub app has no accountable owner
-    - id: source_control_app_policy
+    - id: github_vendor_policy
       scope:
         app:
-          category: source_control
+          vendor_name: github
       suggestions:
         business_criticality: high
       rules:
-        - id: source_control_missing_owner
-          severity: high
-          score_delta: 15
+        - id: github_missing_owner
+          severity: critical
+          score_delta: 20
           when: owner_identity_id == 0
-          title: Source control app has no accountable owner
-    - id: finance_app_policy
-      scope:
-        app:
-          category: finance
-      suggestions:
-        business_criticality: high
-        data_classification: restricted
+          title: GitHub app has no accountable owner

--- a/internal/riskpolicy/policy_test.go
+++ b/internal/riskpolicy/policy_test.go
@@ -137,6 +137,9 @@ spec:
       - id: non_bool
         level: high
         when: actors_30d
+      - id: default_low
+        level: low
+        when: "true"
 `),
 	})
 	if err == nil {
@@ -173,6 +176,64 @@ spec:
 	}
 	if !strings.Contains(err.Error(), "severe") {
 		t.Fatalf("LoadDocuments() error = %v, want invalid level in error", err)
+	}
+}
+
+func TestLoadDocumentsRejectsUnknownSuggestionLevels(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadDocuments(map[string][]byte{
+		"bad.yaml": []byte(`
+api_version: risk.open-sspm.io/v1
+kind: RiskPolicyPack
+metadata:
+  id: bad
+  version: 1.0.0
+  domain: saas
+spec:
+  inputs:
+    schema: saas_app_risk_input.v1
+  suggestions:
+    data_classification:
+      - id: invalid_unknown_data_classification
+        level: unknown
+        when: "true"
+`),
+	})
+	if err == nil {
+		t.Fatal("LoadDocuments() error = nil, want unknown suggestion level error")
+	}
+	if !strings.Contains(err.Error(), "unknown") {
+		t.Fatalf("LoadDocuments() error = %v, want unknown level in error", err)
+	}
+}
+
+func TestLoadDocumentsRejectsSuggestionRulesWithoutFallback(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadDocuments(map[string][]byte{
+		"bad.yaml": []byte(`
+api_version: risk.open-sspm.io/v1
+kind: RiskPolicyPack
+metadata:
+  id: bad
+  version: 1.0.0
+  domain: saas
+spec:
+  inputs:
+    schema: saas_app_risk_input.v1
+  suggestions:
+    business_criticality:
+      - id: high_usage
+        level: high
+        when: actors_30d >= 50
+`),
+	})
+	if err == nil {
+		t.Fatal("LoadDocuments() error = nil, want deterministic fallback error")
+	}
+	if !strings.Contains(err.Error(), "deterministic fallback") {
+		t.Fatalf("LoadDocuments() error = %v, want deterministic fallback error", err)
 	}
 }
 

--- a/internal/riskpolicy/saas_evaluator.go
+++ b/internal/riskpolicy/saas_evaluator.go
@@ -7,28 +7,28 @@ import (
 )
 
 type SaaSInput struct {
-	CanonicalKey                 string
-	DisplayName                  string
-	PrimaryDomain                string
-	VendorName                   string
-	SourceKind                   string
-	SourceName                   string
-	Category                     string
-	Actors30d                    int64
-	HasPrivilegedScope           bool
-	HasConfidentialScope         bool
-	ManagedState                 string
-	ManagedReason                string
-	OwnerIdentityID              int64
-	GovernanceState              string
-	ReviewDisposition            string
-	FollowUpDueDate              *time.Time
-	EffectiveBusinessCriticality string
-	EffectiveDataClassification  string
-	ConnectorBindingConfigured   bool
-	ConnectorBindingEnabled      bool
-	ConnectorBindingStale        bool
-	ConnectorBindingHealthy      bool
+	CanonicalKey                  string
+	DisplayName                   string
+	PrimaryDomain                 string
+	VendorName                    string
+	SourceKind                    string
+	SourceName                    string
+	Category                      string
+	Actors30d                     int64
+	HasPrivilegedScope            bool
+	HasConfidentialScope          bool
+	ManagedState                  string
+	ManagedReason                 string
+	OwnerIdentityID               int64
+	GovernanceState               string
+	ReviewDisposition             string
+	FollowUpDueDate               *time.Time
+	ConfiguredBusinessCriticality string
+	ConfiguredDataClassification  string
+	ConnectorBindingConfigured    bool
+	ConnectorBindingEnabled       bool
+	ConnectorBindingStale         bool
+	ConnectorBindingHealthy       bool
 }
 
 type SaaSResult struct {
@@ -81,7 +81,13 @@ func (r *Registry) EvaluateSaaS(input SaaSInput) (SaaSResult, error) {
 	for _, scopedRule := range scopedRules {
 		result.PolicyPacks = appendPolicyPackRef(result.PolicyPacks, scopedRule.Pack.Policy.Metadata)
 	}
-	activation := saasActivation(input, globalPack.Policy.Spec.Constants, globalPack.Policy.Spec.Scoring.Base)
+	activation := saasActivation(
+		input,
+		input.ConfiguredBusinessCriticality,
+		input.ConfiguredDataClassification,
+		globalPack.Policy.Spec.Constants,
+		globalPack.Policy.Spec.Scoring.Base,
+	)
 	businessCriticality, err := evaluateSuggestionRules(globalPack, globalPack.Policy.Spec.Suggestions.BusinessCriticality, activation)
 	if err != nil {
 		return SaaSResult{}, err
@@ -101,14 +107,18 @@ func (r *Registry) EvaluateSaaS(input SaaSInput) (SaaSResult, error) {
 		result.SuggestedBusinessCriticality = maxBusinessCriticality(result.SuggestedBusinessCriticality, scopedRule.Rule.Suggestions.BusinessCriticality)
 		result.SuggestedDataClassification = maxDataClassification(result.SuggestedDataClassification, scopedRule.Rule.Suggestions.DataClassification)
 	}
-	input.EffectiveBusinessCriticality = effectiveBusinessCriticality(input.EffectiveBusinessCriticality, result.SuggestedBusinessCriticality)
-	input.EffectiveDataClassification = effectiveDataClassification(input.EffectiveDataClassification, result.SuggestedDataClassification)
-	result.EffectiveBusinessCriticality = input.EffectiveBusinessCriticality
-	result.EffectiveDataClassification = input.EffectiveDataClassification
+	result.EffectiveBusinessCriticality = effectiveBusinessCriticality(input.ConfiguredBusinessCriticality, result.SuggestedBusinessCriticality)
+	result.EffectiveDataClassification = effectiveDataClassification(input.ConfiguredDataClassification, result.SuggestedDataClassification)
 
 	score := globalPack.Policy.Spec.Scoring.Base
 	for _, rule := range globalPack.Policy.Spec.Scoring.Rules {
-		activation = saasActivation(input, globalPack.Policy.Spec.Constants, score)
+		activation = saasActivation(
+			input,
+			result.EffectiveBusinessCriticality,
+			result.EffectiveDataClassification,
+			globalPack.Policy.Spec.Constants,
+			score,
+		)
 		matched, err := globalPack.evaluateBool(rule.ID, activation)
 		if err != nil {
 			return SaaSResult{}, err
@@ -135,7 +145,13 @@ func (r *Registry) EvaluateSaaS(input SaaSInput) (SaaSResult, error) {
 	appliedScopedSignals := make(map[scopedSignalDedupeKey]struct{})
 	for _, scopedRule := range scopedRules {
 		for _, rule := range scopedRule.Rule.Rules {
-			activation = saasActivation(input, scopedRule.Pack.Policy.Spec.Constants, score)
+			activation = saasActivation(
+				input,
+				result.EffectiveBusinessCriticality,
+				result.EffectiveDataClassification,
+				scopedRule.Pack.Policy.Spec.Constants,
+				score,
+			)
 			matched, err := scopedRule.Pack.evaluateBool(scopedRule.Rule.ID+"/"+rule.ID, activation)
 			if err != nil {
 				return SaaSResult{}, err
@@ -164,7 +180,13 @@ func (r *Registry) EvaluateSaaS(input SaaSInput) (SaaSResult, error) {
 	}
 
 	result.RiskScore = clampScore(score, globalPack.Policy.Spec.Scoring.Max)
-	activation = saasActivation(input, globalPack.Policy.Spec.Constants, result.RiskScore)
+	activation = saasActivation(
+		input,
+		result.EffectiveBusinessCriticality,
+		result.EffectiveDataClassification,
+		globalPack.Policy.Spec.Constants,
+		result.RiskScore,
+	)
 	level, err := evaluateLevelRules(globalPack, globalPack.Policy.Spec.Levels, activation)
 	if err != nil {
 		return SaaSResult{}, err
@@ -217,8 +239,8 @@ func normalizeSaaSInput(input SaaSInput) SaaSInput {
 	input.ManagedReason = strings.ToLower(strings.TrimSpace(input.ManagedReason))
 	input.GovernanceState = strings.ToLower(strings.TrimSpace(input.GovernanceState))
 	input.ReviewDisposition = strings.ToLower(strings.TrimSpace(input.ReviewDisposition))
-	input.EffectiveBusinessCriticality = strings.ToLower(strings.TrimSpace(input.EffectiveBusinessCriticality))
-	input.EffectiveDataClassification = strings.ToLower(strings.TrimSpace(input.EffectiveDataClassification))
+	input.ConfiguredBusinessCriticality = strings.ToLower(strings.TrimSpace(input.ConfiguredBusinessCriticality))
+	input.ConfiguredDataClassification = strings.ToLower(strings.TrimSpace(input.ConfiguredDataClassification))
 	input.FollowUpDueDate = normalizeTimePtr(input.FollowUpDueDate)
 	return input
 }
@@ -333,7 +355,13 @@ func matchesDomainPatterns(domain string, patterns []string) bool {
 	return false
 }
 
-func saasActivation(input SaaSInput, constants map[string][]string, score int) map[string]any {
+func saasActivation(
+	input SaaSInput,
+	effectiveBusinessCriticality string,
+	effectiveDataClassification string,
+	constants map[string][]string,
+	score int,
+) map[string]any {
 	activation := map[string]any{
 		"canonical_key":                  input.CanonicalKey,
 		"display_name":                   input.DisplayName,
@@ -350,8 +378,8 @@ func saasActivation(input SaaSInput, constants map[string][]string, score int) m
 		"governance_state":               input.GovernanceState,
 		"review_disposition":             input.ReviewDisposition,
 		"follow_up_due_date":             nullableTime(input.FollowUpDueDate),
-		"effective_business_criticality": input.EffectiveBusinessCriticality,
-		"effective_data_classification":  input.EffectiveDataClassification,
+		"effective_business_criticality": effectiveBusinessCriticality,
+		"effective_data_classification":  effectiveDataClassification,
 		"connector_binding_configured":   input.ConnectorBindingConfigured,
 		"connector_binding_enabled":      input.ConnectorBindingEnabled,
 		"connector_binding_stale":        input.ConnectorBindingStale,

--- a/internal/riskpolicy/saas_evaluator.go
+++ b/internal/riskpolicy/saas_evaluator.go
@@ -39,6 +39,7 @@ type SaaSResult struct {
 	SuggestedDataClassification  string
 	EffectiveBusinessCriticality string
 	EffectiveDataClassification  string
+	PolicyPacks                  []PolicyPackRef
 	Signals                      []RiskSignal
 }
 
@@ -76,6 +77,10 @@ func (r *Registry) EvaluateSaaS(input SaaSInput) (SaaSResult, error) {
 
 	globalPack := *matchedPack
 	scopedRules := r.matchingSaaSScopedRules(input)
+	result.PolicyPacks = appendPolicyPackRef(result.PolicyPacks, globalPack.Policy.Metadata)
+	for _, scopedRule := range scopedRules {
+		result.PolicyPacks = appendPolicyPackRef(result.PolicyPacks, scopedRule.Pack.Policy.Metadata)
+	}
 	activation := saasActivation(input, globalPack.Policy.Spec.Constants, globalPack.Policy.Spec.Scoring.Base)
 	businessCriticality, err := evaluateSuggestionRules(globalPack, globalPack.Policy.Spec.Suggestions.BusinessCriticality, activation)
 	if err != nil {
@@ -127,6 +132,7 @@ func (r *Registry) EvaluateSaaS(input SaaSInput) (SaaSResult, error) {
 		}
 	}
 
+	appliedScopedSignals := make(map[scopedSignalDedupeKey]struct{})
 	for _, scopedRule := range scopedRules {
 		for _, rule := range scopedRule.Rule.Rules {
 			activation = saasActivation(input, scopedRule.Pack.Policy.Spec.Constants, score)
@@ -137,6 +143,11 @@ func (r *Registry) EvaluateSaaS(input SaaSInput) (SaaSResult, error) {
 			if !matched {
 				continue
 			}
+			dedupeKey := scopedSignalKey(scopedRule.Pack.Policy.Metadata, rule)
+			if _, ok := appliedScopedSignals[dedupeKey]; ok {
+				continue
+			}
+			appliedScopedSignals[dedupeKey] = struct{}{}
 
 			score += rule.ScoreDelta
 			result.Signals = append(result.Signals, RiskSignal{
@@ -198,8 +209,8 @@ func normalizeSaaSInput(input SaaSInput) SaaSInput {
 	input.CanonicalKey = strings.ToLower(strings.TrimSpace(input.CanonicalKey))
 	input.DisplayName = strings.TrimSpace(input.DisplayName)
 	input.PrimaryDomain = strings.ToLower(strings.TrimSpace(input.PrimaryDomain))
-	input.VendorName = strings.TrimSpace(input.VendorName)
-	input.SourceKind = strings.ToLower(strings.TrimSpace(input.SourceKind))
+	input.VendorName = strings.ToLower(strings.TrimSpace(input.VendorName))
+	input.SourceKind = normalizeSaaSSourceKind(input.SourceKind)
 	input.SourceName = strings.TrimSpace(input.SourceName)
 	input.Category = strings.ToLower(strings.TrimSpace(input.Category))
 	input.ManagedState = strings.ToLower(strings.TrimSpace(input.ManagedState))
@@ -212,9 +223,52 @@ func normalizeSaaSInput(input SaaSInput) SaaSInput {
 	return input
 }
 
+func normalizeSaaSSourceKind(kind string) string {
+	switch normalized := strings.ToLower(strings.TrimSpace(kind)); normalized {
+	case "aws_identity_center":
+		return "aws"
+	default:
+		return normalized
+	}
+}
+
 type matchedSaaSScopedRule struct {
 	Pack CompiledPack
 	Rule ScopedRule
+}
+
+type scopedSignalDedupeKey struct {
+	PolicyPackID      string
+	PolicyPackVersion string
+	RuleID            string
+	Severity          string
+	ScoreDelta        int
+	Title             string
+	Evidence          string
+}
+
+func scopedSignalKey(metadata PolicyMetadata, rule Rule) scopedSignalDedupeKey {
+	return scopedSignalDedupeKey{
+		PolicyPackID:      metadata.ID,
+		PolicyPackVersion: metadata.Version,
+		RuleID:            rule.ID,
+		Severity:          rule.Severity,
+		ScoreDelta:        rule.ScoreDelta,
+		Title:             rule.Title,
+		Evidence:          rule.Evidence,
+	}
+}
+
+func appendPolicyPackRef(refs []PolicyPackRef, metadata PolicyMetadata) []PolicyPackRef {
+	for _, ref := range refs {
+		if ref.ID == metadata.ID && ref.Version == metadata.Version {
+			return refs
+		}
+	}
+	return append(refs, PolicyPackRef{
+		ID:      metadata.ID,
+		Version: metadata.Version,
+	})
 }
 
 func (r *Registry) matchingSaaSScopedRules(input SaaSInput) []matchedSaaSScopedRule {

--- a/internal/riskpolicy/saas_evaluator_test.go
+++ b/internal/riskpolicy/saas_evaluator_test.go
@@ -494,10 +494,10 @@ func saasGoldenCases() []saasGoldenCase {
 		{
 			name: "governance override lowers effective criticality",
 			input: SaaSInput{
-				Actors30d:                    250,
-				ManagedState:                 "unmanaged",
-				OwnerIdentityID:              42,
-				EffectiveBusinessCriticality: "low",
+				Actors30d:                     250,
+				ManagedState:                  "unmanaged",
+				OwnerIdentityID:               42,
+				ConfiguredBusinessCriticality: "low",
 			},
 			wantScore:                        55,
 			wantLevel:                        SeverityMedium,
@@ -528,14 +528,14 @@ func saasGoldenCases() []saasGoldenCase {
 }
 
 type saasParityCase struct {
-	name                         string
-	actors30d                    int64
-	hasPrivilegedScope           bool
-	hasConfidentialScope         bool
-	bindingState                 string
-	hasOwner                     bool
-	effectiveBusinessCriticality string
-	effectiveDataClassification  string
+	name                          string
+	actors30d                     int64
+	hasPrivilegedScope            bool
+	hasConfidentialScope          bool
+	bindingState                  string
+	hasOwner                      bool
+	configuredBusinessCriticality string
+	configuredDataClassification  string
 }
 
 func saasParityCases() []saasParityCase {
@@ -606,19 +606,19 @@ type saasParityReadModel struct {
 func saasParityInput(index int, tc saasParityCase, ownerID int64) SaaSInput {
 	canonicalKey := fmt.Sprintf("saas-risk-parity-%d", index)
 	input := SaaSInput{
-		CanonicalKey:                 canonicalKey,
-		DisplayName:                  fmt.Sprintf("SaaS Risk Parity %d", index),
-		PrimaryDomain:                canonicalKey + ".example.com",
-		VendorName:                   "Example",
-		Actors30d:                    tc.actors30d,
-		HasPrivilegedScope:           tc.hasPrivilegedScope,
-		HasConfidentialScope:         tc.hasConfidentialScope,
-		ManagedState:                 "unmanaged",
-		ManagedReason:                "no_binding",
-		GovernanceState:              "unreviewed",
-		ReviewDisposition:            "unreviewed",
-		EffectiveBusinessCriticality: configuredOrUnknown(tc.effectiveBusinessCriticality),
-		EffectiveDataClassification:  configuredOrUnknown(tc.effectiveDataClassification),
+		CanonicalKey:                  canonicalKey,
+		DisplayName:                   fmt.Sprintf("SaaS Risk Parity %d", index),
+		PrimaryDomain:                 canonicalKey + ".example.com",
+		VendorName:                    "Example",
+		Actors30d:                     tc.actors30d,
+		HasPrivilegedScope:            tc.hasPrivilegedScope,
+		HasConfidentialScope:          tc.hasConfidentialScope,
+		ManagedState:                  "unmanaged",
+		ManagedReason:                 "no_binding",
+		GovernanceState:               "unreviewed",
+		ReviewDisposition:             "unreviewed",
+		ConfiguredBusinessCriticality: configuredOrUnknown(tc.configuredBusinessCriticality),
+		ConfiguredDataClassification:  configuredOrUnknown(tc.configuredDataClassification),
 	}
 	if tc.hasOwner {
 		input.OwnerIdentityID = ownerID
@@ -748,7 +748,7 @@ func insertSaaSParityApp(t *testing.T, ctx context.Context, pool *pgxpool.Pool, 
 		t.Fatalf("insert saas app: %v", err)
 	}
 
-	if tc.hasOwner || tc.effectiveBusinessCriticality != "" || tc.effectiveDataClassification != "" {
+	if tc.hasOwner || tc.configuredBusinessCriticality != "" || tc.configuredDataClassification != "" {
 		insertSaaSParityGovernance(t, ctx, pool, appID, ownerID, tc)
 	}
 	if tc.bindingState != "" {
@@ -760,11 +760,11 @@ func insertSaaSParityApp(t *testing.T, ctx context.Context, pool *pgxpool.Pool, 
 func insertSaaSParityGovernance(t *testing.T, ctx context.Context, pool *pgxpool.Pool, appID, ownerID int64, tc saasParityCase) {
 	t.Helper()
 
-	businessCriticality := tc.effectiveBusinessCriticality
+	businessCriticality := tc.configuredBusinessCriticality
 	if businessCriticality == "" {
 		businessCriticality = "unknown"
 	}
-	dataClassification := tc.effectiveDataClassification
+	dataClassification := tc.configuredDataClassification
 	if dataClassification == "" {
 		dataClassification = "unknown"
 	}

--- a/internal/riskpolicy/saas_evaluator_test.go
+++ b/internal/riskpolicy/saas_evaluator_test.go
@@ -2,6 +2,7 @@ package riskpolicy
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -67,7 +68,7 @@ func TestEvaluateSaaSGoldenCases(t *testing.T) {
 	}
 }
 
-func TestEvaluateSaaSMatchesDiscoveryReadModelView(t *testing.T) {
+func TestEvaluateSaaSStoredRiskMatchesDiscoveryReadModelView(t *testing.T) {
 	t.Parallel()
 
 	registry, err := LoadBuiltin()
@@ -83,29 +84,32 @@ func TestEvaluateSaaSMatchesDiscoveryReadModelView(t *testing.T) {
 		for i, tc := range saasParityCases() {
 			t.Run(tc.name, func(t *testing.T) {
 				appID := insertSaaSParityApp(t, ctx, pool, i, tc, ownerID, now)
-				row := getSaaSParityReadModel(t, ctx, pool, appID)
+				input := saasParityInput(i, tc, ownerID)
 
-				result, err := registry.EvaluateSaaS(row.input())
+				result, err := registry.EvaluateSaaS(input)
 				if err != nil {
 					t.Fatalf("EvaluateSaaS() error = %v", err)
 				}
+				upsertSaaSParityRiskReadModel(t, ctx, pool, appID, result)
+
+				row := getSaaSParityReadModel(t, ctx, pool, appID)
 				if result.RiskScore != int(row.RiskScore) {
-					t.Fatalf("policy RiskScore = %d, SQL risk_score = %d", result.RiskScore, row.RiskScore)
+					t.Fatalf("policy RiskScore = %d, stored view risk_score = %d", result.RiskScore, row.RiskScore)
 				}
 				if result.RiskLevel != row.RiskLevel {
-					t.Fatalf("policy RiskLevel = %q, SQL risk_level = %q", result.RiskLevel, row.RiskLevel)
+					t.Fatalf("policy RiskLevel = %q, stored view risk_level = %q", result.RiskLevel, row.RiskLevel)
 				}
 				if result.SuggestedBusinessCriticality != row.SuggestedBusinessCriticality {
-					t.Fatalf("policy SuggestedBusinessCriticality = %q, SQL suggested_business_criticality = %q", result.SuggestedBusinessCriticality, row.SuggestedBusinessCriticality)
+					t.Fatalf("policy SuggestedBusinessCriticality = %q, stored view suggested_business_criticality = %q", result.SuggestedBusinessCriticality, row.SuggestedBusinessCriticality)
 				}
 				if result.SuggestedDataClassification != row.SuggestedDataClassification {
-					t.Fatalf("policy SuggestedDataClassification = %q, SQL suggested_data_classification = %q", result.SuggestedDataClassification, row.SuggestedDataClassification)
+					t.Fatalf("policy SuggestedDataClassification = %q, stored view suggested_data_classification = %q", result.SuggestedDataClassification, row.SuggestedDataClassification)
 				}
 				if result.EffectiveBusinessCriticality != row.EffectiveBusinessCriticality {
-					t.Fatalf("policy EffectiveBusinessCriticality = %q, SQL effective_business_criticality = %q", result.EffectiveBusinessCriticality, row.EffectiveBusinessCriticality)
+					t.Fatalf("policy EffectiveBusinessCriticality = %q, stored view effective_business_criticality = %q", result.EffectiveBusinessCriticality, row.EffectiveBusinessCriticality)
 				}
 				if result.EffectiveDataClassification != row.EffectiveDataClassification {
-					t.Fatalf("policy EffectiveDataClassification = %q, SQL effective_data_classification = %q", result.EffectiveDataClassification, row.EffectiveDataClassification)
+					t.Fatalf("policy EffectiveDataClassification = %q, stored view effective_data_classification = %q", result.EffectiveDataClassification, row.EffectiveDataClassification)
 				}
 			})
 		}
@@ -155,6 +159,139 @@ spec:
 	}
 	if !strings.Contains(err.Error(), "multiple saas risk policy packs") {
 		t.Fatalf("EvaluateSaaS() error = %v, want duplicate pack error", err)
+	}
+}
+
+func TestEvaluateSaaSAllowsDifferentScopedSignalsWithSameInnerRuleID(t *testing.T) {
+	t.Parallel()
+
+	registry, err := LoadDocuments(map[string][]byte{
+		"global.yaml": []byte(`
+api_version: risk.open-sspm.io/v1
+kind: RiskPolicyPack
+metadata:
+  id: global
+  version: 1.0.0
+  domain: saas
+spec:
+  inputs:
+    schema: saas_app_risk_input.v1
+  levels:
+    - level: low
+      when: "true"
+`),
+		"scoped.yaml": []byte(`
+api_version: risk.open-sspm.io/v1
+kind: RiskPolicyPack
+metadata:
+  id: scoped
+  version: 1.0.0
+  domain: saas
+spec:
+  scoped_rules:
+    - id: github_owner_policy
+      scope:
+        app:
+          canonical_key: github
+      rules:
+        - id: missing_owner
+          severity: high
+          score_delta: 5
+          when: owner_identity_id == 0
+          title: GitHub app has no owner
+    - id: github_security_policy
+      scope:
+        app:
+          canonical_key: github
+      rules:
+        - id: missing_owner
+          severity: medium
+          score_delta: 7
+          when: owner_identity_id == 0
+          title: GitHub security review owner is missing
+`),
+	})
+	if err != nil {
+		t.Fatalf("LoadDocuments() error = %v", err)
+	}
+
+	result, err := registry.EvaluateSaaS(SaaSInput{
+		CanonicalKey:    "github",
+		OwnerIdentityID: 0,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateSaaS() error = %v", err)
+	}
+	if result.RiskScore != 12 {
+		t.Fatalf("RiskScore = %d, want 12; result=%+v", result.RiskScore, result)
+	}
+	if len(result.Signals) != 2 {
+		t.Fatalf("len(Signals) = %d, want 2; signals=%+v", len(result.Signals), result.Signals)
+	}
+	gotTitles := []string{result.Signals[0].Title, result.Signals[1].Title}
+	wantTitles := []string{
+		"GitHub app has no owner",
+		"GitHub security review owner is missing",
+	}
+	if !sameStringSet(gotTitles, wantTitles) {
+		t.Fatalf("signal titles = %v, want %v", gotTitles, wantTitles)
+	}
+}
+
+func TestEvaluateSaaSNormalizesAWSIdentityCenterSourceKindForScopedRules(t *testing.T) {
+	t.Parallel()
+
+	registry, err := LoadDocuments(map[string][]byte{
+		"global.yaml": []byte(`
+api_version: risk.open-sspm.io/v1
+kind: RiskPolicyPack
+metadata:
+  id: global
+  version: 1.0.0
+  domain: saas
+spec:
+  inputs:
+    schema: saas_app_risk_input.v1
+  levels:
+    - level: low
+      when: "true"
+`),
+		"scoped.yaml": []byte(`
+api_version: risk.open-sspm.io/v1
+kind: RiskPolicyPack
+metadata:
+  id: scoped
+  version: 1.0.0
+  domain: saas
+spec:
+  scoped_rules:
+    - id: aws_policy
+      scope:
+        app:
+          source_kind: aws
+      rules:
+        - id: aws_scoped_signal
+          severity: medium
+          score_delta: 11
+          when: "true"
+          title: AWS app matched scoped source policy
+`),
+	})
+	if err != nil {
+		t.Fatalf("LoadDocuments() error = %v", err)
+	}
+
+	result, err := registry.EvaluateSaaS(SaaSInput{
+		SourceKind: "aws_identity_center",
+	})
+	if err != nil {
+		t.Fatalf("EvaluateSaaS() error = %v", err)
+	}
+	if result.RiskScore != 11 {
+		t.Fatalf("RiskScore = %d, want 11; result=%+v", result.RiskScore, result)
+	}
+	if len(result.Signals) != 1 || result.Signals[0].ID != "aws_scoped_signal" {
+		t.Fatalf("signals = %+v, want aws scoped signal", result.Signals)
 	}
 }
 
@@ -263,9 +400,10 @@ func saasGoldenCases() []saasGoldenCase {
 			wantSignalIDs:                    []string{"privileged_scopes"},
 		},
 		{
-			name: "github missing owner matches scoped policy",
+			name: "github missing owner matches scoped policy by domain",
 			input: SaaSInput{
-				CanonicalKey:    "github",
+				CanonicalKey:    "domain:github.com",
+				PrimaryDomain:   "github.com",
 				ManagedState:    "managed",
 				OwnerIdentityID: 0,
 			},
@@ -281,28 +419,66 @@ func saasGoldenCases() []saasGoldenCase {
 			},
 		},
 		{
-			name: "finance category suggestions feed global scoring",
+			name: "github missing owner matches scoped policy by vendor",
+			input: SaaSInput{
+				CanonicalKey:    "okta_app:acme.okta.com:00ogithub",
+				VendorName:      "GitHub",
+				ManagedState:    "managed",
+				OwnerIdentityID: 0,
+			},
+			wantScore:                        35,
+			wantLevel:                        SeverityMedium,
+			wantBusinessCriticality:          "high",
+			wantDataClassification:           "internal",
+			wantEffectiveBusinessCriticality: "high",
+			wantEffectiveDataClassification:  "internal",
+			wantSignalIDs: []string{
+				"missing_owner",
+				"github_missing_owner",
+			},
+		},
+		{
+			name: "github domain and vendor do not double score scoped policy",
+			input: SaaSInput{
+				CanonicalKey:    "domain:github.com",
+				PrimaryDomain:   "github.com",
+				VendorName:      "GitHub",
+				ManagedState:    "managed",
+				OwnerIdentityID: 0,
+			},
+			wantScore:                        35,
+			wantLevel:                        SeverityMedium,
+			wantBusinessCriticality:          "high",
+			wantDataClassification:           "internal",
+			wantEffectiveBusinessCriticality: "high",
+			wantEffectiveDataClassification:  "internal",
+			wantSignalIDs: []string{
+				"missing_owner",
+				"github_missing_owner",
+			},
+		},
+		{
+			name: "category selectors are dormant until app catalog exists",
 			input: SaaSInput{
 				Category:        "finance",
 				ManagedState:    "unmanaged",
 				OwnerIdentityID: 42,
 			},
-			wantScore:                        60,
-			wantLevel:                        SeverityHigh,
-			wantBusinessCriticality:          "high",
-			wantDataClassification:           "restricted",
-			wantEffectiveBusinessCriticality: "high",
-			wantEffectiveDataClassification:  "restricted",
+			wantScore:                        45,
+			wantLevel:                        SeverityMedium,
+			wantBusinessCriticality:          "low",
+			wantDataClassification:           "internal",
+			wantEffectiveBusinessCriticality: "low",
+			wantEffectiveDataClassification:  "internal",
 			wantSignalIDs: []string{
 				"unmanaged_app",
-				"unmanaged_high_business_app",
-				"unmanaged_sensitive_data_app",
 			},
 		},
 		{
 			name: "github policy does not lower critical usage suggestion",
 			input: SaaSInput{
-				CanonicalKey:    "github",
+				CanonicalKey:    "domain:github.com",
+				PrimaryDomain:   "github.com",
 				Actors30d:       250,
 				ManagedState:    "managed",
 				OwnerIdentityID: 42,
@@ -427,26 +603,103 @@ type saasParityReadModel struct {
 	SuggestedDataClassification  string
 }
 
-func (row saasParityReadModel) input() SaaSInput {
-	return SaaSInput{
-		CanonicalKey:                 row.CanonicalKey,
-		DisplayName:                  row.DisplayName,
-		PrimaryDomain:                row.PrimaryDomain,
-		VendorName:                   row.VendorName,
-		Actors30d:                    row.Actors30d,
-		HasPrivilegedScope:           row.HasPrivilegedScope,
-		HasConfidentialScope:         row.HasConfidentialScope,
-		ManagedState:                 row.ManagedState,
-		ManagedReason:                row.ManagedReason,
-		OwnerIdentityID:              row.OwnerIdentityID,
-		GovernanceState:              row.GovernanceState,
-		ReviewDisposition:            row.ReviewDisposition,
-		EffectiveBusinessCriticality: row.EffectiveBusinessCriticality,
-		EffectiveDataClassification:  row.EffectiveDataClassification,
-		ConnectorBindingConfigured:   row.ConnectorConfigured,
-		ConnectorBindingEnabled:      row.ConnectorEnabled,
-		ConnectorBindingStale:        row.ConnectorStale,
-		ConnectorBindingHealthy:      row.ConnectorHealthy,
+func saasParityInput(index int, tc saasParityCase, ownerID int64) SaaSInput {
+	canonicalKey := fmt.Sprintf("saas-risk-parity-%d", index)
+	input := SaaSInput{
+		CanonicalKey:                 canonicalKey,
+		DisplayName:                  fmt.Sprintf("SaaS Risk Parity %d", index),
+		PrimaryDomain:                canonicalKey + ".example.com",
+		VendorName:                   "Example",
+		Actors30d:                    tc.actors30d,
+		HasPrivilegedScope:           tc.hasPrivilegedScope,
+		HasConfidentialScope:         tc.hasConfidentialScope,
+		ManagedState:                 "unmanaged",
+		ManagedReason:                "no_binding",
+		GovernanceState:              "unreviewed",
+		ReviewDisposition:            "unreviewed",
+		EffectiveBusinessCriticality: configuredOrUnknown(tc.effectiveBusinessCriticality),
+		EffectiveDataClassification:  configuredOrUnknown(tc.effectiveDataClassification),
+	}
+	if tc.hasOwner {
+		input.OwnerIdentityID = ownerID
+	}
+
+	if tc.bindingState == "" {
+		return input
+	}
+
+	input.SourceKind = "entra"
+	input.SourceName = fmt.Sprintf("tenant-%d", index)
+	input.ConnectorBindingConfigured = true
+	input.ConnectorBindingEnabled = true
+	switch tc.bindingState {
+	case "disabled":
+		input.ManagedReason = "connector_disabled"
+		input.ConnectorBindingEnabled = false
+	case "not_configured":
+		input.ManagedReason = "connector_not_configured"
+		input.ConnectorBindingConfigured = false
+	case "stale":
+		input.ManagedReason = "stale_sync"
+		input.ConnectorBindingStale = true
+	case "managed":
+		input.ManagedState = "managed"
+		input.ManagedReason = "active_binding_fresh_sync"
+		input.ConnectorBindingHealthy = true
+	}
+	return input
+}
+
+func configuredOrUnknown(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "unknown"
+	}
+	return value
+}
+
+func upsertSaaSParityRiskReadModel(t *testing.T, ctx context.Context, pool *pgxpool.Pool, appID int64, result SaaSResult) {
+	t.Helper()
+
+	policyPacksJSON, err := json.Marshal(result.PolicyPacks)
+	if err != nil {
+		t.Fatalf("marshal policy packs: %v", err)
+	}
+
+	_, err = pool.Exec(ctx, `
+		INSERT INTO saas_app_risk_read_models (
+			saas_app_id,
+			risk_score,
+			risk_level,
+			risk_rank,
+			suggested_business_criticality,
+			suggested_data_classification,
+			effective_business_criticality,
+			effective_data_classification,
+			policy_packs_json
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		ON CONFLICT (saas_app_id) DO UPDATE SET
+			risk_score = EXCLUDED.risk_score,
+			risk_level = EXCLUDED.risk_level,
+			risk_rank = EXCLUDED.risk_rank,
+			suggested_business_criticality = EXCLUDED.suggested_business_criticality,
+			suggested_data_classification = EXCLUDED.suggested_data_classification,
+			effective_business_criticality = EXCLUDED.effective_business_criticality,
+			effective_data_classification = EXCLUDED.effective_data_classification,
+			policy_packs_json = EXCLUDED.policy_packs_json,
+			projection_refreshed_at = now()
+	`, appID,
+		result.RiskScore,
+		result.RiskLevel,
+		result.RiskRank,
+		result.SuggestedBusinessCriticality,
+		result.SuggestedDataClassification,
+		result.EffectiveBusinessCriticality,
+		result.EffectiveDataClassification,
+		policyPacksJSON,
+	)
+	if err != nil {
+		t.Fatalf("upsert saas app risk read model: %v", err)
 	}
 }
 

--- a/internal/riskpolicy/validate.go
+++ b/internal/riskpolicy/validate.go
@@ -64,6 +64,9 @@ func validateSuggestions(errs *[]error, path string, rules []SuggestionRule, rul
 			*errs = append(*errs, fmt.Errorf("%s.when is required", currentPath))
 		}
 	}
+	if len(rules) > 0 && strings.TrimSpace(rules[len(rules)-1].When) != "true" {
+		*errs = append(*errs, fmt.Errorf("%s must end with a deterministic fallback where when is true", path))
+	}
 }
 
 func validateScoring(errs *[]error, scoring Scoring, ruleIDs map[string]string) {
@@ -166,7 +169,7 @@ func validateScopedSuggestions(errs *[]error, path string, suggestions ScopedSug
 
 func validBusinessCriticality(value string) bool {
 	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "unknown", "low", "medium", "high", "critical":
+	case "low", "medium", "high", "critical":
 		return true
 	default:
 		return false
@@ -175,7 +178,7 @@ func validBusinessCriticality(value string) bool {
 
 func validDataClassification(value string) bool {
 	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "unknown", "public", "internal", "confidential", "restricted":
+	case "public", "internal", "confidential", "restricted":
 		return true
 	default:
 		return false


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR materialises SaaS app risk evaluation results into a new `saas_app_risk_read_models` table (migration 48) and wires the builtin risk policy registry into three refresh paths: startup, post-connector-sync, and per-app governance update. The `discovery_app_read_models_v` view is updated to read `risk_score`/`risk_level` from the stored table rather than computing them inline. The scoped policy YAML switches from canonical-key/category selectors to domain-match and vendor-name selectors, and the evaluator gains signal deduplication and policy-pack reference tracking.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all findings are P2 quality-of-life issues with no correctness impact on the happy path.

No P0 or P1 issues found. The deduplication logic, migration ordering, bulk-upsert, and policy evaluation flow are all correct. Findings are limited to a dead SQL condition, a misleading field name, a missing pgx.ErrNoRows guard in an edge case, and a redundant join that lacks a clarifying comment.

internal/readmodels/projector.go (saasPolicyInput field naming, ErrNoRows guard) and db/queries/read_models.sql (dead IS NULL condition, redundant join).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/riskpolicy/saas_evaluator.go | Adds deduplication of scoped signals via a composite key (pack ID+version+rule ID+severity+delta+title), policy-pack reference tracking, and AWS Identity Center source-kind normalisation. Logic is sound; dedup key correctly prevents the same scoped rule from firing twice when matched by overlapping selectors in the same pack. |
| internal/readmodels/projector.go | Adds three new refresh paths (all, by-source, by-ID) that evaluate the builtin risk registry and bulk-upsert results. The `saasPolicyInput` helper maps `configuredBusinessCriticality` to `SaaSInput.EffectiveBusinessCriticality`, which is semantically misleading. `refreshSaaSAppRiskReadModelByID` does not handle `pgx.ErrNoRows`, risking rollback of governance transactions on concurrent deletes. |
| db/queries/read_models.sql | Adds risk-input queries (all, by-source, by-ID) and a bulk upsert. The needs-rebuild check includes a dead `projection_refreshed_at IS NULL` guard that can never be true given the NOT NULL column constraint. Governance table is also re-joined redundantly without explanatory comment. |
| db/migrations/000048_saas_app_risk_read_models.up.sql | Creates `saas_app_risk_read_models` table with appropriate FK, check constraints and indexes; replaces `discovery_app_read_models_v` to join the new table for risk_score/risk_level. Schema and index choices look correct. |
| db/migrations/000048_saas_app_risk_read_models.down.sql | Correctly restores the old view (with inline risk scoring) before dropping the risk read model table. Ordering is safe — view is replaced before the table is dropped. |
| internal/riskpolicy/validate.go | Adds deterministic-fallback validation for suggestion rule lists and removes "unknown" from valid suggestion levels. Both changes are correct and consistent with the evaluator's treatment of "unknown" as an input sentinel. |
| internal/riskpolicy/policies/saas_apps.v1.yaml | Replaces canonical-key and category-based scoped rules with domain-match and vendor-name selectors. Both github_domain_policy and github_vendor_policy now use the same severity=critical and score_delta=20, ensuring the dedup key is identical and double-scoring is correctly prevented for apps matching both selectors. |
| internal/http/handlers/discovery.go | Triggers `RefreshSaaSAppRiskReadModelByID` after governance updates are persisted, keeping risk read models consistent with governance changes within the same transaction. |
| internal/http/handlers/settings.go | Extends connector toggle and save handlers to refresh all SaaS app risk read models after connector state changes, correctly chaining after connector source state refresh. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Connector as Connector Sync
    participant Handler as HTTP Handler
    participant Projector as Projector
    participant Registry as Risk Registry
    participant DB as PostgreSQL

    Note over Connector,DB: Post-sync refresh path
    Connector->>Projector: RefreshSaaSAppRiskReadModelsBySource(kind, name)
    Projector->>DB: ListSaaSAppRiskInputsBySource(kind, name)
    DB-->>Projector: []saasAppRiskInputRow

    Note over Handler,DB: Governance update path
    Handler->>DB: UpsertGovernanceOverride (in tx)
    Handler->>Projector: RefreshSaaSAppRiskReadModelByID(appID)
    Projector->>DB: GetSaaSAppRiskInputByID(appID)
    DB-->>Projector: saasAppRiskInputRow

    Projector->>Registry: EvaluateSaaS(input) per row
    Registry-->>Projector: SaaSResult (score, level, rank, PolicyPacks)
    Projector->>DB: UpsertSaaSAppRiskReadModelsBulk(params)

    Note over DB: saas_app_risk_read_models updated
    Note over DB: discovery_app_read_models_v reads from it
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `db/queries/read_models.sql`, line 374-381 ([link](https://github.com/open-sspm/open-sspm/blob/69ea9e28d61ae414281c0306efbc5b1b7fbcb9eb/db/queries/read_models.sql#L374-L381)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Dead condition in needs-rebuild check**

   `risk.projection_refreshed_at IS NULL` can never be true because the column is declared `NOT NULL DEFAULT now()` — once a row exists in `saas_app_risk_read_models` the timestamp is always set. The only meaningful condition is `risk.saas_app_id IS NULL` (app has no risk row yet). Leaving the dead clause in makes the intent of the check harder to read.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: db/queries/read_models.sql
   Line: 374-381

   Comment:
   **Dead condition in needs-rebuild check**

   `risk.projection_refreshed_at IS NULL` can never be true because the column is declared `NOT NULL DEFAULT now()` — once a row exists in `saas_app_risk_read_models` the timestamp is always set. The only meaningful condition is `risk.saas_app_id IS NULL` (app has no risk row yet). Leaving the dead clause in makes the intent of the check harder to read.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `internal/readmodels/projector.go`, line 1552-1576 ([link](https://github.com/open-sspm/open-sspm/blob/69ea9e28d61ae414281c0306efbc5b1b7fbcb9eb/internal/readmodels/projector.go#L1552-L1576)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Misleading field name in `saasPolicyInput`**

   `EffectiveBusinessCriticality` and `EffectiveDataClassification` in `SaaSInput` receive the *raw configured* governance value (e.g. `"unknown"` when the user hasn't set anything), not the computed effective value. The evaluator treats `"unknown"` as a sentinel meaning "no user override" and falls back to the suggested level. The field name implies the value has already been resolved, which may confuse future maintainers reading the evaluator. Renaming the input fields to `ConfiguredBusinessCriticality` / `ConfiguredDataClassification` would align them with what `configured_business_criticality` means in the SQL layer.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/readmodels/projector.go
   Line: 1552-1576

   Comment:
   **Misleading field name in `saasPolicyInput`**

   `EffectiveBusinessCriticality` and `EffectiveDataClassification` in `SaaSInput` receive the *raw configured* governance value (e.g. `"unknown"` when the user hasn't set anything), not the computed effective value. The evaluator treats `"unknown"` as a sentinel meaning "no user override" and falls back to the suggested level. The field name implies the value has already been resolved, which may confuse future maintainers reading the evaluator. Renaming the input fields to `ConfiguredBusinessCriticality` / `ConfiguredDataClassification` would align them with what `configured_business_criticality` means in the SQL layer.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `internal/readmodels/projector.go`, line 1473-1505 ([link](https://github.com/open-sspm/open-sspm/blob/69ea9e28d61ae414281c0306efbc5b1b7fbcb9eb/internal/readmodels/projector.go#L1473-L1505)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`pgx.ErrNoRows` propagates as transaction failure in governance updates**

   `refreshSaaSAppRiskReadModelByID` is called from `persistDiscoveryGovernanceUpdate` inside an active transaction. If `GetSaaSAppRiskInputByID` returns `pgx.ErrNoRows` — for example because the app was concurrently deleted between the governance write and this read — the error propagates and rolls back the entire governance update rather than succeeding silently. Consider checking `errors.Is(err, pgx.ErrNoRows)` and returning `nil` so the governance write isn't lost in that edge case.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/readmodels/projector.go
   Line: 1473-1505

   Comment:
   **`pgx.ErrNoRows` propagates as transaction failure in governance updates**

   `refreshSaaSAppRiskReadModelByID` is called from `persistDiscoveryGovernanceUpdate` inside an active transaction. If `GetSaaSAppRiskInputByID` returns `pgx.ErrNoRows` — for example because the app was concurrently deleted between the governance write and this read — the error propagates and rolls back the entire governance update rather than succeeding silently. Consider checking `errors.Is(err, pgx.ErrNoRows)` and returning `nil` so the governance write isn't lost in that edge case.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


4. `db/queries/read_models.sql`, line 389-417 ([link](https://github.com/open-sspm/open-sspm/blob/69ea9e28d61ae414281c0306efbc5b1b7fbcb9eb/db/queries/read_models.sql#L389-L417)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`governance_subject_overrides` re-joined when already available from the view**

   `ListAllSaaSAppRiskInputs` (and its siblings `ListSaaSAppRiskInputsBySource`, `GetSaaSAppRiskInputByID`) join `governance_subject_overrides` a second time even though `discovery_app_read_models_v` already materialises governance data. The extra join is intentional (to get the raw `business_criticality` / `data_classification` strings rather than the view's computed effective values), but at scale this doubles the governance table access per row. A comment explaining why the direct join is preferred over pulling from the view columns would clarify the intent and prevent accidental simplification that loses the raw values.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: db/queries/read_models.sql
   Line: 389-417

   Comment:
   **`governance_subject_overrides` re-joined when already available from the view**

   `ListAllSaaSAppRiskInputs` (and its siblings `ListSaaSAppRiskInputsBySource`, `GetSaaSAppRiskInputByID`) join `governance_subject_overrides` a second time even though `discovery_app_read_models_v` already materialises governance data. The extra join is intentional (to get the raw `business_criticality` / `data_classification` strings rather than the view's computed effective values), but at scale this doubles the governance table access per row. A comment explaining why the direct join is preferred over pulling from the view columns would clarify the intent and prevent accidental simplification that loses the raw values.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: db/queries/read_models.sql
Line: 374-381

Comment:
**Dead condition in needs-rebuild check**

`risk.projection_refreshed_at IS NULL` can never be true because the column is declared `NOT NULL DEFAULT now()` — once a row exists in `saas_app_risk_read_models` the timestamp is always set. The only meaningful condition is `risk.saas_app_id IS NULL` (app has no risk row yet). Leaving the dead clause in makes the intent of the check harder to read.

```suggestion
  OR EXISTS (
    SELECT 1
    FROM saas_apps sa
    LEFT JOIN saas_app_risk_read_models risk
      ON risk.saas_app_id = sa.id
    WHERE risk.saas_app_id IS NULL
  )
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/readmodels/projector.go
Line: 1552-1576

Comment:
**Misleading field name in `saasPolicyInput`**

`EffectiveBusinessCriticality` and `EffectiveDataClassification` in `SaaSInput` receive the *raw configured* governance value (e.g. `"unknown"` when the user hasn't set anything), not the computed effective value. The evaluator treats `"unknown"` as a sentinel meaning "no user override" and falls back to the suggested level. The field name implies the value has already been resolved, which may confuse future maintainers reading the evaluator. Renaming the input fields to `ConfiguredBusinessCriticality` / `ConfiguredDataClassification` would align them with what `configured_business_criticality` means in the SQL layer.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/readmodels/projector.go
Line: 1473-1505

Comment:
**`pgx.ErrNoRows` propagates as transaction failure in governance updates**

`refreshSaaSAppRiskReadModelByID` is called from `persistDiscoveryGovernanceUpdate` inside an active transaction. If `GetSaaSAppRiskInputByID` returns `pgx.ErrNoRows` — for example because the app was concurrently deleted between the governance write and this read — the error propagates and rolls back the entire governance update rather than succeeding silently. Consider checking `errors.Is(err, pgx.ErrNoRows)` and returning `nil` so the governance write isn't lost in that edge case.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: db/queries/read_models.sql
Line: 389-417

Comment:
**`governance_subject_overrides` re-joined when already available from the view**

`ListAllSaaSAppRiskInputs` (and its siblings `ListSaaSAppRiskInputsBySource`, `GetSaaSAppRiskInputByID`) join `governance_subject_overrides` a second time even though `discovery_app_read_models_v` already materialises governance data. The extra join is intentional (to get the raw `business_criticality` / `data_classification` strings rather than the view's computed effective values), but at scale this doubles the governance table access per row. A comment explaining why the direct join is preferred over pulling from the view columns would clarify the intent and prevent accidental simplification that loses the raw values.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: risk eval config m3"](https://github.com/open-sspm/open-sspm/commit/69ea9e28d61ae414281c0306efbc5b1b7fbcb9eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29711147)</sub>

<!-- /greptile_comment -->