### PR TITLE
feat: wire non-human read-model refresh to the identity evaluator

### DIFF
--- a/cmd/open-sspm/read_models.go
+++ b/cmd/open-sspm/read_models.go
@@ -44,6 +44,9 @@ func rebuildStoredReadModels(ctx context.Context, pool *pgxpool.Pool, q *gen.Que
 		if err := projector.RefreshAllSaaSAppRiskReadModels(ctx); err != nil {
 			return err
 		}
+		if err := projector.RefreshAllCredentialArtifactRiskReadModels(ctx); err != nil {
+			return err
+		}
 		return projector.RefreshAllNonHumanPrincipalReadModels(ctx)
 	case startupReadModelsActionRebuildAll:
 		reason := "forced"

--- a/cmd/open-sspm/read_models.go
+++ b/cmd/open-sspm/read_models.go
@@ -37,11 +37,14 @@ func rebuildStoredReadModels(ctx context.Context, pool *pgxpool.Pool, q *gen.Que
 
 	switch action {
 	case startupReadModelsActionRefreshConnectorState:
-		slog.Info("refreshing connector source state and SaaS risk read models on startup")
+		slog.Info("refreshing connector source state and policy-backed risk read models on startup")
 		if err := projector.RefreshConnectorSourceState(ctx); err != nil {
 			return err
 		}
-		return projector.RefreshAllSaaSAppRiskReadModels(ctx)
+		if err := projector.RefreshAllSaaSAppRiskReadModels(ctx); err != nil {
+			return err
+		}
+		return projector.RefreshAllNonHumanPrincipalReadModels(ctx)
 	case startupReadModelsActionRebuildAll:
 		reason := "forced"
 		if needsRebuild {

--- a/db/migrations/000049_non_human_policy_signal_storage.down.sql
+++ b/db/migrations/000049_non_human_policy_signal_storage.down.sql
@@ -1,0 +1,37 @@
+DROP VIEW IF EXISTS non_human_principal_read_models_v;
+
+DROP INDEX IF EXISTS idx_non_human_principals_source_risk_priority;
+
+ALTER TABLE non_human_principals
+  DROP COLUMN IF EXISTS policy_packs_json,
+  DROP COLUMN IF EXISTS risk_signals_json;
+
+CREATE OR REPLACE VIEW non_human_principal_read_models_v AS
+SELECT
+  nhp.principal_ref,
+  nhp.identity_id,
+  nhp.app_asset_id,
+  nhp.principal_type,
+  nhp.source_kind,
+  nhp.source_name,
+  nhp.display_name,
+  nhp.secondary_name,
+  nhp.linked_assets_count,
+  nhp.linked_credentials_count,
+  nhp.last_seen_at,
+  nhp.activity_state,
+  nhp.freshness_state,
+  nhp.governance_state,
+  nhp.accountable_owner_identity_id,
+  nhp.accountable_owner_display_name,
+  nhp.accountable_owner_primary_email,
+  nhp.owner_presence,
+  nhp.has_critical_credential,
+  nhp.has_high_risk_credential,
+  nhp.has_expired_credential,
+  nhp.has_expiring_credential,
+  nhp.has_unused_credential,
+  nhp.has_stale_evidence,
+  nhp.risk_reason_count,
+  nhp.risk_level
+FROM non_human_principals nhp;

--- a/db/migrations/000049_non_human_policy_signal_storage.up.sql
+++ b/db/migrations/000049_non_human_policy_signal_storage.up.sql
@@ -1,0 +1,40 @@
+DROP VIEW IF EXISTS non_human_principal_read_models_v;
+
+ALTER TABLE non_human_principals
+  ADD COLUMN IF NOT EXISTS risk_signals_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  ADD COLUMN IF NOT EXISTS policy_packs_json JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+CREATE INDEX IF NOT EXISTS idx_non_human_principals_source_risk_priority
+  ON non_human_principals (source_kind, source_name, risk_level, owner_presence, governance_state, freshness_state);
+
+CREATE OR REPLACE VIEW non_human_principal_read_models_v AS
+SELECT
+  nhp.principal_ref,
+  nhp.identity_id,
+  nhp.app_asset_id,
+  nhp.principal_type,
+  nhp.source_kind,
+  nhp.source_name,
+  nhp.display_name,
+  nhp.secondary_name,
+  nhp.linked_assets_count,
+  nhp.linked_credentials_count,
+  nhp.last_seen_at,
+  nhp.activity_state,
+  nhp.freshness_state,
+  nhp.governance_state,
+  nhp.accountable_owner_identity_id,
+  nhp.accountable_owner_display_name,
+  nhp.accountable_owner_primary_email,
+  nhp.owner_presence,
+  nhp.has_critical_credential,
+  nhp.has_high_risk_credential,
+  nhp.has_expired_credential,
+  nhp.has_expiring_credential,
+  nhp.has_unused_credential,
+  nhp.has_stale_evidence,
+  nhp.risk_reason_count,
+  nhp.risk_level,
+  nhp.risk_signals_json,
+  nhp.policy_packs_json
+FROM non_human_principals nhp;

--- a/db/migrations/000050_credential_policy_read_models.down.sql
+++ b/db/migrations/000050_credential_policy_read_models.down.sql
@@ -1,0 +1,559 @@
+CREATE OR REPLACE FUNCTION credential_artifact_risk_level(
+  status text,
+  credential_kind text,
+  expires_at_source timestamptz,
+  last_used_at_source timestamptz,
+  created_by_external_id text,
+  approved_by_external_id text,
+  evaluated_at timestamptz
+)
+RETURNS text
+LANGUAGE sql
+STABLE
+AS $$
+SELECT CASE
+  WHEN expires_at_source IS NOT NULL
+    AND expires_at_source < evaluated_at
+    AND lower(COALESCE(NULLIF(trim(status), ''), 'active')) IN ('active', 'approved', 'pending_approval')
+    THEN 'critical'
+  WHEN expires_at_source IS NOT NULL
+    AND expires_at_source < evaluated_at
+    THEN 'high'
+  WHEN lower(trim(COALESCE(credential_kind, ''))) IN ('entra_client_secret', 'github_deploy_key', 'github_pat_request', 'github_pat_fine_grained')
+    AND trim(COALESCE(created_by_external_id, '')) = ''
+    AND trim(COALESCE(approved_by_external_id, '')) = ''
+    THEN 'critical'
+  WHEN expires_at_source IS NOT NULL
+    AND expires_at_source >= evaluated_at
+    AND expires_at_source <= evaluated_at + make_interval(days => 7)
+    THEN 'high'
+  WHEN trim(COALESCE(created_by_external_id, '')) = ''
+    THEN 'high'
+  WHEN last_used_at_source IS NOT NULL
+    AND last_used_at_source <= evaluated_at - make_interval(days => 90)
+    THEN 'high'
+  WHEN expires_at_source IS NOT NULL
+    AND expires_at_source >= evaluated_at
+    AND expires_at_source <= evaluated_at + make_interval(days => 30)
+    THEN 'medium'
+  ELSE 'low'
+END;
+$$;
+
+CREATE OR REPLACE VIEW non_human_principal_projection_v AS
+WITH active_accounts AS (
+  SELECT
+    a.id AS account_id,
+    a.source_kind,
+    a.source_name,
+    a.external_id,
+    a.display_name AS account_display_name,
+    a.email,
+    a.entity_category,
+    a.created_at,
+    a.last_observed_at,
+    non_human_account_asset_external_id(a.source_kind, a.entity_category, a.external_id) AS asset_match_external_id
+  FROM accounts a
+  WHERE a.expired_at IS NULL
+    AND a.last_observed_run_id IS NOT NULL
+),
+non_human_identity_accounts AS (
+  SELECT
+    i.id AS identity_id,
+    i.kind AS principal_type,
+    COALESCE(NULLIF(trim(i.display_name), ''), NULLIF(trim(i.primary_email), ''), 'Identity ' || i.id::text)::text AS display_name,
+    COALESCE(i.primary_email, '')::text AS primary_email,
+    aa.account_id,
+    aa.source_kind,
+    aa.source_name,
+    aa.external_id,
+    aa.created_at,
+    aa.last_observed_at
+  FROM identities i
+  JOIN identity_accounts ia ON ia.identity_id = i.id
+  JOIN active_accounts aa ON aa.account_id = ia.account_id
+  WHERE i.kind IN ('service', 'bot')
+),
+identity_primary_source AS (
+  SELECT DISTINCT ON (nia.identity_id)
+    nia.identity_id,
+    nia.source_kind,
+    nia.source_name,
+    nia.external_id
+  FROM non_human_identity_accounts nia
+  LEFT JOIN identity_source_settings iss
+    ON iss.source_kind = nia.source_kind
+   AND iss.source_name = nia.source_name
+   AND iss.is_authoritative
+  ORDER BY nia.identity_id, (iss.is_authoritative IS NOT TRUE), nia.account_id
+),
+identity_summary AS (
+  SELECT
+    nia.identity_id,
+    min(nia.principal_type)::text AS principal_type,
+    min(nia.display_name)::text AS display_name,
+    min(nia.primary_email)::text AS primary_email,
+    max(nia.last_observed_at)::timestamptz AS account_last_seen_at,
+    min(nia.created_at)::timestamptz AS first_seen_at
+  FROM non_human_identity_accounts nia
+  GROUP BY nia.identity_id
+),
+active_assets AS (
+  SELECT
+    pr.id::bigint AS app_asset_id,
+    pr.source_kind::text AS source_kind,
+    pr.source_name::text AS source_name,
+    pr.asset_kind::text AS asset_kind,
+    pr.external_id::text AS external_id,
+    pr.parent_external_id::text AS parent_external_id,
+    COALESCE(NULLIF(trim(pr.display_name), ''), pr.external_id)::text AS display_name,
+    pr.status::text AS status,
+    pr.governance_state::text AS governance_state,
+    pr.governance_owner_identity_id::bigint AS governance_owner_identity_id,
+    pr.governance_owner_display_name::text AS governance_owner_display_name,
+    pr.governance_owner_primary_email::text AS governance_owner_primary_email,
+    pr.evidence_last_seen_at::timestamptz AS evidence_last_seen_at,
+    pr.evidence_freshness::text AS evidence_freshness
+  FROM connected_app_read_models_v pr
+),
+connector_state AS (
+  SELECT
+    css.source_kind,
+    css.source_name,
+    css.fresh_until_at
+  FROM connector_source_state css
+),
+identity_connector_state AS (
+  SELECT
+    ips.identity_id,
+    css.fresh_until_at
+  FROM identity_primary_source ips
+  LEFT JOIN connector_state css
+    ON css.source_kind = ips.source_kind
+   AND lower(trim(css.source_name)) = lower(trim(ips.source_name))
+),
+asset_owner_candidates AS (
+  SELECT
+    aa.app_asset_id,
+    COALESCE(owner_by_external.id, owner_by_email.id, 0)::bigint AS owner_identity_id,
+    COALESCE(
+      NULLIF(trim(owner_by_external.display_name), ''),
+      NULLIF(trim(owner_by_email.display_name), ''),
+      NULLIF(trim(aao.owner_display_name), ''),
+      NULLIF(trim(aao.owner_email), ''),
+      trim(aao.owner_external_id)
+    )::text AS owner_display_name,
+    COALESCE(
+      NULLIF(trim(owner_by_external.primary_email), ''),
+      NULLIF(trim(owner_by_email.primary_email), ''),
+      NULLIF(lower(trim(aao.owner_email)), ''),
+      ''
+    )::text AS owner_primary_email,
+    count(*) OVER (PARTITION BY aa.app_asset_id)::bigint AS owner_count,
+    row_number() OVER (
+      PARTITION BY aa.app_asset_id
+      ORDER BY lower(
+        COALESCE(
+          NULLIF(trim(aao.owner_display_name), ''),
+          NULLIF(trim(aao.owner_email), ''),
+          trim(aao.owner_external_id)
+        )
+      ) ASC,
+      aao.id ASC
+    ) AS row_num
+  FROM app_asset_owners aao
+  JOIN active_assets aa ON aa.app_asset_id = aao.app_asset_id
+  LEFT JOIN LATERAL (
+    SELECT
+      i.id,
+      i.display_name,
+      i.primary_email
+    FROM active_accounts oa
+    JOIN identity_accounts ia ON ia.account_id = oa.account_id
+    JOIN identities i ON i.id = ia.identity_id
+    WHERE oa.source_kind = aa.source_kind
+      AND oa.source_name = aa.source_name
+      AND lower(trim(oa.external_id)) = lower(trim(aao.owner_external_id))
+    ORDER BY i.id ASC
+    LIMIT 1
+  ) owner_by_external ON TRUE
+  LEFT JOIN LATERAL (
+    SELECT
+      i.id,
+      i.display_name,
+      i.primary_email
+    FROM identities i
+    WHERE lower(trim(i.primary_email)) = lower(trim(aao.owner_email))
+    ORDER BY i.id ASC
+    LIMIT 1
+  ) owner_by_email ON TRUE
+  WHERE aao.expired_at IS NULL
+    AND aao.last_observed_run_id IS NOT NULL
+),
+asset_owner_choice AS (
+  SELECT
+    aoc.app_asset_id,
+    aoc.owner_identity_id,
+    CASE
+      WHEN aoc.owner_count > 1 THEN aoc.owner_display_name || ' +' || (aoc.owner_count - 1)::text
+      ELSE aoc.owner_display_name
+    END::text AS owner_display_name,
+    aoc.owner_primary_email::text AS owner_primary_email,
+    aoc.owner_count::bigint AS owner_count
+  FROM asset_owner_candidates aoc
+  WHERE aoc.row_num = 1
+),
+asset_credential_stats AS (
+  SELECT
+    aa.app_asset_id,
+    count(DISTINCT ca.id)::bigint AS linked_credentials_count,
+    max(ca.last_used_at_source)::timestamptz AS credential_last_used_at,
+    bool_or(
+      credential_artifact_risk_level(
+        ca.status,
+        ca.credential_kind,
+        ca.expires_at_source,
+        ca.last_used_at_source,
+        ca.created_by_external_id,
+        ca.approved_by_external_id,
+        now()
+      ) = 'critical'
+    )::boolean AS has_critical_credential,
+    bool_or(
+      credential_artifact_risk_level(
+        ca.status,
+        ca.credential_kind,
+        ca.expires_at_source,
+        ca.last_used_at_source,
+        ca.created_by_external_id,
+        ca.approved_by_external_id,
+        now()
+      ) IN ('critical', 'high')
+    )::boolean AS has_high_risk_credential,
+    bool_or(
+      ca.expires_at_source IS NOT NULL
+      AND ca.expires_at_source < now()
+    )::boolean AS has_expired_credential,
+    bool_or(
+      ca.expires_at_source IS NOT NULL
+      AND ca.expires_at_source >= now()
+      AND ca.expires_at_source <= now() + interval '30 days'
+    )::boolean AS has_expiring_credential,
+    bool_or(
+      ca.last_used_at_source IS NOT NULL
+      AND ca.last_used_at_source <= now() - interval '90 days'
+    )::boolean AS has_unused_credential
+  FROM active_assets aa
+  LEFT JOIN non_human_app_asset_credential_refs_v nhac
+    ON nhac.app_asset_id = aa.app_asset_id
+  LEFT JOIN credential_artifacts ca
+    ON ca.source_kind = nhac.source_kind
+   AND ca.source_name = nhac.source_name
+   AND ca.asset_ref_kind = nhac.asset_ref_kind
+   AND ca.asset_ref_external_id = nhac.asset_ref_external_id
+   AND ca.expired_at IS NULL
+   AND ca.last_observed_run_id IS NOT NULL
+  GROUP BY aa.app_asset_id
+),
+identity_asset_stats AS (
+  SELECT
+    nhpal.principal_ref,
+    nhpal.identity_id,
+    count(DISTINCT nhpal.app_asset_id)::bigint AS linked_assets_count,
+    max(aa.evidence_last_seen_at)::timestamptz AS asset_last_seen_at,
+    max(acs.credential_last_used_at)::timestamptz AS credential_last_used_at,
+    COALESCE(sum(acs.linked_credentials_count), 0)::bigint AS linked_credentials_count,
+    bool_or(COALESCE(acs.has_critical_credential, false))::boolean AS has_critical_credential,
+    bool_or(COALESCE(acs.has_high_risk_credential, false))::boolean AS has_high_risk_credential,
+    bool_or(COALESCE(acs.has_expired_credential, false))::boolean AS has_expired_credential,
+    bool_or(COALESCE(acs.has_expiring_credential, false))::boolean AS has_expiring_credential,
+    bool_or(COALESCE(acs.has_unused_credential, false))::boolean AS has_unused_credential,
+    bool_or(
+      aa.evidence_freshness = 'stale'
+      OR css.fresh_until_at IS NULL
+      OR css.fresh_until_at < now()
+    )::boolean AS has_stale_evidence
+  FROM non_human_principal_asset_links_v nhpal
+  JOIN active_assets aa ON aa.app_asset_id = nhpal.app_asset_id
+  LEFT JOIN asset_credential_stats acs ON acs.app_asset_id = nhpal.app_asset_id
+  LEFT JOIN connector_state css
+    ON css.source_kind = aa.source_kind
+   AND lower(trim(css.source_name)) = lower(trim(aa.source_name))
+  WHERE nhpal.identity_id > 0
+  GROUP BY nhpal.principal_ref, nhpal.identity_id
+),
+identity_governance_choice AS (
+  SELECT DISTINCT ON (nhpal.identity_id)
+    nhpal.identity_id,
+    aa.governance_state,
+    aa.governance_owner_identity_id,
+    aa.governance_owner_display_name,
+    aa.governance_owner_primary_email
+  FROM non_human_principal_asset_links_v nhpal
+  JOIN active_assets aa ON aa.app_asset_id = nhpal.app_asset_id
+  WHERE nhpal.identity_id > 0
+  ORDER BY
+    nhpal.identity_id,
+    CASE aa.governance_state
+      WHEN 'action_required' THEN 0
+      WHEN 'in_review' THEN 1
+      WHEN 'ticketed' THEN 2
+      WHEN 'approved' THEN 3
+      ELSE 4
+    END ASC,
+    (aa.governance_owner_identity_id = 0) ASC,
+    aa.app_asset_id ASC
+),
+identity_source_owner_choice AS (
+  SELECT DISTINCT ON (nhpal.identity_id)
+    nhpal.identity_id,
+    aoc.owner_identity_id,
+    aoc.owner_display_name,
+    aoc.owner_primary_email
+  FROM non_human_principal_asset_links_v nhpal
+  JOIN asset_owner_choice aoc ON aoc.app_asset_id = nhpal.app_asset_id
+  WHERE nhpal.identity_id > 0
+  ORDER BY
+    nhpal.identity_id,
+    (NULLIF(trim(aoc.owner_display_name), '') IS NULL) ASC,
+    aoc.app_asset_id ASC
+),
+identity_rows AS (
+  SELECT
+    'identity-' || isy.identity_id::text AS principal_ref,
+    isy.identity_id::bigint AS identity_id,
+    0::bigint AS app_asset_id,
+    isy.principal_type::text AS principal_type,
+    COALESCE(ips.source_kind, '')::text AS source_kind,
+    COALESCE(ips.source_name, '')::text AS source_name,
+    isy.display_name::text AS display_name,
+    COALESCE(NULLIF(trim(isy.primary_email), ''), NULLIF(trim(ips.external_id), ''), '')::text AS secondary_name,
+    COALESCE(ias.linked_assets_count, 0)::bigint AS linked_assets_count,
+    COALESCE(ias.linked_credentials_count, 0)::bigint AS linked_credentials_count,
+    NULLIF(
+      GREATEST(
+        COALESCE(isy.account_last_seen_at, '-infinity'::timestamptz),
+        COALESCE(ias.asset_last_seen_at, '-infinity'::timestamptz),
+        COALESCE(ias.credential_last_used_at, '-infinity'::timestamptz)
+      ),
+      '-infinity'::timestamptz
+    )::timestamptz AS last_seen_at,
+    COALESCE(igc.governance_state, 'unreviewed')::text AS governance_state,
+    CASE
+      WHEN COALESCE(igc.governance_owner_identity_id, 0) > 0 THEN igc.governance_owner_identity_id
+      WHEN COALESCE(NULLIF(trim(isoc.owner_display_name), ''), NULLIF(trim(isoc.owner_primary_email), '')) IS NOT NULL THEN isoc.owner_identity_id
+      ELSE 0
+    END::bigint AS accountable_owner_identity_id,
+    CASE
+      WHEN COALESCE(igc.governance_owner_identity_id, 0) > 0 THEN COALESCE(
+        NULLIF(trim(igc.governance_owner_display_name), ''),
+        NULLIF(trim(igc.governance_owner_primary_email), ''),
+        ''
+      )
+      ELSE COALESCE(
+        NULLIF(trim(isoc.owner_display_name), ''),
+        NULLIF(trim(isoc.owner_primary_email), ''),
+        ''
+      )
+    END::text AS accountable_owner_display_name,
+    CASE
+      WHEN COALESCE(igc.governance_owner_identity_id, 0) > 0 THEN COALESCE(NULLIF(trim(igc.governance_owner_primary_email), ''), '')
+      ELSE COALESCE(NULLIF(trim(isoc.owner_primary_email), ''), '')
+    END::text AS accountable_owner_primary_email,
+    CASE
+      WHEN COALESCE(igc.governance_owner_identity_id, 0) > 0
+        OR COALESCE(NULLIF(trim(isoc.owner_display_name), ''), NULLIF(trim(isoc.owner_primary_email), '')) IS NOT NULL
+        THEN 'owned'
+      ELSE 'unknown'
+    END::text AS owner_presence,
+    COALESCE(ias.has_critical_credential, false)::boolean AS has_critical_credential,
+    COALESCE(ias.has_high_risk_credential, false)::boolean AS has_high_risk_credential,
+    COALESCE(ias.has_expired_credential, false)::boolean AS has_expired_credential,
+    COALESCE(ias.has_expiring_credential, false)::boolean AS has_expiring_credential,
+    COALESCE(ias.has_unused_credential, false)::boolean AS has_unused_credential,
+    (
+      COALESCE(ias.has_stale_evidence, false)
+      OR ics.fresh_until_at IS NULL
+      OR ics.fresh_until_at < now()
+    )::boolean AS has_stale_evidence
+  FROM identity_summary isy
+  LEFT JOIN identity_primary_source ips ON ips.identity_id = isy.identity_id
+  LEFT JOIN identity_asset_stats ias ON ias.identity_id = isy.identity_id
+  LEFT JOIN identity_governance_choice igc ON igc.identity_id = isy.identity_id
+  LEFT JOIN identity_source_owner_choice isoc ON isoc.identity_id = isy.identity_id
+  LEFT JOIN identity_connector_state ics ON ics.identity_id = isy.identity_id
+),
+asset_linked_to_identity AS (
+  SELECT DISTINCT nhpal.app_asset_id
+  FROM non_human_principal_asset_links_v nhpal
+  WHERE nhpal.identity_id > 0
+),
+asset_rows AS (
+  SELECT
+    'app-asset-' || aa.app_asset_id::text AS principal_ref,
+    0::bigint AS identity_id,
+    aa.app_asset_id::bigint AS app_asset_id,
+    CASE
+      WHEN aa.asset_kind = 'entra_service_principal' THEN 'service'
+      ELSE 'app'
+    END::text AS principal_type,
+    aa.source_kind::text AS source_kind,
+    aa.source_name::text AS source_name,
+    aa.display_name::text AS display_name,
+    aa.external_id::text AS secondary_name,
+    1::bigint AS linked_assets_count,
+    COALESCE(acs.linked_credentials_count, 0)::bigint AS linked_credentials_count,
+    NULLIF(
+      GREATEST(
+        COALESCE(aa.evidence_last_seen_at, '-infinity'::timestamptz),
+        COALESCE(acs.credential_last_used_at, '-infinity'::timestamptz)
+      ),
+      '-infinity'::timestamptz
+    )::timestamptz AS last_seen_at,
+    aa.governance_state::text AS governance_state,
+    CASE
+      WHEN COALESCE(aa.governance_owner_identity_id, 0) > 0 THEN aa.governance_owner_identity_id
+      WHEN COALESCE(NULLIF(trim(aoc.owner_display_name), ''), NULLIF(trim(aoc.owner_primary_email), '')) IS NOT NULL THEN aoc.owner_identity_id
+      ELSE 0
+    END::bigint AS accountable_owner_identity_id,
+    CASE
+      WHEN COALESCE(aa.governance_owner_identity_id, 0) > 0 THEN COALESCE(
+        NULLIF(trim(aa.governance_owner_display_name), ''),
+        NULLIF(trim(aa.governance_owner_primary_email), ''),
+        ''
+      )
+      ELSE COALESCE(
+        NULLIF(trim(aoc.owner_display_name), ''),
+        NULLIF(trim(aoc.owner_primary_email), ''),
+        ''
+      )
+    END::text AS accountable_owner_display_name,
+    CASE
+      WHEN COALESCE(aa.governance_owner_identity_id, 0) > 0 THEN COALESCE(NULLIF(trim(aa.governance_owner_primary_email), ''), '')
+      ELSE COALESCE(NULLIF(trim(aoc.owner_primary_email), ''), '')
+    END::text AS accountable_owner_primary_email,
+    CASE
+      WHEN COALESCE(aa.governance_owner_identity_id, 0) > 0
+        OR COALESCE(NULLIF(trim(aoc.owner_display_name), ''), NULLIF(trim(aoc.owner_primary_email), '')) IS NOT NULL
+        THEN 'owned'
+      ELSE 'unknown'
+    END::text AS owner_presence,
+    COALESCE(acs.has_critical_credential, false)::boolean AS has_critical_credential,
+    COALESCE(acs.has_high_risk_credential, false)::boolean AS has_high_risk_credential,
+    COALESCE(acs.has_expired_credential, false)::boolean AS has_expired_credential,
+    COALESCE(acs.has_expiring_credential, false)::boolean AS has_expiring_credential,
+    COALESCE(acs.has_unused_credential, false)::boolean AS has_unused_credential,
+    (
+      aa.evidence_freshness = 'stale'
+      OR css.fresh_until_at IS NULL
+      OR css.fresh_until_at < now()
+    )::boolean AS has_stale_evidence
+  FROM active_assets aa
+  LEFT JOIN asset_linked_to_identity ali ON ali.app_asset_id = aa.app_asset_id
+  LEFT JOIN asset_owner_choice aoc ON aoc.app_asset_id = aa.app_asset_id
+  LEFT JOIN asset_credential_stats acs ON acs.app_asset_id = aa.app_asset_id
+  LEFT JOIN connector_state css
+    ON css.source_kind = aa.source_kind
+   AND lower(trim(css.source_name)) = lower(trim(aa.source_name))
+  WHERE ali.app_asset_id IS NULL
+),
+base AS (
+  SELECT *
+  FROM identity_rows
+  UNION ALL
+  SELECT *
+  FROM asset_rows
+),
+scored AS (
+  SELECT
+    b.*,
+    CASE
+      WHEN b.last_seen_at IS NULL THEN 'never_seen'
+      WHEN b.last_seen_at >= now() - interval '30 days' THEN 'recent'
+      WHEN b.last_seen_at >= now() - interval '90 days' THEN 'aging'
+      ELSE 'stale'
+    END::text AS activity_state,
+    CASE
+      WHEN b.has_stale_evidence THEN 'stale'
+      WHEN b.last_seen_at IS NULL THEN 'unknown'
+      ELSE 'current'
+    END::text AS freshness_state,
+    (
+      CASE WHEN b.owner_presence = 'unknown' THEN 1 ELSE 0 END
+      + CASE
+          WHEN b.has_critical_credential THEN 1
+          WHEN b.has_high_risk_credential THEN 1
+          ELSE 0
+        END
+      + CASE WHEN b.has_expired_credential THEN 1 ELSE 0 END
+      + CASE WHEN b.has_expiring_credential THEN 1 ELSE 0 END
+      + CASE WHEN b.has_unused_credential THEN 1 ELSE 0 END
+      + CASE WHEN b.has_stale_evidence THEN 1 ELSE 0 END
+      + CASE
+          WHEN b.governance_state = 'unreviewed'
+            AND (
+              b.has_high_risk_credential
+              OR b.has_expired_credential
+              OR b.has_expiring_credential
+              OR b.has_unused_credential
+              OR b.has_stale_evidence
+            )
+            THEN 1
+          ELSE 0
+        END
+    )::int AS risk_reason_count,
+    CASE
+      WHEN b.has_critical_credential THEN 'critical'
+      WHEN b.owner_presence = 'unknown'
+        OR b.has_high_risk_credential
+        OR b.has_expired_credential
+        OR (
+          b.governance_state = 'unreviewed'
+          AND (
+            b.has_high_risk_credential
+            OR b.has_expired_credential
+            OR b.has_expiring_credential
+            OR b.has_unused_credential
+            OR b.has_stale_evidence
+          )
+        )
+        THEN 'high'
+      WHEN b.has_expiring_credential
+        OR b.has_unused_credential
+        OR b.has_stale_evidence
+        THEN 'medium'
+      ELSE 'low'
+    END::text AS risk_level
+  FROM base b
+)
+SELECT
+  s.principal_ref::text AS principal_ref,
+  s.identity_id,
+  s.app_asset_id,
+  s.principal_type,
+  s.source_kind,
+  s.source_name,
+  s.display_name,
+  s.secondary_name,
+  s.linked_assets_count,
+  s.linked_credentials_count,
+  s.last_seen_at,
+  s.activity_state,
+  s.freshness_state,
+  s.governance_state,
+  s.accountable_owner_identity_id,
+  s.accountable_owner_display_name,
+  s.accountable_owner_primary_email,
+  s.owner_presence,
+  s.has_critical_credential,
+  s.has_high_risk_credential,
+  s.has_expired_credential,
+  s.has_expiring_credential,
+  s.has_unused_credential,
+  s.has_stale_evidence,
+  s.risk_reason_count,
+  s.risk_level
+FROM scored s;
+
+DROP INDEX IF EXISTS idx_credential_artifact_risk_read_models_level_rank;
+DROP TABLE IF EXISTS credential_artifact_risk_read_models;

--- a/db/migrations/000050_credential_policy_read_models.up.sql
+++ b/db/migrations/000050_credential_policy_read_models.up.sql
@@ -1,0 +1,476 @@
+CREATE TABLE IF NOT EXISTS credential_artifact_risk_read_models (
+  credential_artifact_id BIGINT PRIMARY KEY REFERENCES credential_artifacts(id) ON DELETE CASCADE,
+  risk_level TEXT NOT NULL DEFAULT 'low',
+  risk_rank INT NOT NULL DEFAULT 1,
+  risk_signals_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  policy_packs_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  projection_refreshed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT credential_artifact_risk_read_models_level_check CHECK (risk_level IN ('low', 'medium', 'high', 'critical')),
+  CONSTRAINT credential_artifact_risk_read_models_rank_check CHECK (risk_rank >= 1)
+);
+
+CREATE INDEX IF NOT EXISTS idx_credential_artifact_risk_read_models_level_rank
+  ON credential_artifact_risk_read_models (risk_level, risk_rank DESC, credential_artifact_id);
+
+CREATE OR REPLACE VIEW non_human_principal_projection_v AS
+WITH active_accounts AS (
+  SELECT
+    a.id AS account_id,
+    a.source_kind,
+    a.source_name,
+    a.external_id,
+    a.display_name AS account_display_name,
+    a.email,
+    a.entity_category,
+    a.created_at,
+    a.last_observed_at,
+    non_human_account_asset_external_id(a.source_kind, a.entity_category, a.external_id) AS asset_match_external_id
+  FROM accounts a
+  WHERE a.expired_at IS NULL
+    AND a.last_observed_run_id IS NOT NULL
+),
+non_human_identity_accounts AS (
+  SELECT
+    i.id AS identity_id,
+    i.kind AS principal_type,
+    COALESCE(NULLIF(trim(i.display_name), ''), NULLIF(trim(i.primary_email), ''), 'Identity ' || i.id::text)::text AS display_name,
+    COALESCE(i.primary_email, '')::text AS primary_email,
+    aa.account_id,
+    aa.source_kind,
+    aa.source_name,
+    aa.external_id,
+    aa.created_at,
+    aa.last_observed_at
+  FROM identities i
+  JOIN identity_accounts ia ON ia.identity_id = i.id
+  JOIN active_accounts aa ON aa.account_id = ia.account_id
+  WHERE i.kind IN ('service', 'bot')
+),
+identity_primary_source AS (
+  SELECT DISTINCT ON (nia.identity_id)
+    nia.identity_id,
+    nia.source_kind,
+    nia.source_name,
+    nia.external_id
+  FROM non_human_identity_accounts nia
+  LEFT JOIN identity_source_settings iss
+    ON iss.source_kind = nia.source_kind
+   AND iss.source_name = nia.source_name
+   AND iss.is_authoritative
+  ORDER BY nia.identity_id, (iss.is_authoritative IS NOT TRUE), nia.account_id
+),
+identity_summary AS (
+  SELECT
+    nia.identity_id,
+    min(nia.principal_type)::text AS principal_type,
+    min(nia.display_name)::text AS display_name,
+    min(nia.primary_email)::text AS primary_email,
+    max(nia.last_observed_at)::timestamptz AS account_last_seen_at,
+    min(nia.created_at)::timestamptz AS first_seen_at
+  FROM non_human_identity_accounts nia
+  GROUP BY nia.identity_id
+),
+active_assets AS (
+  SELECT
+    pr.id::bigint AS app_asset_id,
+    pr.source_kind::text AS source_kind,
+    pr.source_name::text AS source_name,
+    pr.asset_kind::text AS asset_kind,
+    pr.external_id::text AS external_id,
+    pr.parent_external_id::text AS parent_external_id,
+    COALESCE(NULLIF(trim(pr.display_name), ''), pr.external_id)::text AS display_name,
+    pr.status::text AS status,
+    pr.governance_state::text AS governance_state,
+    pr.governance_owner_identity_id::bigint AS governance_owner_identity_id,
+    pr.governance_owner_display_name::text AS governance_owner_display_name,
+    pr.governance_owner_primary_email::text AS governance_owner_primary_email,
+    pr.evidence_last_seen_at::timestamptz AS evidence_last_seen_at,
+    pr.evidence_freshness::text AS evidence_freshness
+  FROM connected_app_read_models_v pr
+),
+connector_state AS (
+  SELECT
+    css.source_kind,
+    css.source_name,
+    css.fresh_until_at
+  FROM connector_source_state css
+),
+identity_connector_state AS (
+  SELECT
+    ips.identity_id,
+    css.fresh_until_at
+  FROM identity_primary_source ips
+  LEFT JOIN connector_state css
+    ON css.source_kind = ips.source_kind
+   AND lower(trim(css.source_name)) = lower(trim(ips.source_name))
+),
+asset_owner_candidates AS (
+  SELECT
+    aa.app_asset_id,
+    COALESCE(owner_by_external.id, owner_by_email.id, 0)::bigint AS owner_identity_id,
+    COALESCE(
+      NULLIF(trim(owner_by_external.display_name), ''),
+      NULLIF(trim(owner_by_email.display_name), ''),
+      NULLIF(trim(aao.owner_display_name), ''),
+      NULLIF(trim(aao.owner_email), ''),
+      trim(aao.owner_external_id)
+    )::text AS owner_display_name,
+    COALESCE(
+      NULLIF(trim(owner_by_external.primary_email), ''),
+      NULLIF(trim(owner_by_email.primary_email), ''),
+      NULLIF(lower(trim(aao.owner_email)), ''),
+      ''
+    )::text AS owner_primary_email,
+    count(*) OVER (PARTITION BY aa.app_asset_id)::bigint AS owner_count,
+    row_number() OVER (
+      PARTITION BY aa.app_asset_id
+      ORDER BY lower(
+        COALESCE(
+          NULLIF(trim(aao.owner_display_name), ''),
+          NULLIF(trim(aao.owner_email), ''),
+          trim(aao.owner_external_id)
+        )
+      ) ASC,
+      aao.id ASC
+    ) AS row_num
+  FROM app_asset_owners aao
+  JOIN active_assets aa ON aa.app_asset_id = aao.app_asset_id
+  LEFT JOIN LATERAL (
+    SELECT
+      i.id,
+      i.display_name,
+      i.primary_email
+    FROM active_accounts oa
+    JOIN identity_accounts ia ON ia.account_id = oa.account_id
+    JOIN identities i ON i.id = ia.identity_id
+    WHERE oa.source_kind = aa.source_kind
+      AND oa.source_name = aa.source_name
+      AND lower(trim(oa.external_id)) = lower(trim(aao.owner_external_id))
+    ORDER BY i.id ASC
+    LIMIT 1
+  ) owner_by_external ON TRUE
+  LEFT JOIN LATERAL (
+    SELECT
+      i.id,
+      i.display_name,
+      i.primary_email
+    FROM identities i
+    WHERE lower(trim(i.primary_email)) = lower(trim(aao.owner_email))
+    ORDER BY i.id ASC
+    LIMIT 1
+  ) owner_by_email ON TRUE
+  WHERE aao.expired_at IS NULL
+    AND aao.last_observed_run_id IS NOT NULL
+),
+asset_owner_choice AS (
+  SELECT
+    aoc.app_asset_id,
+    aoc.owner_identity_id,
+    CASE
+      WHEN aoc.owner_count > 1 THEN aoc.owner_display_name || ' +' || (aoc.owner_count - 1)::text
+      ELSE aoc.owner_display_name
+    END::text AS owner_display_name,
+    aoc.owner_primary_email::text AS owner_primary_email,
+    aoc.owner_count::bigint AS owner_count
+  FROM asset_owner_candidates aoc
+  WHERE aoc.row_num = 1
+),
+asset_credential_stats AS (
+  SELECT
+    aa.app_asset_id,
+    count(DISTINCT ca.id)::bigint AS linked_credentials_count,
+    max(ca.last_used_at_source)::timestamptz AS credential_last_used_at,
+    bool_or(COALESCE(crrm.risk_level, 'low') = 'critical')::boolean AS has_critical_credential,
+    bool_or(COALESCE(crrm.risk_rank, 1) >= 3)::boolean AS has_high_risk_credential,
+    bool_or(
+      ca.expires_at_source IS NOT NULL
+      AND ca.expires_at_source < now()
+    )::boolean AS has_expired_credential,
+    bool_or(
+      ca.expires_at_source IS NOT NULL
+      AND ca.expires_at_source >= now()
+      AND ca.expires_at_source <= now() + interval '30 days'
+    )::boolean AS has_expiring_credential,
+    bool_or(
+      ca.last_used_at_source IS NOT NULL
+      AND ca.last_used_at_source <= now() - interval '90 days'
+    )::boolean AS has_unused_credential
+  FROM active_assets aa
+  LEFT JOIN non_human_app_asset_credential_refs_v nhac
+    ON nhac.app_asset_id = aa.app_asset_id
+  LEFT JOIN credential_artifacts ca
+    ON ca.source_kind = nhac.source_kind
+   AND ca.source_name = nhac.source_name
+   AND ca.asset_ref_kind = nhac.asset_ref_kind
+   AND ca.asset_ref_external_id = nhac.asset_ref_external_id
+   AND ca.expired_at IS NULL
+   AND ca.last_observed_run_id IS NOT NULL
+  LEFT JOIN credential_artifact_risk_read_models crrm
+    ON crrm.credential_artifact_id = ca.id
+  GROUP BY aa.app_asset_id
+),
+identity_asset_stats AS (
+  SELECT
+    nhpal.principal_ref,
+    nhpal.identity_id,
+    count(DISTINCT nhpal.app_asset_id)::bigint AS linked_assets_count,
+    max(aa.evidence_last_seen_at)::timestamptz AS asset_last_seen_at,
+    max(acs.credential_last_used_at)::timestamptz AS credential_last_used_at,
+    COALESCE(sum(acs.linked_credentials_count), 0)::bigint AS linked_credentials_count,
+    bool_or(COALESCE(acs.has_critical_credential, false))::boolean AS has_critical_credential,
+    bool_or(COALESCE(acs.has_high_risk_credential, false))::boolean AS has_high_risk_credential,
+    bool_or(COALESCE(acs.has_expired_credential, false))::boolean AS has_expired_credential,
+    bool_or(COALESCE(acs.has_expiring_credential, false))::boolean AS has_expiring_credential,
+    bool_or(COALESCE(acs.has_unused_credential, false))::boolean AS has_unused_credential,
+    bool_or(
+      aa.evidence_freshness = 'stale'
+      OR css.fresh_until_at IS NULL
+      OR css.fresh_until_at < now()
+    )::boolean AS has_stale_evidence
+  FROM non_human_principal_asset_links_v nhpal
+  JOIN active_assets aa ON aa.app_asset_id = nhpal.app_asset_id
+  LEFT JOIN asset_credential_stats acs ON acs.app_asset_id = nhpal.app_asset_id
+  LEFT JOIN connector_state css
+    ON css.source_kind = aa.source_kind
+   AND lower(trim(css.source_name)) = lower(trim(aa.source_name))
+  WHERE nhpal.identity_id > 0
+  GROUP BY nhpal.principal_ref, nhpal.identity_id
+),
+identity_governance_choice AS (
+  SELECT DISTINCT ON (nhpal.identity_id)
+    nhpal.identity_id,
+    aa.governance_state,
+    aa.governance_owner_identity_id,
+    aa.governance_owner_display_name,
+    aa.governance_owner_primary_email
+  FROM non_human_principal_asset_links_v nhpal
+  JOIN active_assets aa ON aa.app_asset_id = nhpal.app_asset_id
+  WHERE nhpal.identity_id > 0
+  ORDER BY
+    nhpal.identity_id,
+    CASE aa.governance_state
+      WHEN 'action_required' THEN 0
+      WHEN 'in_review' THEN 1
+      WHEN 'ticketed' THEN 2
+      WHEN 'approved' THEN 3
+      ELSE 4
+    END ASC,
+    (aa.governance_owner_identity_id = 0) ASC,
+    aa.app_asset_id ASC
+),
+identity_source_owner_choice AS (
+  SELECT DISTINCT ON (nhpal.identity_id)
+    nhpal.identity_id,
+    aoc.owner_identity_id,
+    aoc.owner_display_name,
+    aoc.owner_primary_email
+  FROM non_human_principal_asset_links_v nhpal
+  JOIN asset_owner_choice aoc ON aoc.app_asset_id = nhpal.app_asset_id
+  WHERE nhpal.identity_id > 0
+  ORDER BY
+    nhpal.identity_id,
+    (NULLIF(trim(aoc.owner_display_name), '') IS NULL) ASC,
+    aoc.app_asset_id ASC
+),
+identity_rows AS (
+  SELECT
+    'identity-' || isy.identity_id::text AS principal_ref,
+    isy.identity_id::bigint AS identity_id,
+    0::bigint AS app_asset_id,
+    isy.principal_type::text AS principal_type,
+    COALESCE(ips.source_kind, '')::text AS source_kind,
+    COALESCE(ips.source_name, '')::text AS source_name,
+    isy.display_name::text AS display_name,
+    COALESCE(NULLIF(trim(isy.primary_email), ''), NULLIF(trim(ips.external_id), ''), '')::text AS secondary_name,
+    COALESCE(ias.linked_assets_count, 0)::bigint AS linked_assets_count,
+    COALESCE(ias.linked_credentials_count, 0)::bigint AS linked_credentials_count,
+    NULLIF(
+      GREATEST(
+        COALESCE(isy.account_last_seen_at, '-infinity'::timestamptz),
+        COALESCE(ias.asset_last_seen_at, '-infinity'::timestamptz),
+        COALESCE(ias.credential_last_used_at, '-infinity'::timestamptz)
+      ),
+      '-infinity'::timestamptz
+    )::timestamptz AS last_seen_at,
+    COALESCE(igc.governance_state, 'unreviewed')::text AS governance_state,
+    CASE
+      WHEN COALESCE(igc.governance_owner_identity_id, 0) > 0 THEN igc.governance_owner_identity_id
+      WHEN COALESCE(NULLIF(trim(isoc.owner_display_name), ''), NULLIF(trim(isoc.owner_primary_email), '')) IS NOT NULL THEN isoc.owner_identity_id
+      ELSE 0
+    END::bigint AS accountable_owner_identity_id,
+    CASE
+      WHEN COALESCE(igc.governance_owner_identity_id, 0) > 0 THEN COALESCE(
+        NULLIF(trim(igc.governance_owner_display_name), ''),
+        NULLIF(trim(igc.governance_owner_primary_email), ''),
+        ''
+      )
+      ELSE COALESCE(
+        NULLIF(trim(isoc.owner_display_name), ''),
+        NULLIF(trim(isoc.owner_primary_email), ''),
+        ''
+      )
+    END::text AS accountable_owner_display_name,
+    CASE
+      WHEN COALESCE(igc.governance_owner_identity_id, 0) > 0 THEN COALESCE(NULLIF(trim(igc.governance_owner_primary_email), ''), '')
+      ELSE COALESCE(NULLIF(trim(isoc.owner_primary_email), ''), '')
+    END::text AS accountable_owner_primary_email,
+    CASE
+      WHEN COALESCE(igc.governance_owner_identity_id, 0) > 0
+        OR COALESCE(NULLIF(trim(isoc.owner_display_name), ''), NULLIF(trim(isoc.owner_primary_email), '')) IS NOT NULL
+        THEN 'owned'
+      ELSE 'unknown'
+    END::text AS owner_presence,
+    COALESCE(ias.has_critical_credential, false)::boolean AS has_critical_credential,
+    COALESCE(ias.has_high_risk_credential, false)::boolean AS has_high_risk_credential,
+    COALESCE(ias.has_expired_credential, false)::boolean AS has_expired_credential,
+    COALESCE(ias.has_expiring_credential, false)::boolean AS has_expiring_credential,
+    COALESCE(ias.has_unused_credential, false)::boolean AS has_unused_credential,
+    (
+      COALESCE(ias.has_stale_evidence, false)
+      OR ics.fresh_until_at IS NULL
+      OR ics.fresh_until_at < now()
+    )::boolean AS has_stale_evidence
+  FROM identity_summary isy
+  LEFT JOIN identity_primary_source ips ON ips.identity_id = isy.identity_id
+  LEFT JOIN identity_asset_stats ias ON ias.identity_id = isy.identity_id
+  LEFT JOIN identity_governance_choice igc ON igc.identity_id = isy.identity_id
+  LEFT JOIN identity_source_owner_choice isoc ON isoc.identity_id = isy.identity_id
+  LEFT JOIN identity_connector_state ics ON ics.identity_id = isy.identity_id
+),
+asset_linked_to_identity AS (
+  SELECT DISTINCT nhpal.app_asset_id
+  FROM non_human_principal_asset_links_v nhpal
+  WHERE nhpal.identity_id > 0
+),
+asset_rows AS (
+  SELECT
+    'app-asset-' || aa.app_asset_id::text AS principal_ref,
+    0::bigint AS identity_id,
+    aa.app_asset_id::bigint AS app_asset_id,
+    CASE
+      WHEN aa.asset_kind = 'entra_service_principal' THEN 'service'
+      ELSE 'app'
+    END::text AS principal_type,
+    aa.source_kind::text AS source_kind,
+    aa.source_name::text AS source_name,
+    aa.display_name::text AS display_name,
+    aa.external_id::text AS secondary_name,
+    1::bigint AS linked_assets_count,
+    COALESCE(acs.linked_credentials_count, 0)::bigint AS linked_credentials_count,
+    NULLIF(
+      GREATEST(
+        COALESCE(aa.evidence_last_seen_at, '-infinity'::timestamptz),
+        COALESCE(acs.credential_last_used_at, '-infinity'::timestamptz)
+      ),
+      '-infinity'::timestamptz
+    )::timestamptz AS last_seen_at,
+    aa.governance_state::text AS governance_state,
+    CASE
+      WHEN COALESCE(aa.governance_owner_identity_id, 0) > 0 THEN aa.governance_owner_identity_id
+      WHEN COALESCE(NULLIF(trim(aoc.owner_display_name), ''), NULLIF(trim(aoc.owner_primary_email), '')) IS NOT NULL THEN aoc.owner_identity_id
+      ELSE 0
+    END::bigint AS accountable_owner_identity_id,
+    CASE
+      WHEN COALESCE(aa.governance_owner_identity_id, 0) > 0 THEN COALESCE(
+        NULLIF(trim(aa.governance_owner_display_name), ''),
+        NULLIF(trim(aa.governance_owner_primary_email), ''),
+        ''
+      )
+      ELSE COALESCE(
+        NULLIF(trim(aoc.owner_display_name), ''),
+        NULLIF(trim(aoc.owner_primary_email), ''),
+        ''
+      )
+    END::text AS accountable_owner_display_name,
+    CASE
+      WHEN COALESCE(aa.governance_owner_identity_id, 0) > 0 THEN COALESCE(NULLIF(trim(aa.governance_owner_primary_email), ''), '')
+      ELSE COALESCE(NULLIF(trim(aoc.owner_primary_email), ''), '')
+    END::text AS accountable_owner_primary_email,
+    CASE
+      WHEN COALESCE(aa.governance_owner_identity_id, 0) > 0
+        OR COALESCE(NULLIF(trim(aoc.owner_display_name), ''), NULLIF(trim(aoc.owner_primary_email), '')) IS NOT NULL
+        THEN 'owned'
+      ELSE 'unknown'
+    END::text AS owner_presence,
+    COALESCE(acs.has_critical_credential, false)::boolean AS has_critical_credential,
+    COALESCE(acs.has_high_risk_credential, false)::boolean AS has_high_risk_credential,
+    COALESCE(acs.has_expired_credential, false)::boolean AS has_expired_credential,
+    COALESCE(acs.has_expiring_credential, false)::boolean AS has_expiring_credential,
+    COALESCE(acs.has_unused_credential, false)::boolean AS has_unused_credential,
+    (
+      aa.evidence_freshness = 'stale'
+      OR css.fresh_until_at IS NULL
+      OR css.fresh_until_at < now()
+    )::boolean AS has_stale_evidence
+  FROM active_assets aa
+  LEFT JOIN asset_linked_to_identity ali ON ali.app_asset_id = aa.app_asset_id
+  LEFT JOIN asset_owner_choice aoc ON aoc.app_asset_id = aa.app_asset_id
+  LEFT JOIN asset_credential_stats acs ON acs.app_asset_id = aa.app_asset_id
+  LEFT JOIN connector_state css
+    ON css.source_kind = aa.source_kind
+   AND lower(trim(css.source_name)) = lower(trim(aa.source_name))
+  WHERE ali.app_asset_id IS NULL
+),
+base AS (
+  SELECT *
+  FROM identity_rows
+  UNION ALL
+  SELECT *
+  FROM asset_rows
+),
+scored AS (
+  SELECT
+    b.*,
+    CASE
+      WHEN b.last_seen_at IS NULL THEN 'never_seen'
+      WHEN b.last_seen_at >= now() - interval '30 days' THEN 'recent'
+      WHEN b.last_seen_at >= now() - interval '90 days' THEN 'aging'
+      ELSE 'stale'
+    END::text AS activity_state,
+    CASE
+      WHEN b.has_stale_evidence THEN 'stale'
+      WHEN b.last_seen_at IS NULL THEN 'unknown'
+      ELSE 'current'
+    END::text AS freshness_state,
+    0::int AS risk_reason_count,
+    'low'::text AS risk_level
+  FROM base b
+)
+SELECT
+  s.principal_ref::text AS principal_ref,
+  s.identity_id,
+  s.app_asset_id,
+  s.principal_type,
+  s.source_kind,
+  s.source_name,
+  s.display_name,
+  s.secondary_name,
+  s.linked_assets_count,
+  s.linked_credentials_count,
+  s.last_seen_at,
+  s.activity_state,
+  s.freshness_state,
+  s.governance_state,
+  s.accountable_owner_identity_id,
+  s.accountable_owner_display_name,
+  s.accountable_owner_primary_email,
+  s.owner_presence,
+  s.has_critical_credential,
+  s.has_high_risk_credential,
+  s.has_expired_credential,
+  s.has_expiring_credential,
+  s.has_unused_credential,
+  s.has_stale_evidence,
+  s.risk_reason_count,
+  s.risk_level
+FROM scored s;
+
+DROP FUNCTION IF EXISTS credential_artifact_risk_level(
+  text,
+  text,
+  timestamptz,
+  timestamptz,
+  text,
+  text,
+  timestamptz
+);

--- a/db/queries/credential_artifacts.sql
+++ b/db/queries/credential_artifacts.sql
@@ -118,16 +118,10 @@ ON CONFLICT (source_kind, source_name, credential_kind, external_id, asset_ref_k
 WITH rated_credentials AS (
   SELECT
     ca.*,
-    credential_artifact_risk_level(
-      ca.status,
-      ca.credential_kind,
-      ca.expires_at_source,
-      ca.last_used_at_source,
-      ca.created_by_external_id,
-      ca.approved_by_external_id,
-      sqlc.arg(evaluated_at)::timestamptz
-    ) AS risk_level
+    COALESCE(risk.risk_level, 'low')::text AS risk_level
   FROM credential_artifacts ca
+  LEFT JOIN credential_artifact_risk_read_models risk
+    ON risk.credential_artifact_id = ca.id
   WHERE
     ca.source_kind = sqlc.arg(source_kind)::text
     AND ca.source_name = sqlc.arg(source_name)::text
@@ -182,16 +176,10 @@ WHERE
 WITH rated_credentials AS (
   SELECT
     ca.*,
-    credential_artifact_risk_level(
-      ca.status,
-      ca.credential_kind,
-      ca.expires_at_source,
-      ca.last_used_at_source,
-      ca.created_by_external_id,
-      ca.approved_by_external_id,
-      sqlc.arg(evaluated_at)::timestamptz
-    ) AS risk_level
+    COALESCE(risk.risk_level, 'low')::text AS risk_level
   FROM credential_artifacts ca
+  LEFT JOIN credential_artifact_risk_read_models risk
+    ON risk.credential_artifact_id = ca.id
   WHERE
     ca.source_kind = sqlc.arg(source_kind)::text
     AND ca.source_name = sqlc.arg(source_name)::text
@@ -259,16 +247,10 @@ WITH configured_sources AS (
 rated_credentials AS (
   SELECT
     ca.*,
-    credential_artifact_risk_level(
-      ca.status,
-      ca.credential_kind,
-      ca.expires_at_source,
-      ca.last_used_at_source,
-      ca.created_by_external_id,
-      ca.approved_by_external_id,
-      sqlc.arg(evaluated_at)::timestamptz
-    ) AS risk_level
+    COALESCE(risk.risk_level, 'low')::text AS risk_level
   FROM credential_artifacts ca
+  LEFT JOIN credential_artifact_risk_read_models risk
+    ON risk.credential_artifact_id = ca.id
   JOIN configured_sources cs
     ON cs.source_kind = ca.source_kind
    AND cs.source_name = ca.source_name
@@ -331,16 +313,10 @@ WITH configured_sources AS (
 rated_credentials AS (
   SELECT
     ca.*,
-    credential_artifact_risk_level(
-      ca.status,
-      ca.credential_kind,
-      ca.expires_at_source,
-      ca.last_used_at_source,
-      ca.created_by_external_id,
-      ca.approved_by_external_id,
-      sqlc.arg(evaluated_at)::timestamptz
-    ) AS risk_level
+    COALESCE(risk.risk_level, 'low')::text AS risk_level
   FROM credential_artifacts ca
+  LEFT JOIN credential_artifact_risk_read_models risk
+    ON risk.credential_artifact_id = ca.id
   JOIN configured_sources cs
     ON cs.source_kind = ca.source_kind
    AND cs.source_name = ca.source_name
@@ -403,16 +379,10 @@ OFFSET sqlc.arg(page_offset)::int;
 -- name: ListCredentialArtifactsForAssetRef :many
 SELECT
   ca.*,
-  credential_artifact_risk_level(
-    ca.status,
-    ca.credential_kind,
-    ca.expires_at_source,
-    ca.last_used_at_source,
-    ca.created_by_external_id,
-    ca.approved_by_external_id,
-    sqlc.arg(evaluated_at)::timestamptz
-  ) AS risk_level
+  COALESCE(risk.risk_level, 'low')::text AS risk_level
 FROM credential_artifacts ca
+LEFT JOIN credential_artifact_risk_read_models risk
+  ON risk.credential_artifact_id = ca.id
 WHERE ca.source_kind = sqlc.arg(source_kind)::text
   AND ca.source_name = sqlc.arg(source_name)::text
   AND ca.asset_ref_kind = sqlc.arg(asset_ref_kind)::text
@@ -426,16 +396,12 @@ ORDER BY
 -- name: GetCredentialArtifactByID :one
 SELECT
   ca.*,
-  credential_artifact_risk_level(
-    ca.status,
-    ca.credential_kind,
-    ca.expires_at_source,
-    ca.last_used_at_source,
-    ca.created_by_external_id,
-    ca.approved_by_external_id,
-    sqlc.arg(evaluated_at)::timestamptz
-  ) AS risk_level
+  COALESCE(risk.risk_level, 'low')::text AS risk_level,
+  COALESCE(risk.risk_signals_json, '[]'::jsonb)::jsonb AS risk_signals_json,
+  COALESCE(risk.policy_packs_json, '[]'::jsonb)::jsonb AS policy_packs_json
 FROM credential_artifacts ca
+LEFT JOIN credential_artifact_risk_read_models risk
+  ON risk.credential_artifact_id = ca.id
 WHERE ca.id = sqlc.arg(id)::bigint
   AND expired_at IS NULL
   AND last_observed_run_id IS NOT NULL;

--- a/db/queries/non_human_access.sql
+++ b/db/queries/non_human_access.sql
@@ -444,15 +444,7 @@ WITH credential_matches AS (
     ca.external_id::text AS external_id,
     COALESCE(NULLIF(trim(ca.display_name), ''), ca.external_id)::text AS display_name,
     ca.status::text AS status,
-    credential_artifact_risk_level(
-      ca.status,
-      ca.credential_kind,
-      ca.expires_at_source,
-      ca.last_used_at_source,
-      ca.created_by_external_id,
-      ca.approved_by_external_id,
-      now()
-    )::text AS risk_level,
+    COALESCE(risk.risk_level, 'low')::text AS risk_level,
     ca.expires_at_source::timestamptz AS expires_at_source,
     ca.last_used_at_source::timestamptz AS last_used_at_source,
     ca.created_by_display_name::text AS created_by_display_name,
@@ -472,6 +464,8 @@ WITH credential_matches AS (
    AND ca.asset_ref_external_id = nhac.asset_ref_external_id
    AND ca.expired_at IS NULL
    AND ca.last_observed_run_id IS NOT NULL
+  LEFT JOIN credential_artifact_risk_read_models risk
+    ON risk.credential_artifact_id = ca.id
   WHERE nhpal.principal_ref = sqlc.arg(principal_ref)::text
   ORDER BY
     ca.id,

--- a/db/queries/non_human_access.sql
+++ b/db/queries/non_human_access.sql
@@ -395,7 +395,9 @@ SELECT
   pr.has_unused_credential,
   pr.has_stale_evidence,
   pr.risk_reason_count,
-  pr.risk_level
+  pr.risk_level,
+  pr.risk_signals_json,
+  pr.policy_packs_json
 FROM non_human_principal_read_models_v pr
 WHERE pr.principal_ref = sqlc.arg(principal_ref)::text;
 

--- a/db/queries/non_human_access_events.sql
+++ b/db/queries/non_human_access_events.sql
@@ -36,15 +36,7 @@ WHERE css.configured = true;
 WITH linked_credentials AS (
   SELECT
     ca.id::bigint AS credential_id,
-    credential_artifact_risk_level(
-      ca.status,
-      ca.credential_kind,
-      ca.expires_at_source,
-      ca.last_used_at_source,
-      ca.created_by_external_id,
-      ca.approved_by_external_id,
-      now()
-    )::text AS risk_level,
+    COALESCE(risk.risk_rank, 1)::int AS risk_rank,
     (
       pr.owner_presence = 'owned'
       OR NULLIF(trim(ca.created_by_display_name), '') IS NOT NULL
@@ -70,25 +62,20 @@ WITH linked_credentials AS (
    AND ca.asset_ref_external_id = nhac.asset_ref_external_id
    AND ca.expired_at IS NULL
    AND ca.last_observed_run_id IS NOT NULL
+  LEFT JOIN credential_artifact_risk_read_models risk
+    ON risk.credential_artifact_id = ca.id
 ),
 deduped AS (
   SELECT
     lc.credential_id,
-    max(
-      CASE lc.risk_level
-        WHEN 'critical' THEN 3
-        WHEN 'high' THEN 2
-        WHEN 'medium' THEN 1
-        ELSE 0
-      END
-    )::int AS risk_rank,
+    max(lc.risk_rank)::int AS risk_rank,
     bool_or(lc.has_attribution)::boolean AS has_attribution
   FROM linked_credentials lc
   GROUP BY lc.credential_id
 )
 SELECT
-  count(*) FILTER (WHERE d.risk_rank >= 2)::bigint AS high_risk_credential_count,
-  count(*) FILTER (WHERE d.risk_rank >= 2 AND d.has_attribution)::bigint AS high_risk_with_attribution_count
+  count(*) FILTER (WHERE d.risk_rank >= 3)::bigint AS high_risk_credential_count,
+  count(*) FILTER (WHERE d.risk_rank >= 3 AND d.has_attribution)::bigint AS high_risk_with_attribution_count
 FROM deduped d;
 
 -- name: CountNonHumanAccessWeeklyAdminReviewSessions :one

--- a/db/queries/read_models.sql
+++ b/db/queries/read_models.sql
@@ -76,6 +76,18 @@ SELECT (
   )
   OR EXISTS (
     SELECT 1
+    FROM credential_artifacts ca
+    LEFT JOIN credential_artifact_risk_read_models risk
+      ON risk.credential_artifact_id = ca.id
+    WHERE ca.expired_at IS NULL
+      AND ca.last_observed_run_id IS NOT NULL
+      AND (
+        risk.credential_artifact_id IS NULL
+        OR risk.policy_packs_json = '[]'::jsonb
+      )
+  )
+  OR EXISTS (
+    SELECT 1
     FROM non_human_principals nhp
     WHERE nhp.projection_refreshed_at IS NULL
       OR nhp.policy_packs_json = '[]'::jsonb
@@ -251,6 +263,96 @@ ON CONFLICT (saas_app_id) DO UPDATE SET
   suggested_data_classification = EXCLUDED.suggested_data_classification,
   effective_business_criticality = EXCLUDED.effective_business_criticality,
   effective_data_classification = EXCLUDED.effective_data_classification,
+  policy_packs_json = EXCLUDED.policy_packs_json,
+  projection_refreshed_at = now();
+
+-- name: DeleteAllCredentialArtifactRiskReadModels :exec
+DELETE FROM credential_artifact_risk_read_models;
+
+-- name: DeleteCredentialArtifactRiskReadModelsBySource :exec
+DELETE FROM credential_artifact_risk_read_models risk
+USING credential_artifacts ca
+WHERE risk.credential_artifact_id = ca.id
+  AND lower(trim(ca.source_kind)) = lower(trim(sqlc.arg(source_kind)::text))
+  AND lower(trim(ca.source_name)) = lower(trim(sqlc.arg(source_name)::text));
+
+-- name: ListAllCredentialArtifactRiskInputs :many
+SELECT
+  ca.id::bigint AS credential_artifact_id,
+  ca.source_kind::text AS source_kind,
+  ca.source_name::text AS source_name,
+  ca.credential_kind::text AS credential_kind,
+  ca.status::text AS status,
+  ca.expires_at_source::timestamptz AS expires_at_source,
+  ca.last_used_at_source::timestamptz AS last_used_at_source,
+  ca.created_at_source::timestamptz AS created_at_source,
+  ca.created_by_external_id::text AS created_by_external_id,
+  ca.created_by_display_name::text AS created_by_display_name,
+  ca.approved_by_external_id::text AS approved_by_external_id,
+  ca.approved_by_display_name::text AS approved_by_display_name,
+  ca.asset_ref_kind::text AS asset_ref_kind,
+  ca.asset_ref_external_id::text AS asset_ref_external_id,
+  ca.scope_json::jsonb AS scope_json
+FROM credential_artifacts ca
+WHERE ca.expired_at IS NULL
+  AND ca.last_observed_run_id IS NOT NULL
+ORDER BY ca.id ASC;
+
+-- name: ListCredentialArtifactRiskInputsBySource :many
+SELECT
+  ca.id::bigint AS credential_artifact_id,
+  ca.source_kind::text AS source_kind,
+  ca.source_name::text AS source_name,
+  ca.credential_kind::text AS credential_kind,
+  ca.status::text AS status,
+  ca.expires_at_source::timestamptz AS expires_at_source,
+  ca.last_used_at_source::timestamptz AS last_used_at_source,
+  ca.created_at_source::timestamptz AS created_at_source,
+  ca.created_by_external_id::text AS created_by_external_id,
+  ca.created_by_display_name::text AS created_by_display_name,
+  ca.approved_by_external_id::text AS approved_by_external_id,
+  ca.approved_by_display_name::text AS approved_by_display_name,
+  ca.asset_ref_kind::text AS asset_ref_kind,
+  ca.asset_ref_external_id::text AS asset_ref_external_id,
+  ca.scope_json::jsonb AS scope_json
+FROM credential_artifacts ca
+WHERE ca.expired_at IS NULL
+  AND ca.last_observed_run_id IS NOT NULL
+  AND lower(trim(ca.source_kind)) = lower(trim(sqlc.arg(source_kind)::text))
+  AND lower(trim(ca.source_name)) = lower(trim(sqlc.arg(source_name)::text))
+ORDER BY ca.id ASC;
+
+-- name: UpsertCredentialArtifactRiskReadModelsBulk :execrows
+WITH input AS (
+  SELECT
+    i,
+    (sqlc.arg(credential_artifact_ids)::bigint[])[i] AS credential_artifact_id,
+    (sqlc.arg(risk_levels)::text[])[i] AS risk_level,
+    (sqlc.arg(risk_ranks)::int[])[i] AS risk_rank,
+    (sqlc.arg(risk_signals_jsons)::jsonb[])[i] AS risk_signals_json,
+    (sqlc.arg(policy_packs_jsons)::jsonb[])[i] AS policy_packs_json
+  FROM generate_subscripts(sqlc.arg(credential_artifact_ids)::bigint[], 1) AS s(i)
+)
+INSERT INTO credential_artifact_risk_read_models (
+  credential_artifact_id,
+  risk_level,
+  risk_rank,
+  risk_signals_json,
+  policy_packs_json,
+  projection_refreshed_at
+)
+SELECT
+  input.credential_artifact_id,
+  input.risk_level,
+  input.risk_rank,
+  input.risk_signals_json,
+  input.policy_packs_json,
+  now()
+FROM input
+ON CONFLICT (credential_artifact_id) DO UPDATE SET
+  risk_level = EXCLUDED.risk_level,
+  risk_rank = EXCLUDED.risk_rank,
+  risk_signals_json = EXCLUDED.risk_signals_json,
   policy_packs_json = EXCLUDED.policy_packs_json,
   projection_refreshed_at = now();
 

--- a/db/queries/read_models.sql
+++ b/db/queries/read_models.sql
@@ -679,6 +679,7 @@ SELECT
   pr.source_name::text AS source_name,
   pr.display_name::text AS display_name,
   pr.secondary_name::text AS secondary_name,
+  -- Projection folds identity primary email into secondary_name, falling back to external ID.
   pr.secondary_name::text AS primary_email,
   pr.linked_assets_count::bigint AS linked_assets_count,
   pr.linked_credentials_count::bigint AS linked_credentials_count,
@@ -760,6 +761,7 @@ SELECT
   pr.source_name::text AS source_name,
   pr.display_name::text AS display_name,
   pr.secondary_name::text AS secondary_name,
+  -- Projection folds identity primary email into secondary_name, falling back to external ID.
   pr.secondary_name::text AS primary_email,
   pr.linked_assets_count::bigint AS linked_assets_count,
   pr.linked_credentials_count::bigint AS linked_credentials_count,

--- a/db/queries/read_models.sql
+++ b/db/queries/read_models.sql
@@ -78,6 +78,7 @@ SELECT (
     SELECT 1
     FROM non_human_principals nhp
     WHERE nhp.projection_refreshed_at IS NULL
+      OR nhp.policy_packs_json = '[]'::jsonb
   )
   OR (
     NOT EXISTS (
@@ -506,6 +507,304 @@ SET
   projection_refreshed_at = now()
 FROM merged
 WHERE aa.id = merged.id;
+
+-- name: DeleteAllNonHumanPrincipalReadModels :exec
+DELETE FROM non_human_principals;
+
+-- name: DeleteNonHumanPrincipalPolicyReadModelsBySource :exec
+WITH requested_source AS (
+  SELECT
+    lower(trim(sqlc.arg(source_kind)::text)) AS source_kind,
+    lower(trim(sqlc.arg(source_name)::text)) AS source_name
+),
+affected_identity_ids AS (
+  SELECT DISTINCT i.id AS identity_id
+  FROM identities i
+  JOIN identity_accounts ia ON ia.identity_id = i.id
+  JOIN accounts a ON a.id = ia.account_id
+  JOIN requested_source rs
+    ON rs.source_kind <> ''
+   AND rs.source_name <> ''
+   AND lower(trim(a.source_kind)) = rs.source_kind
+   AND lower(trim(a.source_name)) = rs.source_name
+  WHERE i.kind IN ('service', 'bot')
+  UNION
+  SELECT DISTINCT nhp.identity_id
+  FROM non_human_principals nhp
+  JOIN requested_source rs
+    ON rs.source_kind <> ''
+   AND rs.source_name <> ''
+   AND lower(trim(nhp.source_kind)) = rs.source_kind
+   AND lower(trim(nhp.source_name)) = rs.source_name
+  WHERE nhp.identity_id > 0
+),
+affected_asset_ids AS (
+  SELECT DISTINCT aa.id AS app_asset_id
+  FROM app_assets aa
+  JOIN requested_source rs
+    ON rs.source_kind <> ''
+   AND rs.source_name <> ''
+   AND lower(trim(aa.source_kind)) = rs.source_kind
+   AND lower(trim(aa.source_name)) = rs.source_name
+  UNION
+  SELECT DISTINCT nhp.app_asset_id
+  FROM non_human_principals nhp
+  JOIN requested_source rs
+    ON rs.source_kind <> ''
+   AND rs.source_name <> ''
+   AND lower(trim(nhp.source_kind)) = rs.source_kind
+   AND lower(trim(nhp.source_name)) = rs.source_name
+  WHERE nhp.app_asset_id > 0
+),
+affected_principal_refs AS (
+  SELECT 'identity-' || ai.identity_id::text AS principal_ref
+  FROM affected_identity_ids ai
+  UNION
+  SELECT 'app-asset-' || aa.app_asset_id::text AS principal_ref
+  FROM affected_asset_ids aa
+)
+DELETE FROM non_human_principals nhp
+USING affected_principal_refs apr
+WHERE nhp.principal_ref = apr.principal_ref;
+
+-- name: ListAllNonHumanPrincipalRiskInputs :many
+SELECT
+  pr.principal_ref::text AS principal_ref,
+  pr.identity_id::bigint AS identity_id,
+  pr.app_asset_id::bigint AS app_asset_id,
+  pr.principal_type::text AS principal_type,
+  pr.source_kind::text AS source_kind,
+  pr.source_name::text AS source_name,
+  pr.display_name::text AS display_name,
+  pr.secondary_name::text AS secondary_name,
+  pr.secondary_name::text AS primary_email,
+  pr.linked_assets_count::bigint AS linked_assets_count,
+  pr.linked_credentials_count::bigint AS linked_credentials_count,
+  pr.last_seen_at::timestamptz AS last_seen_at,
+  pr.activity_state::text AS activity_state,
+  pr.freshness_state::text AS freshness_state,
+  pr.governance_state::text AS governance_state,
+  pr.accountable_owner_identity_id::bigint AS accountable_owner_identity_id,
+  pr.accountable_owner_display_name::text AS accountable_owner_display_name,
+  pr.accountable_owner_primary_email::text AS accountable_owner_primary_email,
+  pr.owner_presence::text AS owner_presence,
+  pr.has_critical_credential::boolean AS has_critical_credential,
+  pr.has_high_risk_credential::boolean AS has_high_risk_credential,
+  pr.has_expired_credential::boolean AS has_expired_credential,
+  pr.has_expiring_credential::boolean AS has_expiring_credential,
+  pr.has_unused_credential::boolean AS has_unused_credential,
+  pr.has_stale_evidence::boolean AS has_stale_evidence
+FROM non_human_principal_projection_v pr
+ORDER BY pr.principal_ref;
+
+-- name: ListNonHumanPrincipalRiskInputsBySource :many
+WITH requested_source AS (
+  SELECT
+    lower(trim(sqlc.arg(source_kind)::text)) AS source_kind,
+    lower(trim(sqlc.arg(source_name)::text)) AS source_name
+),
+affected_identity_ids AS (
+  SELECT DISTINCT i.id AS identity_id
+  FROM identities i
+  JOIN identity_accounts ia ON ia.identity_id = i.id
+  JOIN accounts a ON a.id = ia.account_id
+  JOIN requested_source rs
+    ON rs.source_kind <> ''
+   AND rs.source_name <> ''
+   AND lower(trim(a.source_kind)) = rs.source_kind
+   AND lower(trim(a.source_name)) = rs.source_name
+  WHERE i.kind IN ('service', 'bot')
+  UNION
+  SELECT DISTINCT nhp.identity_id
+  FROM non_human_principals nhp
+  JOIN requested_source rs
+    ON rs.source_kind <> ''
+   AND rs.source_name <> ''
+   AND lower(trim(nhp.source_kind)) = rs.source_kind
+   AND lower(trim(nhp.source_name)) = rs.source_name
+  WHERE nhp.identity_id > 0
+),
+affected_asset_ids AS (
+  SELECT DISTINCT aa.id AS app_asset_id
+  FROM app_assets aa
+  JOIN requested_source rs
+    ON rs.source_kind <> ''
+   AND rs.source_name <> ''
+   AND lower(trim(aa.source_kind)) = rs.source_kind
+   AND lower(trim(aa.source_name)) = rs.source_name
+  UNION
+  SELECT DISTINCT nhp.app_asset_id
+  FROM non_human_principals nhp
+  JOIN requested_source rs
+    ON rs.source_kind <> ''
+   AND rs.source_name <> ''
+   AND lower(trim(nhp.source_kind)) = rs.source_kind
+   AND lower(trim(nhp.source_name)) = rs.source_name
+  WHERE nhp.app_asset_id > 0
+),
+affected_principal_refs AS (
+  SELECT 'identity-' || ai.identity_id::text AS principal_ref
+  FROM affected_identity_ids ai
+  UNION
+  SELECT 'app-asset-' || aa.app_asset_id::text AS principal_ref
+  FROM affected_asset_ids aa
+)
+SELECT
+  pr.principal_ref::text AS principal_ref,
+  pr.identity_id::bigint AS identity_id,
+  pr.app_asset_id::bigint AS app_asset_id,
+  pr.principal_type::text AS principal_type,
+  pr.source_kind::text AS source_kind,
+  pr.source_name::text AS source_name,
+  pr.display_name::text AS display_name,
+  pr.secondary_name::text AS secondary_name,
+  pr.secondary_name::text AS primary_email,
+  pr.linked_assets_count::bigint AS linked_assets_count,
+  pr.linked_credentials_count::bigint AS linked_credentials_count,
+  pr.last_seen_at::timestamptz AS last_seen_at,
+  pr.activity_state::text AS activity_state,
+  pr.freshness_state::text AS freshness_state,
+  pr.governance_state::text AS governance_state,
+  pr.accountable_owner_identity_id::bigint AS accountable_owner_identity_id,
+  pr.accountable_owner_display_name::text AS accountable_owner_display_name,
+  pr.accountable_owner_primary_email::text AS accountable_owner_primary_email,
+  pr.owner_presence::text AS owner_presence,
+  pr.has_critical_credential::boolean AS has_critical_credential,
+  pr.has_high_risk_credential::boolean AS has_high_risk_credential,
+  pr.has_expired_credential::boolean AS has_expired_credential,
+  pr.has_expiring_credential::boolean AS has_expiring_credential,
+  pr.has_unused_credential::boolean AS has_unused_credential,
+  pr.has_stale_evidence::boolean AS has_stale_evidence
+FROM non_human_principal_projection_v pr
+JOIN affected_principal_refs apr
+  ON apr.principal_ref = pr.principal_ref
+ORDER BY pr.principal_ref;
+
+-- name: UpsertNonHumanPrincipalReadModelsBulk :execrows
+WITH input AS (
+  SELECT
+    i,
+    (sqlc.arg(principal_refs)::text[])[i] AS principal_ref,
+    (sqlc.arg(identity_ids)::bigint[])[i] AS identity_id,
+    (sqlc.arg(app_asset_ids)::bigint[])[i] AS app_asset_id,
+    (sqlc.arg(principal_types)::text[])[i] AS principal_type,
+    (sqlc.arg(source_kinds)::text[])[i] AS source_kind,
+    (sqlc.arg(source_names)::text[])[i] AS source_name,
+    (sqlc.arg(display_names)::text[])[i] AS display_name,
+    (sqlc.arg(secondary_names)::text[])[i] AS secondary_name,
+    (sqlc.arg(linked_assets_counts)::bigint[])[i] AS linked_assets_count,
+    (sqlc.arg(linked_credentials_counts)::bigint[])[i] AS linked_credentials_count,
+    (sqlc.arg(last_seen_ats)::timestamptz[])[i] AS last_seen_at,
+    (sqlc.arg(activity_states)::text[])[i] AS activity_state,
+    (sqlc.arg(freshness_states)::text[])[i] AS freshness_state,
+    (sqlc.arg(governance_states)::text[])[i] AS governance_state,
+    (sqlc.arg(accountable_owner_identity_ids)::bigint[])[i] AS accountable_owner_identity_id,
+    (sqlc.arg(accountable_owner_display_names)::text[])[i] AS accountable_owner_display_name,
+    (sqlc.arg(accountable_owner_primary_emails)::text[])[i] AS accountable_owner_primary_email,
+    (sqlc.arg(owner_presences)::text[])[i] AS owner_presence,
+    (sqlc.arg(has_critical_credentials)::boolean[])[i] AS has_critical_credential,
+    (sqlc.arg(has_high_risk_credentials)::boolean[])[i] AS has_high_risk_credential,
+    (sqlc.arg(has_expired_credentials)::boolean[])[i] AS has_expired_credential,
+    (sqlc.arg(has_expiring_credentials)::boolean[])[i] AS has_expiring_credential,
+    (sqlc.arg(has_unused_credentials)::boolean[])[i] AS has_unused_credential,
+    (sqlc.arg(has_stale_evidences)::boolean[])[i] AS has_stale_evidence,
+    (sqlc.arg(risk_reason_counts)::int[])[i] AS risk_reason_count,
+    (sqlc.arg(risk_levels)::text[])[i] AS risk_level,
+    (sqlc.arg(risk_signals_jsons)::jsonb[])[i] AS risk_signals_json,
+    (sqlc.arg(policy_packs_jsons)::jsonb[])[i] AS policy_packs_json
+  FROM generate_subscripts(sqlc.arg(principal_refs)::text[], 1) AS s(i)
+)
+INSERT INTO non_human_principals (
+  principal_ref,
+  identity_id,
+  app_asset_id,
+  principal_type,
+  source_kind,
+  source_name,
+  display_name,
+  secondary_name,
+  linked_assets_count,
+  linked_credentials_count,
+  last_seen_at,
+  activity_state,
+  freshness_state,
+  governance_state,
+  accountable_owner_identity_id,
+  accountable_owner_display_name,
+  accountable_owner_primary_email,
+  owner_presence,
+  has_critical_credential,
+  has_high_risk_credential,
+  has_expired_credential,
+  has_expiring_credential,
+  has_unused_credential,
+  has_stale_evidence,
+  risk_reason_count,
+  risk_level,
+  risk_signals_json,
+  policy_packs_json,
+  projection_refreshed_at
+)
+SELECT
+  input.principal_ref,
+  input.identity_id,
+  input.app_asset_id,
+  input.principal_type,
+  input.source_kind,
+  input.source_name,
+  input.display_name,
+  input.secondary_name,
+  input.linked_assets_count,
+  input.linked_credentials_count,
+  input.last_seen_at,
+  input.activity_state,
+  input.freshness_state,
+  input.governance_state,
+  input.accountable_owner_identity_id,
+  input.accountable_owner_display_name,
+  input.accountable_owner_primary_email,
+  input.owner_presence,
+  input.has_critical_credential,
+  input.has_high_risk_credential,
+  input.has_expired_credential,
+  input.has_expiring_credential,
+  input.has_unused_credential,
+  input.has_stale_evidence,
+  input.risk_reason_count,
+  input.risk_level,
+  input.risk_signals_json,
+  input.policy_packs_json,
+  now()
+FROM input
+ON CONFLICT (principal_ref) DO UPDATE SET
+  identity_id = EXCLUDED.identity_id,
+  app_asset_id = EXCLUDED.app_asset_id,
+  principal_type = EXCLUDED.principal_type,
+  source_kind = EXCLUDED.source_kind,
+  source_name = EXCLUDED.source_name,
+  display_name = EXCLUDED.display_name,
+  secondary_name = EXCLUDED.secondary_name,
+  linked_assets_count = EXCLUDED.linked_assets_count,
+  linked_credentials_count = EXCLUDED.linked_credentials_count,
+  last_seen_at = EXCLUDED.last_seen_at,
+  activity_state = EXCLUDED.activity_state,
+  freshness_state = EXCLUDED.freshness_state,
+  governance_state = EXCLUDED.governance_state,
+  accountable_owner_identity_id = EXCLUDED.accountable_owner_identity_id,
+  accountable_owner_display_name = EXCLUDED.accountable_owner_display_name,
+  accountable_owner_primary_email = EXCLUDED.accountable_owner_primary_email,
+  owner_presence = EXCLUDED.owner_presence,
+  has_critical_credential = EXCLUDED.has_critical_credential,
+  has_high_risk_credential = EXCLUDED.has_high_risk_credential,
+  has_expired_credential = EXCLUDED.has_expired_credential,
+  has_expiring_credential = EXCLUDED.has_expiring_credential,
+  has_unused_credential = EXCLUDED.has_unused_credential,
+  has_stale_evidence = EXCLUDED.has_stale_evidence,
+  risk_reason_count = EXCLUDED.risk_reason_count,
+  risk_level = EXCLUDED.risk_level,
+  risk_signals_json = EXCLUDED.risk_signals_json,
+  policy_packs_json = EXCLUDED.policy_packs_json,
+  projection_refreshed_at = now();
 
 -- name: RefreshAllNonHumanPrincipalReadModels :execrows
 WITH cleared AS (

--- a/internal/connectors/entra/full_sync_integration_test.go
+++ b/internal/connectors/entra/full_sync_integration_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/golang-migrate/migrate/v4"
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/open-sspm/open-sspm/internal/connectors/registry"
 	"github.com/open-sspm/open-sspm/internal/db/gen"
@@ -381,10 +380,7 @@ func TestEntraRunFullPersistsEffectiveEntitlements(t *testing.T) {
 			t.Fatalf("unexpected service principal owner: %+v", servicePrincipalOwners[0])
 		}
 
-		nowTS := pgtype.Timestamptz{Time: time.Now().UTC(), Valid: true}
-
 		applicationCredentials, err := q.ListCredentialArtifactsForAssetRef(ctx, gen.ListCredentialArtifactsForAssetRefParams{
-			EvaluatedAt:        nowTS,
 			SourceKind:         "entra",
 			SourceName:         fullSyncTenantID,
 			AssetRefKind:       "app_asset",
@@ -408,7 +404,6 @@ func TestEntraRunFullPersistsEffectiveEntitlements(t *testing.T) {
 		}
 
 		servicePrincipalCredentials, err := q.ListCredentialArtifactsForAssetRef(ctx, gen.ListCredentialArtifactsForAssetRefParams{
-			EvaluatedAt:        nowTS,
 			SourceKind:         "entra",
 			SourceName:         fullSyncTenantID,
 			AssetRefKind:       "app_asset",

--- a/internal/connectors/registry/helpers.go
+++ b/internal/connectors/registry/helpers.go
@@ -554,6 +554,9 @@ func refreshPostSuccessReadModelsInTx(ctx context.Context, q *gen.Queries, sourc
 	if err := refreshSaaSAppRiskReadModelsInTx(ctx, q, sourceKind, sourceName); err != nil {
 		return err
 	}
+	if err := refreshCredentialArtifactRiskReadModelsInTx(ctx, q, sourceKind, sourceName); err != nil {
+		return err
+	}
 	return refreshNonHumanPrincipalReadModelsInTx(ctx, q, sourceKind, sourceName)
 }
 
@@ -571,6 +574,14 @@ func refreshSaaSAppRiskReadModelsInTx(ctx context.Context, q *gen.Queries, sourc
 		return nil
 	}
 	return projector.RefreshSaaSAppRiskReadModelsBySource(ctx, sourceKind, sourceName)
+}
+
+func refreshCredentialArtifactRiskReadModelsInTx(ctx context.Context, q *gen.Queries, sourceKind, sourceName string) error {
+	projector := readmodels.ProjectorFromContext(ctx, q)
+	if projector == nil {
+		return nil
+	}
+	return projector.RefreshCredentialArtifactRiskReadModelsBySource(ctx, sourceKind, sourceName)
 }
 
 func refreshNonHumanPrincipalReadModelsInTx(ctx context.Context, q *gen.Queries, sourceKind, sourceName string) error {

--- a/internal/db/gen/credential_artifacts.sql.go
+++ b/internal/db/gen/credential_artifacts.sql.go
@@ -15,16 +15,10 @@ const countCredentialArtifactsBySourceAndQueryAndFilters = `-- name: CountCreden
 WITH rated_credentials AS (
   SELECT
     ca.id, ca.source_kind, ca.source_name, ca.asset_ref_kind, ca.asset_ref_external_id, ca.credential_kind, ca.external_id, ca.display_name, ca.fingerprint, ca.scope_json, ca.status, ca.created_at_source, ca.expires_at_source, ca.last_used_at_source, ca.created_by_kind, ca.created_by_external_id, ca.created_by_display_name, ca.approved_by_kind, ca.approved_by_external_id, ca.approved_by_display_name, ca.raw_json, ca.seen_in_run_id, ca.seen_at, ca.last_observed_run_id, ca.last_observed_at, ca.expired_at, ca.expired_run_id, ca.created_at, ca.updated_at,
-    credential_artifact_risk_level(
-      ca.status,
-      ca.credential_kind,
-      ca.expires_at_source,
-      ca.last_used_at_source,
-      ca.created_by_external_id,
-      ca.approved_by_external_id,
-      $3::timestamptz
-    ) AS risk_level
+    COALESCE(risk.risk_level, 'low')::text AS risk_level
   FROM credential_artifacts ca
+  LEFT JOIN credential_artifact_risk_read_models risk
+    ON risk.credential_artifact_id = ca.id
   WHERE
     ca.source_kind = $6::text
     AND ca.source_name = $7::text
@@ -116,16 +110,10 @@ WITH configured_sources AS (
 rated_credentials AS (
   SELECT
     ca.id, ca.source_kind, ca.source_name, ca.asset_ref_kind, ca.asset_ref_external_id, ca.credential_kind, ca.external_id, ca.display_name, ca.fingerprint, ca.scope_json, ca.status, ca.created_at_source, ca.expires_at_source, ca.last_used_at_source, ca.created_by_kind, ca.created_by_external_id, ca.created_by_display_name, ca.approved_by_kind, ca.approved_by_external_id, ca.approved_by_display_name, ca.raw_json, ca.seen_in_run_id, ca.seen_at, ca.last_observed_run_id, ca.last_observed_at, ca.expired_at, ca.expired_run_id, ca.created_at, ca.updated_at,
-    credential_artifact_risk_level(
-      ca.status,
-      ca.credential_kind,
-      ca.expires_at_source,
-      ca.last_used_at_source,
-      ca.created_by_external_id,
-      ca.approved_by_external_id,
-      $3::timestamptz
-    ) AS risk_level
+    COALESCE(risk.risk_level, 'low')::text AS risk_level
   FROM credential_artifacts ca
+  LEFT JOIN credential_artifact_risk_read_models risk
+    ON risk.credential_artifact_id = ca.id
   JOIN configured_sources cs
     ON cs.source_kind = ca.source_kind
    AND cs.source_name = ca.source_name
@@ -239,25 +227,16 @@ func (q *Queries) ExpireCredentialArtifactsNotSeenInRunBySource(ctx context.Cont
 const getCredentialArtifactByID = `-- name: GetCredentialArtifactByID :one
 SELECT
   ca.id, ca.source_kind, ca.source_name, ca.asset_ref_kind, ca.asset_ref_external_id, ca.credential_kind, ca.external_id, ca.display_name, ca.fingerprint, ca.scope_json, ca.status, ca.created_at_source, ca.expires_at_source, ca.last_used_at_source, ca.created_by_kind, ca.created_by_external_id, ca.created_by_display_name, ca.approved_by_kind, ca.approved_by_external_id, ca.approved_by_display_name, ca.raw_json, ca.seen_in_run_id, ca.seen_at, ca.last_observed_run_id, ca.last_observed_at, ca.expired_at, ca.expired_run_id, ca.created_at, ca.updated_at,
-  credential_artifact_risk_level(
-    ca.status,
-    ca.credential_kind,
-    ca.expires_at_source,
-    ca.last_used_at_source,
-    ca.created_by_external_id,
-    ca.approved_by_external_id,
-    $1::timestamptz
-  ) AS risk_level
+  COALESCE(risk.risk_level, 'low')::text AS risk_level,
+  COALESCE(risk.risk_signals_json, '[]'::jsonb)::jsonb AS risk_signals_json,
+  COALESCE(risk.policy_packs_json, '[]'::jsonb)::jsonb AS policy_packs_json
 FROM credential_artifacts ca
-WHERE ca.id = $2::bigint
+LEFT JOIN credential_artifact_risk_read_models risk
+  ON risk.credential_artifact_id = ca.id
+WHERE ca.id = $1::bigint
   AND expired_at IS NULL
   AND last_observed_run_id IS NOT NULL
 `
-
-type GetCredentialArtifactByIDParams struct {
-	EvaluatedAt pgtype.Timestamptz `json:"evaluated_at"`
-	ID          int64              `json:"id"`
-}
 
 type GetCredentialArtifactByIDRow struct {
 	ID                    int64              `json:"id"`
@@ -290,10 +269,12 @@ type GetCredentialArtifactByIDRow struct {
 	CreatedAt             pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt             pgtype.Timestamptz `json:"updated_at"`
 	RiskLevel             string             `json:"risk_level"`
+	RiskSignalsJson       []byte             `json:"risk_signals_json"`
+	PolicyPacksJson       []byte             `json:"policy_packs_json"`
 }
 
-func (q *Queries) GetCredentialArtifactByID(ctx context.Context, arg GetCredentialArtifactByIDParams) (GetCredentialArtifactByIDRow, error) {
-	row := q.db.QueryRow(ctx, getCredentialArtifactByID, arg.EvaluatedAt, arg.ID)
+func (q *Queries) GetCredentialArtifactByID(ctx context.Context, id int64) (GetCredentialArtifactByIDRow, error) {
+	row := q.db.QueryRow(ctx, getCredentialArtifactByID, id)
 	var i GetCredentialArtifactByIDRow
 	err := row.Scan(
 		&i.ID,
@@ -326,6 +307,8 @@ func (q *Queries) GetCredentialArtifactByID(ctx context.Context, arg GetCredenti
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.RiskLevel,
+		&i.RiskSignalsJson,
+		&i.PolicyPacksJson,
 	)
 	return i, err
 }
@@ -396,20 +379,14 @@ func (q *Queries) ListCredentialArtifactCountsByAssetRef(ctx context.Context, ar
 const listCredentialArtifactsForAssetRef = `-- name: ListCredentialArtifactsForAssetRef :many
 SELECT
   ca.id, ca.source_kind, ca.source_name, ca.asset_ref_kind, ca.asset_ref_external_id, ca.credential_kind, ca.external_id, ca.display_name, ca.fingerprint, ca.scope_json, ca.status, ca.created_at_source, ca.expires_at_source, ca.last_used_at_source, ca.created_by_kind, ca.created_by_external_id, ca.created_by_display_name, ca.approved_by_kind, ca.approved_by_external_id, ca.approved_by_display_name, ca.raw_json, ca.seen_in_run_id, ca.seen_at, ca.last_observed_run_id, ca.last_observed_at, ca.expired_at, ca.expired_run_id, ca.created_at, ca.updated_at,
-  credential_artifact_risk_level(
-    ca.status,
-    ca.credential_kind,
-    ca.expires_at_source,
-    ca.last_used_at_source,
-    ca.created_by_external_id,
-    ca.approved_by_external_id,
-    $1::timestamptz
-  ) AS risk_level
+  COALESCE(risk.risk_level, 'low')::text AS risk_level
 FROM credential_artifacts ca
-WHERE ca.source_kind = $2::text
-  AND ca.source_name = $3::text
-  AND ca.asset_ref_kind = $4::text
-  AND ca.asset_ref_external_id = $5::text
+LEFT JOIN credential_artifact_risk_read_models risk
+  ON risk.credential_artifact_id = ca.id
+WHERE ca.source_kind = $1::text
+  AND ca.source_name = $2::text
+  AND ca.asset_ref_kind = $3::text
+  AND ca.asset_ref_external_id = $4::text
   AND ca.expired_at IS NULL
   AND ca.last_observed_run_id IS NOT NULL
 ORDER BY
@@ -418,11 +395,10 @@ ORDER BY
 `
 
 type ListCredentialArtifactsForAssetRefParams struct {
-	EvaluatedAt        pgtype.Timestamptz `json:"evaluated_at"`
-	SourceKind         string             `json:"source_kind"`
-	SourceName         string             `json:"source_name"`
-	AssetRefKind       string             `json:"asset_ref_kind"`
-	AssetRefExternalID string             `json:"asset_ref_external_id"`
+	SourceKind         string `json:"source_kind"`
+	SourceName         string `json:"source_name"`
+	AssetRefKind       string `json:"asset_ref_kind"`
+	AssetRefExternalID string `json:"asset_ref_external_id"`
 }
 
 type ListCredentialArtifactsForAssetRefRow struct {
@@ -460,7 +436,6 @@ type ListCredentialArtifactsForAssetRefRow struct {
 
 func (q *Queries) ListCredentialArtifactsForAssetRef(ctx context.Context, arg ListCredentialArtifactsForAssetRefParams) ([]ListCredentialArtifactsForAssetRefRow, error) {
 	rows, err := q.db.Query(ctx, listCredentialArtifactsForAssetRef,
-		arg.EvaluatedAt,
 		arg.SourceKind,
 		arg.SourceName,
 		arg.AssetRefKind,
@@ -519,16 +494,10 @@ const listCredentialArtifactsPageBySourceAndQueryAndFilters = `-- name: ListCred
 WITH rated_credentials AS (
   SELECT
     ca.id, ca.source_kind, ca.source_name, ca.asset_ref_kind, ca.asset_ref_external_id, ca.credential_kind, ca.external_id, ca.display_name, ca.fingerprint, ca.scope_json, ca.status, ca.created_at_source, ca.expires_at_source, ca.last_used_at_source, ca.created_by_kind, ca.created_by_external_id, ca.created_by_display_name, ca.approved_by_kind, ca.approved_by_external_id, ca.approved_by_display_name, ca.raw_json, ca.seen_in_run_id, ca.seen_at, ca.last_observed_run_id, ca.last_observed_at, ca.expired_at, ca.expired_run_id, ca.created_at, ca.updated_at,
-    credential_artifact_risk_level(
-      ca.status,
-      ca.credential_kind,
-      ca.expires_at_source,
-      ca.last_used_at_source,
-      ca.created_by_external_id,
-      ca.approved_by_external_id,
-      $3::timestamptz
-    ) AS risk_level
+    COALESCE(risk.risk_level, 'low')::text AS risk_level
   FROM credential_artifacts ca
+  LEFT JOIN credential_artifact_risk_read_models risk
+    ON risk.credential_artifact_id = ca.id
   WHERE
     ca.source_kind = $8::text
     AND ca.source_name = $9::text
@@ -707,16 +676,10 @@ WITH configured_sources AS (
 rated_credentials AS (
   SELECT
     ca.id, ca.source_kind, ca.source_name, ca.asset_ref_kind, ca.asset_ref_external_id, ca.credential_kind, ca.external_id, ca.display_name, ca.fingerprint, ca.scope_json, ca.status, ca.created_at_source, ca.expires_at_source, ca.last_used_at_source, ca.created_by_kind, ca.created_by_external_id, ca.created_by_display_name, ca.approved_by_kind, ca.approved_by_external_id, ca.approved_by_display_name, ca.raw_json, ca.seen_in_run_id, ca.seen_at, ca.last_observed_run_id, ca.last_observed_at, ca.expired_at, ca.expired_run_id, ca.created_at, ca.updated_at,
-    credential_artifact_risk_level(
-      ca.status,
-      ca.credential_kind,
-      ca.expires_at_source,
-      ca.last_used_at_source,
-      ca.created_by_external_id,
-      ca.approved_by_external_id,
-      $3::timestamptz
-    ) AS risk_level
+    COALESCE(risk.risk_level, 'low')::text AS risk_level
   FROM credential_artifacts ca
+  LEFT JOIN credential_artifact_risk_read_models risk
+    ON risk.credential_artifact_id = ca.id
   JOIN configured_sources cs
     ON cs.source_kind = ca.source_kind
    AND cs.source_name = ca.source_name

--- a/internal/db/gen/models.go
+++ b/internal/db/gen/models.go
@@ -195,6 +195,15 @@ type CredentialArtifact struct {
 	UpdatedAt             pgtype.Timestamptz `json:"updated_at"`
 }
 
+type CredentialArtifactRiskReadModel struct {
+	CredentialArtifactID  int64              `json:"credential_artifact_id"`
+	RiskLevel             string             `json:"risk_level"`
+	RiskRank              int32              `json:"risk_rank"`
+	RiskSignalsJson       []byte             `json:"risk_signals_json"`
+	PolicyPacksJson       []byte             `json:"policy_packs_json"`
+	ProjectionRefreshedAt pgtype.Timestamptz `json:"projection_refreshed_at"`
+}
+
 type CredentialAuditEvent struct {
 	ID                   int64              `json:"id"`
 	SourceKind           string             `json:"source_kind"`

--- a/internal/db/gen/models.go
+++ b/internal/db/gen/models.go
@@ -375,6 +375,8 @@ type NonHumanPrincipal struct {
 	RiskReasonCount              int32              `json:"risk_reason_count"`
 	RiskLevel                    string             `json:"risk_level"`
 	ProjectionRefreshedAt        pgtype.Timestamptz `json:"projection_refreshed_at"`
+	RiskSignalsJson              []byte             `json:"risk_signals_json"`
+	PolicyPacksJson              []byte             `json:"policy_packs_json"`
 }
 
 type NonHumanPrincipalAssetLinksV struct {
@@ -441,6 +443,8 @@ type NonHumanPrincipalReadModelsV struct {
 	HasStaleEvidence             bool               `json:"has_stale_evidence"`
 	RiskReasonCount              int32              `json:"risk_reason_count"`
 	RiskLevel                    string             `json:"risk_level"`
+	RiskSignalsJson              []byte             `json:"risk_signals_json"`
+	PolicyPacksJson              []byte             `json:"policy_packs_json"`
 }
 
 type OktaApp struct {

--- a/internal/db/gen/non_human_access.sql.go
+++ b/internal/db/gen/non_human_access.sql.go
@@ -159,7 +159,9 @@ SELECT
   pr.has_unused_credential,
   pr.has_stale_evidence,
   pr.risk_reason_count,
-  pr.risk_level
+  pr.risk_level,
+  pr.risk_signals_json,
+  pr.policy_packs_json
 FROM non_human_principal_read_models_v pr
 WHERE pr.principal_ref = $1::text
 `
@@ -194,6 +196,8 @@ func (q *Queries) GetNonHumanPrincipalByRef(ctx context.Context, principalRef st
 		&i.HasStaleEvidence,
 		&i.RiskReasonCount,
 		&i.RiskLevel,
+		&i.RiskSignalsJson,
+		&i.PolicyPacksJson,
 	)
 	return i, err
 }
@@ -466,7 +470,7 @@ effective_configured_sources AS (
   )
 ),
 base AS (
-  SELECT pr.principal_ref, pr.identity_id, pr.app_asset_id, pr.principal_type, pr.source_kind, pr.source_name, pr.display_name, pr.secondary_name, pr.linked_assets_count, pr.linked_credentials_count, pr.last_seen_at, pr.activity_state, pr.freshness_state, pr.governance_state, pr.accountable_owner_identity_id, pr.accountable_owner_display_name, pr.accountable_owner_primary_email, pr.owner_presence, pr.has_critical_credential, pr.has_high_risk_credential, pr.has_expired_credential, pr.has_expiring_credential, pr.has_unused_credential, pr.has_stale_evidence, pr.risk_reason_count, pr.risk_level
+  SELECT pr.principal_ref, pr.identity_id, pr.app_asset_id, pr.principal_type, pr.source_kind, pr.source_name, pr.display_name, pr.secondary_name, pr.linked_assets_count, pr.linked_credentials_count, pr.last_seen_at, pr.activity_state, pr.freshness_state, pr.governance_state, pr.accountable_owner_identity_id, pr.accountable_owner_display_name, pr.accountable_owner_primary_email, pr.owner_presence, pr.has_critical_credential, pr.has_high_risk_credential, pr.has_expired_credential, pr.has_expiring_credential, pr.has_unused_credential, pr.has_stale_evidence, pr.risk_reason_count, pr.risk_level, pr.risk_signals_json, pr.policy_packs_json
   FROM non_human_principal_read_models_v pr
   JOIN effective_configured_sources cs
     ON cs.source_kind = pr.source_kind

--- a/internal/db/gen/non_human_access.sql.go
+++ b/internal/db/gen/non_human_access.sql.go
@@ -304,15 +304,7 @@ WITH credential_matches AS (
     ca.external_id::text AS external_id,
     COALESCE(NULLIF(trim(ca.display_name), ''), ca.external_id)::text AS display_name,
     ca.status::text AS status,
-    credential_artifact_risk_level(
-      ca.status,
-      ca.credential_kind,
-      ca.expires_at_source,
-      ca.last_used_at_source,
-      ca.created_by_external_id,
-      ca.approved_by_external_id,
-      now()
-    )::text AS risk_level,
+    COALESCE(risk.risk_level, 'low')::text AS risk_level,
     ca.expires_at_source::timestamptz AS expires_at_source,
     ca.last_used_at_source::timestamptz AS last_used_at_source,
     ca.created_by_display_name::text AS created_by_display_name,
@@ -332,6 +324,8 @@ WITH credential_matches AS (
    AND ca.asset_ref_external_id = nhac.asset_ref_external_id
    AND ca.expired_at IS NULL
    AND ca.last_observed_run_id IS NOT NULL
+  LEFT JOIN credential_artifact_risk_read_models risk
+    ON risk.credential_artifact_id = ca.id
   WHERE nhpal.principal_ref = $1::text
   ORDER BY
     ca.id,

--- a/internal/db/gen/non_human_access_events.sql.go
+++ b/internal/db/gen/non_human_access_events.sql.go
@@ -15,15 +15,7 @@ const countConfiguredNonHumanHighRiskCredentialAttribution = `-- name: CountConf
 WITH linked_credentials AS (
   SELECT
     ca.id::bigint AS credential_id,
-    credential_artifact_risk_level(
-      ca.status,
-      ca.credential_kind,
-      ca.expires_at_source,
-      ca.last_used_at_source,
-      ca.created_by_external_id,
-      ca.approved_by_external_id,
-      now()
-    )::text AS risk_level,
+    COALESCE(risk.risk_rank, 1)::int AS risk_rank,
     (
       pr.owner_presence = 'owned'
       OR NULLIF(trim(ca.created_by_display_name), '') IS NOT NULL
@@ -49,25 +41,20 @@ WITH linked_credentials AS (
    AND ca.asset_ref_external_id = nhac.asset_ref_external_id
    AND ca.expired_at IS NULL
    AND ca.last_observed_run_id IS NOT NULL
+  LEFT JOIN credential_artifact_risk_read_models risk
+    ON risk.credential_artifact_id = ca.id
 ),
 deduped AS (
   SELECT
     lc.credential_id,
-    max(
-      CASE lc.risk_level
-        WHEN 'critical' THEN 3
-        WHEN 'high' THEN 2
-        WHEN 'medium' THEN 1
-        ELSE 0
-      END
-    )::int AS risk_rank,
+    max(lc.risk_rank)::int AS risk_rank,
     bool_or(lc.has_attribution)::boolean AS has_attribution
   FROM linked_credentials lc
   GROUP BY lc.credential_id
 )
 SELECT
-  count(*) FILTER (WHERE d.risk_rank >= 2)::bigint AS high_risk_credential_count,
-  count(*) FILTER (WHERE d.risk_rank >= 2 AND d.has_attribution)::bigint AS high_risk_with_attribution_count
+  count(*) FILTER (WHERE d.risk_rank >= 3)::bigint AS high_risk_credential_count,
+  count(*) FILTER (WHERE d.risk_rank >= 3 AND d.has_attribution)::bigint AS high_risk_with_attribution_count
 FROM deduped d
 `
 

--- a/internal/db/gen/non_human_access_integration_test.go
+++ b/internal/db/gen/non_human_access_integration_test.go
@@ -55,7 +55,7 @@ func TestNonHumanAccessReadModelsAndMetrics(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("UpsertAppAssetGovernance(service): %v", err)
 		}
-		insertCredentialArtifact(t, ctx, pool, entraRunID, credentialArtifactSeed{
+		ownedCredentialID := insertCredentialArtifact(t, ctx, pool, entraRunID, credentialArtifactSeed{
 			SourceKind:          "entra",
 			SourceName:          "tenant-1",
 			AssetRefKind:        "app_asset",
@@ -76,7 +76,7 @@ func TestNonHumanAccessReadModelsAndMetrics(t *testing.T) {
 			ExternalID:  "github-actions",
 			DisplayName: "GitHub Actions",
 		})
-		insertCredentialArtifact(t, ctx, pool, githubRunID, credentialArtifactSeed{
+		unownedCredentialID := insertCredentialArtifact(t, ctx, pool, githubRunID, credentialArtifactSeed{
 			SourceKind:         "github",
 			SourceName:         "acme",
 			AssetRefKind:       "app_asset",
@@ -87,6 +87,8 @@ func TestNonHumanAccessReadModelsAndMetrics(t *testing.T) {
 			Status:             "active",
 			LastUsedAtSource:   now.Add(-120 * 24 * time.Hour),
 		})
+		insertCredentialRiskReadModel(t, ctx, pool, ownedCredentialID, "critical", 4)
+		insertCredentialRiskReadModel(t, ctx, pool, unownedCredentialID, "critical", 4)
 
 		if _, err := q.RefreshAllAppAssetReadModels(ctx); err != nil {
 			t.Fatalf("RefreshAllAppAssetReadModels(): %v", err)
@@ -193,6 +195,30 @@ func TestNonHumanAccessReadModelsAndMetrics(t *testing.T) {
 			t.Fatalf("weekly sessions = %d want 1", weeklySessions)
 		}
 	})
+}
+
+func insertCredentialRiskReadModel(t *testing.T, ctx context.Context, pool *pgxpool.Pool, credentialID int64, riskLevel string, riskRank int) {
+	t.Helper()
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO credential_artifact_risk_read_models (
+			credential_artifact_id,
+			risk_level,
+			risk_rank,
+			risk_signals_json,
+			policy_packs_json,
+			projection_refreshed_at
+		)
+		VALUES ($1, $2, $3, '[]'::jsonb, '[{"id":"builtin-credential-risk","version":"1.0.0"}]'::jsonb, now())
+		ON CONFLICT (credential_artifact_id) DO UPDATE SET
+			risk_level = EXCLUDED.risk_level,
+			risk_rank = EXCLUDED.risk_rank,
+			risk_signals_json = EXCLUDED.risk_signals_json,
+			policy_packs_json = EXCLUDED.policy_packs_json,
+			projection_refreshed_at = now()
+	`, credentialID, riskLevel, riskRank); err != nil {
+		t.Fatalf("insert credential risk read model %d: %v", credentialID, err)
+	}
 }
 
 func TestRefreshNonHumanPrincipalReadModelsBySourceKeepsUnrelatedRowsUntouched(t *testing.T) {

--- a/internal/db/gen/programmatic_access_integration_test.go
+++ b/internal/db/gen/programmatic_access_integration_test.go
@@ -203,7 +203,7 @@ func TestListCredentialArtifactsPageBySourcesAndQueryAndFiltersPaginatesGlobally
 	})
 }
 
-func TestCredentialArtifactRiskLevelConsistentAcrossQueries(t *testing.T) {
+func TestCredentialArtifactStoredRiskLevelConsistentAcrossQueries(t *testing.T) {
 	t.Parallel()
 
 	withEntityCategoryTestDatabase(t, func(ctx context.Context, pool *pgxpool.Pool, q *Queries, migrator *migrate.Migrate) {
@@ -326,11 +326,9 @@ func TestCredentialArtifactRiskLevelConsistentAcrossQueries(t *testing.T) {
 				CreatedByExternalID:  tc.seed.CreatedByExternalID,
 				ApprovedByExternalID: tc.seed.ApprovedByExternalID,
 			})
+			insertCredentialRiskReadModel(t, ctx, pool, credentialID, tc.want, credentialRiskRank(tc.want))
 
-			gotByID, err := q.GetCredentialArtifactByID(ctx, GetCredentialArtifactByIDParams{
-				EvaluatedAt: evaluatedAt,
-				ID:          credentialID,
-			})
+			gotByID, err := q.GetCredentialArtifactByID(ctx, credentialID)
 			if err != nil {
 				t.Fatalf("%s: GetCredentialArtifactByID(): %v", tc.name, err)
 			}
@@ -339,7 +337,6 @@ func TestCredentialArtifactRiskLevelConsistentAcrossQueries(t *testing.T) {
 			}
 
 			assetRows, err := q.ListCredentialArtifactsForAssetRef(ctx, ListCredentialArtifactsForAssetRefParams{
-				EvaluatedAt:        evaluatedAt,
 				SourceKind:         "github",
 				SourceName:         sourceName,
 				AssetRefKind:       "repository",
@@ -1187,6 +1184,19 @@ func nullableTime(value time.Time) any {
 		return nil
 	}
 	return value.UTC()
+}
+
+func credentialRiskRank(value string) int {
+	switch value {
+	case "critical":
+		return 4
+	case "high":
+		return 3
+	case "medium":
+		return 2
+	default:
+		return 1
+	}
 }
 
 func validTimestamptz(value time.Time) pgtype.Timestamptz {

--- a/internal/db/gen/read_models.sql.go
+++ b/internal/db/gen/read_models.sql.go
@@ -298,6 +298,7 @@ SELECT
   pr.source_name::text AS source_name,
   pr.display_name::text AS display_name,
   pr.secondary_name::text AS secondary_name,
+  -- Projection folds identity primary email into secondary_name, falling back to external ID.
   pr.secondary_name::text AS primary_email,
   pr.linked_assets_count::bigint AS linked_assets_count,
   pr.linked_credentials_count::bigint AS linked_credentials_count,
@@ -691,6 +692,7 @@ SELECT
   pr.source_name::text AS source_name,
   pr.display_name::text AS display_name,
   pr.secondary_name::text AS secondary_name,
+  -- Projection folds identity primary email into secondary_name, falling back to external ID.
   pr.secondary_name::text AS primary_email,
   pr.linked_assets_count::bigint AS linked_assets_count,
   pr.linked_credentials_count::bigint AS linked_credentials_count,

--- a/internal/db/gen/read_models.sql.go
+++ b/internal/db/gen/read_models.sql.go
@@ -11,12 +11,88 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const deleteAllNonHumanPrincipalReadModels = `-- name: DeleteAllNonHumanPrincipalReadModels :exec
+DELETE FROM non_human_principals
+`
+
+func (q *Queries) DeleteAllNonHumanPrincipalReadModels(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, deleteAllNonHumanPrincipalReadModels)
+	return err
+}
+
 const deleteConnectorSourceStateAll = `-- name: DeleteConnectorSourceStateAll :exec
 DELETE FROM connector_source_state
 `
 
 func (q *Queries) DeleteConnectorSourceStateAll(ctx context.Context) error {
 	_, err := q.db.Exec(ctx, deleteConnectorSourceStateAll)
+	return err
+}
+
+const deleteNonHumanPrincipalPolicyReadModelsBySource = `-- name: DeleteNonHumanPrincipalPolicyReadModelsBySource :exec
+WITH requested_source AS (
+  SELECT
+    lower(trim($1::text)) AS source_kind,
+    lower(trim($2::text)) AS source_name
+),
+affected_identity_ids AS (
+  SELECT DISTINCT i.id AS identity_id
+  FROM identities i
+  JOIN identity_accounts ia ON ia.identity_id = i.id
+  JOIN accounts a ON a.id = ia.account_id
+  JOIN requested_source rs
+    ON rs.source_kind <> ''
+   AND rs.source_name <> ''
+   AND lower(trim(a.source_kind)) = rs.source_kind
+   AND lower(trim(a.source_name)) = rs.source_name
+  WHERE i.kind IN ('service', 'bot')
+  UNION
+  SELECT DISTINCT nhp.identity_id
+  FROM non_human_principals nhp
+  JOIN requested_source rs
+    ON rs.source_kind <> ''
+   AND rs.source_name <> ''
+   AND lower(trim(nhp.source_kind)) = rs.source_kind
+   AND lower(trim(nhp.source_name)) = rs.source_name
+  WHERE nhp.identity_id > 0
+),
+affected_asset_ids AS (
+  SELECT DISTINCT aa.id AS app_asset_id
+  FROM app_assets aa
+  JOIN requested_source rs
+    ON rs.source_kind <> ''
+   AND rs.source_name <> ''
+   AND lower(trim(aa.source_kind)) = rs.source_kind
+   AND lower(trim(aa.source_name)) = rs.source_name
+  UNION
+  SELECT DISTINCT nhp.app_asset_id
+  FROM non_human_principals nhp
+  JOIN requested_source rs
+    ON rs.source_kind <> ''
+   AND rs.source_name <> ''
+   AND lower(trim(nhp.source_kind)) = rs.source_kind
+   AND lower(trim(nhp.source_name)) = rs.source_name
+  WHERE nhp.app_asset_id > 0
+),
+affected_principal_refs AS (
+  SELECT 'identity-' || ai.identity_id::text AS principal_ref
+  FROM affected_identity_ids ai
+  UNION
+  SELECT 'app-asset-' || aa.app_asset_id::text AS principal_ref
+  FROM affected_asset_ids aa
+)
+DELETE FROM non_human_principals nhp
+USING affected_principal_refs apr
+WHERE nhp.principal_ref = apr.principal_ref
+`
+
+type DeleteNonHumanPrincipalPolicyReadModelsBySourceParams struct {
+	SourceKind string `json:"source_kind"`
+	SourceName string `json:"source_name"`
+}
+
+func (q *Queries) DeleteNonHumanPrincipalPolicyReadModelsBySource(ctx context.Context, arg DeleteNonHumanPrincipalPolicyReadModelsBySourceParams) error {
+	_, err := q.db.Exec(ctx, deleteNonHumanPrincipalPolicyReadModelsBySource, arg.SourceKind, arg.SourceName)
 	return err
 }
 
@@ -106,6 +182,111 @@ func (q *Queries) GetSaaSAppRiskInputByID(ctx context.Context, saasAppID int64) 
 		&i.ConnectorBindingHealthy,
 	)
 	return i, err
+}
+
+const listAllNonHumanPrincipalRiskInputs = `-- name: ListAllNonHumanPrincipalRiskInputs :many
+SELECT
+  pr.principal_ref::text AS principal_ref,
+  pr.identity_id::bigint AS identity_id,
+  pr.app_asset_id::bigint AS app_asset_id,
+  pr.principal_type::text AS principal_type,
+  pr.source_kind::text AS source_kind,
+  pr.source_name::text AS source_name,
+  pr.display_name::text AS display_name,
+  pr.secondary_name::text AS secondary_name,
+  pr.secondary_name::text AS primary_email,
+  pr.linked_assets_count::bigint AS linked_assets_count,
+  pr.linked_credentials_count::bigint AS linked_credentials_count,
+  pr.last_seen_at::timestamptz AS last_seen_at,
+  pr.activity_state::text AS activity_state,
+  pr.freshness_state::text AS freshness_state,
+  pr.governance_state::text AS governance_state,
+  pr.accountable_owner_identity_id::bigint AS accountable_owner_identity_id,
+  pr.accountable_owner_display_name::text AS accountable_owner_display_name,
+  pr.accountable_owner_primary_email::text AS accountable_owner_primary_email,
+  pr.owner_presence::text AS owner_presence,
+  pr.has_critical_credential::boolean AS has_critical_credential,
+  pr.has_high_risk_credential::boolean AS has_high_risk_credential,
+  pr.has_expired_credential::boolean AS has_expired_credential,
+  pr.has_expiring_credential::boolean AS has_expiring_credential,
+  pr.has_unused_credential::boolean AS has_unused_credential,
+  pr.has_stale_evidence::boolean AS has_stale_evidence
+FROM non_human_principal_projection_v pr
+ORDER BY pr.principal_ref
+`
+
+type ListAllNonHumanPrincipalRiskInputsRow struct {
+	PrincipalRef                 string             `json:"principal_ref"`
+	IdentityID                   int64              `json:"identity_id"`
+	AppAssetID                   int64              `json:"app_asset_id"`
+	PrincipalType                string             `json:"principal_type"`
+	SourceKind                   string             `json:"source_kind"`
+	SourceName                   string             `json:"source_name"`
+	DisplayName                  string             `json:"display_name"`
+	SecondaryName                string             `json:"secondary_name"`
+	PrimaryEmail                 string             `json:"primary_email"`
+	LinkedAssetsCount            int64              `json:"linked_assets_count"`
+	LinkedCredentialsCount       int64              `json:"linked_credentials_count"`
+	LastSeenAt                   pgtype.Timestamptz `json:"last_seen_at"`
+	ActivityState                string             `json:"activity_state"`
+	FreshnessState               string             `json:"freshness_state"`
+	GovernanceState              string             `json:"governance_state"`
+	AccountableOwnerIdentityID   int64              `json:"accountable_owner_identity_id"`
+	AccountableOwnerDisplayName  string             `json:"accountable_owner_display_name"`
+	AccountableOwnerPrimaryEmail string             `json:"accountable_owner_primary_email"`
+	OwnerPresence                string             `json:"owner_presence"`
+	HasCriticalCredential        bool               `json:"has_critical_credential"`
+	HasHighRiskCredential        bool               `json:"has_high_risk_credential"`
+	HasExpiredCredential         bool               `json:"has_expired_credential"`
+	HasExpiringCredential        bool               `json:"has_expiring_credential"`
+	HasUnusedCredential          bool               `json:"has_unused_credential"`
+	HasStaleEvidence             bool               `json:"has_stale_evidence"`
+}
+
+func (q *Queries) ListAllNonHumanPrincipalRiskInputs(ctx context.Context) ([]ListAllNonHumanPrincipalRiskInputsRow, error) {
+	rows, err := q.db.Query(ctx, listAllNonHumanPrincipalRiskInputs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListAllNonHumanPrincipalRiskInputsRow
+	for rows.Next() {
+		var i ListAllNonHumanPrincipalRiskInputsRow
+		if err := rows.Scan(
+			&i.PrincipalRef,
+			&i.IdentityID,
+			&i.AppAssetID,
+			&i.PrincipalType,
+			&i.SourceKind,
+			&i.SourceName,
+			&i.DisplayName,
+			&i.SecondaryName,
+			&i.PrimaryEmail,
+			&i.LinkedAssetsCount,
+			&i.LinkedCredentialsCount,
+			&i.LastSeenAt,
+			&i.ActivityState,
+			&i.FreshnessState,
+			&i.GovernanceState,
+			&i.AccountableOwnerIdentityID,
+			&i.AccountableOwnerDisplayName,
+			&i.AccountableOwnerPrimaryEmail,
+			&i.OwnerPresence,
+			&i.HasCriticalCredential,
+			&i.HasHighRiskCredential,
+			&i.HasExpiredCredential,
+			&i.HasExpiringCredential,
+			&i.HasUnusedCredential,
+			&i.HasStaleEvidence,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listAllSaaSAppRiskInputs = `-- name: ListAllSaaSAppRiskInputs :many
@@ -251,6 +432,169 @@ func (q *Queries) ListLatestSuccessfulSyncRunsBySource(ctx context.Context) ([]L
 	for rows.Next() {
 		var i ListLatestSuccessfulSyncRunsBySourceRow
 		if err := rows.Scan(&i.SourceKind, &i.SourceName, &i.LastSuccessAt); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listNonHumanPrincipalRiskInputsBySource = `-- name: ListNonHumanPrincipalRiskInputsBySource :many
+WITH requested_source AS (
+  SELECT
+    lower(trim($1::text)) AS source_kind,
+    lower(trim($2::text)) AS source_name
+),
+affected_identity_ids AS (
+  SELECT DISTINCT i.id AS identity_id
+  FROM identities i
+  JOIN identity_accounts ia ON ia.identity_id = i.id
+  JOIN accounts a ON a.id = ia.account_id
+  JOIN requested_source rs
+    ON rs.source_kind <> ''
+   AND rs.source_name <> ''
+   AND lower(trim(a.source_kind)) = rs.source_kind
+   AND lower(trim(a.source_name)) = rs.source_name
+  WHERE i.kind IN ('service', 'bot')
+  UNION
+  SELECT DISTINCT nhp.identity_id
+  FROM non_human_principals nhp
+  JOIN requested_source rs
+    ON rs.source_kind <> ''
+   AND rs.source_name <> ''
+   AND lower(trim(nhp.source_kind)) = rs.source_kind
+   AND lower(trim(nhp.source_name)) = rs.source_name
+  WHERE nhp.identity_id > 0
+),
+affected_asset_ids AS (
+  SELECT DISTINCT aa.id AS app_asset_id
+  FROM app_assets aa
+  JOIN requested_source rs
+    ON rs.source_kind <> ''
+   AND rs.source_name <> ''
+   AND lower(trim(aa.source_kind)) = rs.source_kind
+   AND lower(trim(aa.source_name)) = rs.source_name
+  UNION
+  SELECT DISTINCT nhp.app_asset_id
+  FROM non_human_principals nhp
+  JOIN requested_source rs
+    ON rs.source_kind <> ''
+   AND rs.source_name <> ''
+   AND lower(trim(nhp.source_kind)) = rs.source_kind
+   AND lower(trim(nhp.source_name)) = rs.source_name
+  WHERE nhp.app_asset_id > 0
+),
+affected_principal_refs AS (
+  SELECT 'identity-' || ai.identity_id::text AS principal_ref
+  FROM affected_identity_ids ai
+  UNION
+  SELECT 'app-asset-' || aa.app_asset_id::text AS principal_ref
+  FROM affected_asset_ids aa
+)
+SELECT
+  pr.principal_ref::text AS principal_ref,
+  pr.identity_id::bigint AS identity_id,
+  pr.app_asset_id::bigint AS app_asset_id,
+  pr.principal_type::text AS principal_type,
+  pr.source_kind::text AS source_kind,
+  pr.source_name::text AS source_name,
+  pr.display_name::text AS display_name,
+  pr.secondary_name::text AS secondary_name,
+  pr.secondary_name::text AS primary_email,
+  pr.linked_assets_count::bigint AS linked_assets_count,
+  pr.linked_credentials_count::bigint AS linked_credentials_count,
+  pr.last_seen_at::timestamptz AS last_seen_at,
+  pr.activity_state::text AS activity_state,
+  pr.freshness_state::text AS freshness_state,
+  pr.governance_state::text AS governance_state,
+  pr.accountable_owner_identity_id::bigint AS accountable_owner_identity_id,
+  pr.accountable_owner_display_name::text AS accountable_owner_display_name,
+  pr.accountable_owner_primary_email::text AS accountable_owner_primary_email,
+  pr.owner_presence::text AS owner_presence,
+  pr.has_critical_credential::boolean AS has_critical_credential,
+  pr.has_high_risk_credential::boolean AS has_high_risk_credential,
+  pr.has_expired_credential::boolean AS has_expired_credential,
+  pr.has_expiring_credential::boolean AS has_expiring_credential,
+  pr.has_unused_credential::boolean AS has_unused_credential,
+  pr.has_stale_evidence::boolean AS has_stale_evidence
+FROM non_human_principal_projection_v pr
+JOIN affected_principal_refs apr
+  ON apr.principal_ref = pr.principal_ref
+ORDER BY pr.principal_ref
+`
+
+type ListNonHumanPrincipalRiskInputsBySourceParams struct {
+	SourceKind string `json:"source_kind"`
+	SourceName string `json:"source_name"`
+}
+
+type ListNonHumanPrincipalRiskInputsBySourceRow struct {
+	PrincipalRef                 string             `json:"principal_ref"`
+	IdentityID                   int64              `json:"identity_id"`
+	AppAssetID                   int64              `json:"app_asset_id"`
+	PrincipalType                string             `json:"principal_type"`
+	SourceKind                   string             `json:"source_kind"`
+	SourceName                   string             `json:"source_name"`
+	DisplayName                  string             `json:"display_name"`
+	SecondaryName                string             `json:"secondary_name"`
+	PrimaryEmail                 string             `json:"primary_email"`
+	LinkedAssetsCount            int64              `json:"linked_assets_count"`
+	LinkedCredentialsCount       int64              `json:"linked_credentials_count"`
+	LastSeenAt                   pgtype.Timestamptz `json:"last_seen_at"`
+	ActivityState                string             `json:"activity_state"`
+	FreshnessState               string             `json:"freshness_state"`
+	GovernanceState              string             `json:"governance_state"`
+	AccountableOwnerIdentityID   int64              `json:"accountable_owner_identity_id"`
+	AccountableOwnerDisplayName  string             `json:"accountable_owner_display_name"`
+	AccountableOwnerPrimaryEmail string             `json:"accountable_owner_primary_email"`
+	OwnerPresence                string             `json:"owner_presence"`
+	HasCriticalCredential        bool               `json:"has_critical_credential"`
+	HasHighRiskCredential        bool               `json:"has_high_risk_credential"`
+	HasExpiredCredential         bool               `json:"has_expired_credential"`
+	HasExpiringCredential        bool               `json:"has_expiring_credential"`
+	HasUnusedCredential          bool               `json:"has_unused_credential"`
+	HasStaleEvidence             bool               `json:"has_stale_evidence"`
+}
+
+func (q *Queries) ListNonHumanPrincipalRiskInputsBySource(ctx context.Context, arg ListNonHumanPrincipalRiskInputsBySourceParams) ([]ListNonHumanPrincipalRiskInputsBySourceRow, error) {
+	rows, err := q.db.Query(ctx, listNonHumanPrincipalRiskInputsBySource, arg.SourceKind, arg.SourceName)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListNonHumanPrincipalRiskInputsBySourceRow
+	for rows.Next() {
+		var i ListNonHumanPrincipalRiskInputsBySourceRow
+		if err := rows.Scan(
+			&i.PrincipalRef,
+			&i.IdentityID,
+			&i.AppAssetID,
+			&i.PrincipalType,
+			&i.SourceKind,
+			&i.SourceName,
+			&i.DisplayName,
+			&i.SecondaryName,
+			&i.PrimaryEmail,
+			&i.LinkedAssetsCount,
+			&i.LinkedCredentialsCount,
+			&i.LastSeenAt,
+			&i.ActivityState,
+			&i.FreshnessState,
+			&i.GovernanceState,
+			&i.AccountableOwnerIdentityID,
+			&i.AccountableOwnerDisplayName,
+			&i.AccountableOwnerPrimaryEmail,
+			&i.OwnerPresence,
+			&i.HasCriticalCredential,
+			&i.HasHighRiskCredential,
+			&i.HasExpiredCredential,
+			&i.HasExpiringCredential,
+			&i.HasUnusedCredential,
+			&i.HasStaleEvidence,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -1021,6 +1365,7 @@ SELECT (
     SELECT 1
     FROM non_human_principals nhp
     WHERE nhp.projection_refreshed_at IS NULL
+      OR nhp.policy_packs_json = '[]'::jsonb
   )
   OR (
     NOT EXISTS (
@@ -1102,6 +1447,201 @@ func (q *Queries) UpsertConnectorSourceState(ctx context.Context, arg UpsertConn
 		arg.FreshUntilAt,
 	)
 	return err
+}
+
+const upsertNonHumanPrincipalReadModelsBulk = `-- name: UpsertNonHumanPrincipalReadModelsBulk :execrows
+WITH input AS (
+  SELECT
+    i,
+    ($1::text[])[i] AS principal_ref,
+    ($2::bigint[])[i] AS identity_id,
+    ($3::bigint[])[i] AS app_asset_id,
+    ($4::text[])[i] AS principal_type,
+    ($5::text[])[i] AS source_kind,
+    ($6::text[])[i] AS source_name,
+    ($7::text[])[i] AS display_name,
+    ($8::text[])[i] AS secondary_name,
+    ($9::bigint[])[i] AS linked_assets_count,
+    ($10::bigint[])[i] AS linked_credentials_count,
+    ($11::timestamptz[])[i] AS last_seen_at,
+    ($12::text[])[i] AS activity_state,
+    ($13::text[])[i] AS freshness_state,
+    ($14::text[])[i] AS governance_state,
+    ($15::bigint[])[i] AS accountable_owner_identity_id,
+    ($16::text[])[i] AS accountable_owner_display_name,
+    ($17::text[])[i] AS accountable_owner_primary_email,
+    ($18::text[])[i] AS owner_presence,
+    ($19::boolean[])[i] AS has_critical_credential,
+    ($20::boolean[])[i] AS has_high_risk_credential,
+    ($21::boolean[])[i] AS has_expired_credential,
+    ($22::boolean[])[i] AS has_expiring_credential,
+    ($23::boolean[])[i] AS has_unused_credential,
+    ($24::boolean[])[i] AS has_stale_evidence,
+    ($25::int[])[i] AS risk_reason_count,
+    ($26::text[])[i] AS risk_level,
+    ($27::jsonb[])[i] AS risk_signals_json,
+    ($28::jsonb[])[i] AS policy_packs_json
+  FROM generate_subscripts($1::text[], 1) AS s(i)
+)
+INSERT INTO non_human_principals (
+  principal_ref,
+  identity_id,
+  app_asset_id,
+  principal_type,
+  source_kind,
+  source_name,
+  display_name,
+  secondary_name,
+  linked_assets_count,
+  linked_credentials_count,
+  last_seen_at,
+  activity_state,
+  freshness_state,
+  governance_state,
+  accountable_owner_identity_id,
+  accountable_owner_display_name,
+  accountable_owner_primary_email,
+  owner_presence,
+  has_critical_credential,
+  has_high_risk_credential,
+  has_expired_credential,
+  has_expiring_credential,
+  has_unused_credential,
+  has_stale_evidence,
+  risk_reason_count,
+  risk_level,
+  risk_signals_json,
+  policy_packs_json,
+  projection_refreshed_at
+)
+SELECT
+  input.principal_ref,
+  input.identity_id,
+  input.app_asset_id,
+  input.principal_type,
+  input.source_kind,
+  input.source_name,
+  input.display_name,
+  input.secondary_name,
+  input.linked_assets_count,
+  input.linked_credentials_count,
+  input.last_seen_at,
+  input.activity_state,
+  input.freshness_state,
+  input.governance_state,
+  input.accountable_owner_identity_id,
+  input.accountable_owner_display_name,
+  input.accountable_owner_primary_email,
+  input.owner_presence,
+  input.has_critical_credential,
+  input.has_high_risk_credential,
+  input.has_expired_credential,
+  input.has_expiring_credential,
+  input.has_unused_credential,
+  input.has_stale_evidence,
+  input.risk_reason_count,
+  input.risk_level,
+  input.risk_signals_json,
+  input.policy_packs_json,
+  now()
+FROM input
+ON CONFLICT (principal_ref) DO UPDATE SET
+  identity_id = EXCLUDED.identity_id,
+  app_asset_id = EXCLUDED.app_asset_id,
+  principal_type = EXCLUDED.principal_type,
+  source_kind = EXCLUDED.source_kind,
+  source_name = EXCLUDED.source_name,
+  display_name = EXCLUDED.display_name,
+  secondary_name = EXCLUDED.secondary_name,
+  linked_assets_count = EXCLUDED.linked_assets_count,
+  linked_credentials_count = EXCLUDED.linked_credentials_count,
+  last_seen_at = EXCLUDED.last_seen_at,
+  activity_state = EXCLUDED.activity_state,
+  freshness_state = EXCLUDED.freshness_state,
+  governance_state = EXCLUDED.governance_state,
+  accountable_owner_identity_id = EXCLUDED.accountable_owner_identity_id,
+  accountable_owner_display_name = EXCLUDED.accountable_owner_display_name,
+  accountable_owner_primary_email = EXCLUDED.accountable_owner_primary_email,
+  owner_presence = EXCLUDED.owner_presence,
+  has_critical_credential = EXCLUDED.has_critical_credential,
+  has_high_risk_credential = EXCLUDED.has_high_risk_credential,
+  has_expired_credential = EXCLUDED.has_expired_credential,
+  has_expiring_credential = EXCLUDED.has_expiring_credential,
+  has_unused_credential = EXCLUDED.has_unused_credential,
+  has_stale_evidence = EXCLUDED.has_stale_evidence,
+  risk_reason_count = EXCLUDED.risk_reason_count,
+  risk_level = EXCLUDED.risk_level,
+  risk_signals_json = EXCLUDED.risk_signals_json,
+  policy_packs_json = EXCLUDED.policy_packs_json,
+  projection_refreshed_at = now()
+`
+
+type UpsertNonHumanPrincipalReadModelsBulkParams struct {
+	PrincipalRefs                 []string             `json:"principal_refs"`
+	IdentityIds                   []int64              `json:"identity_ids"`
+	AppAssetIds                   []int64              `json:"app_asset_ids"`
+	PrincipalTypes                []string             `json:"principal_types"`
+	SourceKinds                   []string             `json:"source_kinds"`
+	SourceNames                   []string             `json:"source_names"`
+	DisplayNames                  []string             `json:"display_names"`
+	SecondaryNames                []string             `json:"secondary_names"`
+	LinkedAssetsCounts            []int64              `json:"linked_assets_counts"`
+	LinkedCredentialsCounts       []int64              `json:"linked_credentials_counts"`
+	LastSeenAts                   []pgtype.Timestamptz `json:"last_seen_ats"`
+	ActivityStates                []string             `json:"activity_states"`
+	FreshnessStates               []string             `json:"freshness_states"`
+	GovernanceStates              []string             `json:"governance_states"`
+	AccountableOwnerIdentityIds   []int64              `json:"accountable_owner_identity_ids"`
+	AccountableOwnerDisplayNames  []string             `json:"accountable_owner_display_names"`
+	AccountableOwnerPrimaryEmails []string             `json:"accountable_owner_primary_emails"`
+	OwnerPresences                []string             `json:"owner_presences"`
+	HasCriticalCredentials        []bool               `json:"has_critical_credentials"`
+	HasHighRiskCredentials        []bool               `json:"has_high_risk_credentials"`
+	HasExpiredCredentials         []bool               `json:"has_expired_credentials"`
+	HasExpiringCredentials        []bool               `json:"has_expiring_credentials"`
+	HasUnusedCredentials          []bool               `json:"has_unused_credentials"`
+	HasStaleEvidences             []bool               `json:"has_stale_evidences"`
+	RiskReasonCounts              []int32              `json:"risk_reason_counts"`
+	RiskLevels                    []string             `json:"risk_levels"`
+	RiskSignalsJsons              [][]byte             `json:"risk_signals_jsons"`
+	PolicyPacksJsons              [][]byte             `json:"policy_packs_jsons"`
+}
+
+func (q *Queries) UpsertNonHumanPrincipalReadModelsBulk(ctx context.Context, arg UpsertNonHumanPrincipalReadModelsBulkParams) (int64, error) {
+	result, err := q.db.Exec(ctx, upsertNonHumanPrincipalReadModelsBulk,
+		arg.PrincipalRefs,
+		arg.IdentityIds,
+		arg.AppAssetIds,
+		arg.PrincipalTypes,
+		arg.SourceKinds,
+		arg.SourceNames,
+		arg.DisplayNames,
+		arg.SecondaryNames,
+		arg.LinkedAssetsCounts,
+		arg.LinkedCredentialsCounts,
+		arg.LastSeenAts,
+		arg.ActivityStates,
+		arg.FreshnessStates,
+		arg.GovernanceStates,
+		arg.AccountableOwnerIdentityIds,
+		arg.AccountableOwnerDisplayNames,
+		arg.AccountableOwnerPrimaryEmails,
+		arg.OwnerPresences,
+		arg.HasCriticalCredentials,
+		arg.HasHighRiskCredentials,
+		arg.HasExpiredCredentials,
+		arg.HasExpiringCredentials,
+		arg.HasUnusedCredentials,
+		arg.HasStaleEvidences,
+		arg.RiskReasonCounts,
+		arg.RiskLevels,
+		arg.RiskSignalsJsons,
+		arg.PolicyPacksJsons,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const upsertSaaSAppRiskReadModelsBulk = `-- name: UpsertSaaSAppRiskReadModelsBulk :execrows

--- a/internal/db/gen/read_models.sql.go
+++ b/internal/db/gen/read_models.sql.go
@@ -11,6 +11,15 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const deleteAllCredentialArtifactRiskReadModels = `-- name: DeleteAllCredentialArtifactRiskReadModels :exec
+DELETE FROM credential_artifact_risk_read_models
+`
+
+func (q *Queries) DeleteAllCredentialArtifactRiskReadModels(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, deleteAllCredentialArtifactRiskReadModels)
+	return err
+}
+
 const deleteAllNonHumanPrincipalReadModels = `-- name: DeleteAllNonHumanPrincipalReadModels :exec
 DELETE FROM non_human_principals
 `
@@ -26,6 +35,24 @@ DELETE FROM connector_source_state
 
 func (q *Queries) DeleteConnectorSourceStateAll(ctx context.Context) error {
 	_, err := q.db.Exec(ctx, deleteConnectorSourceStateAll)
+	return err
+}
+
+const deleteCredentialArtifactRiskReadModelsBySource = `-- name: DeleteCredentialArtifactRiskReadModelsBySource :exec
+DELETE FROM credential_artifact_risk_read_models risk
+USING credential_artifacts ca
+WHERE risk.credential_artifact_id = ca.id
+  AND lower(trim(ca.source_kind)) = lower(trim($1::text))
+  AND lower(trim(ca.source_name)) = lower(trim($2::text))
+`
+
+type DeleteCredentialArtifactRiskReadModelsBySourceParams struct {
+	SourceKind string `json:"source_kind"`
+	SourceName string `json:"source_name"`
+}
+
+func (q *Queries) DeleteCredentialArtifactRiskReadModelsBySource(ctx context.Context, arg DeleteCredentialArtifactRiskReadModelsBySourceParams) error {
+	_, err := q.db.Exec(ctx, deleteCredentialArtifactRiskReadModelsBySource, arg.SourceKind, arg.SourceName)
 	return err
 }
 
@@ -182,6 +209,83 @@ func (q *Queries) GetSaaSAppRiskInputByID(ctx context.Context, saasAppID int64) 
 		&i.ConnectorBindingHealthy,
 	)
 	return i, err
+}
+
+const listAllCredentialArtifactRiskInputs = `-- name: ListAllCredentialArtifactRiskInputs :many
+SELECT
+  ca.id::bigint AS credential_artifact_id,
+  ca.source_kind::text AS source_kind,
+  ca.source_name::text AS source_name,
+  ca.credential_kind::text AS credential_kind,
+  ca.status::text AS status,
+  ca.expires_at_source::timestamptz AS expires_at_source,
+  ca.last_used_at_source::timestamptz AS last_used_at_source,
+  ca.created_at_source::timestamptz AS created_at_source,
+  ca.created_by_external_id::text AS created_by_external_id,
+  ca.created_by_display_name::text AS created_by_display_name,
+  ca.approved_by_external_id::text AS approved_by_external_id,
+  ca.approved_by_display_name::text AS approved_by_display_name,
+  ca.asset_ref_kind::text AS asset_ref_kind,
+  ca.asset_ref_external_id::text AS asset_ref_external_id,
+  ca.scope_json::jsonb AS scope_json
+FROM credential_artifacts ca
+WHERE ca.expired_at IS NULL
+  AND ca.last_observed_run_id IS NOT NULL
+ORDER BY ca.id ASC
+`
+
+type ListAllCredentialArtifactRiskInputsRow struct {
+	CredentialArtifactID  int64              `json:"credential_artifact_id"`
+	SourceKind            string             `json:"source_kind"`
+	SourceName            string             `json:"source_name"`
+	CredentialKind        string             `json:"credential_kind"`
+	Status                string             `json:"status"`
+	ExpiresAtSource       pgtype.Timestamptz `json:"expires_at_source"`
+	LastUsedAtSource      pgtype.Timestamptz `json:"last_used_at_source"`
+	CreatedAtSource       pgtype.Timestamptz `json:"created_at_source"`
+	CreatedByExternalID   string             `json:"created_by_external_id"`
+	CreatedByDisplayName  string             `json:"created_by_display_name"`
+	ApprovedByExternalID  string             `json:"approved_by_external_id"`
+	ApprovedByDisplayName string             `json:"approved_by_display_name"`
+	AssetRefKind          string             `json:"asset_ref_kind"`
+	AssetRefExternalID    string             `json:"asset_ref_external_id"`
+	ScopeJson             []byte             `json:"scope_json"`
+}
+
+func (q *Queries) ListAllCredentialArtifactRiskInputs(ctx context.Context) ([]ListAllCredentialArtifactRiskInputsRow, error) {
+	rows, err := q.db.Query(ctx, listAllCredentialArtifactRiskInputs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListAllCredentialArtifactRiskInputsRow
+	for rows.Next() {
+		var i ListAllCredentialArtifactRiskInputsRow
+		if err := rows.Scan(
+			&i.CredentialArtifactID,
+			&i.SourceKind,
+			&i.SourceName,
+			&i.CredentialKind,
+			&i.Status,
+			&i.ExpiresAtSource,
+			&i.LastUsedAtSource,
+			&i.CreatedAtSource,
+			&i.CreatedByExternalID,
+			&i.CreatedByDisplayName,
+			&i.ApprovedByExternalID,
+			&i.ApprovedByDisplayName,
+			&i.AssetRefKind,
+			&i.AssetRefExternalID,
+			&i.ScopeJson,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listAllNonHumanPrincipalRiskInputs = `-- name: ListAllNonHumanPrincipalRiskInputs :many
@@ -379,6 +483,90 @@ func (q *Queries) ListAllSaaSAppRiskInputs(ctx context.Context) ([]ListAllSaaSAp
 			&i.ConnectorBindingEnabled,
 			&i.ConnectorBindingStale,
 			&i.ConnectorBindingHealthy,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listCredentialArtifactRiskInputsBySource = `-- name: ListCredentialArtifactRiskInputsBySource :many
+SELECT
+  ca.id::bigint AS credential_artifact_id,
+  ca.source_kind::text AS source_kind,
+  ca.source_name::text AS source_name,
+  ca.credential_kind::text AS credential_kind,
+  ca.status::text AS status,
+  ca.expires_at_source::timestamptz AS expires_at_source,
+  ca.last_used_at_source::timestamptz AS last_used_at_source,
+  ca.created_at_source::timestamptz AS created_at_source,
+  ca.created_by_external_id::text AS created_by_external_id,
+  ca.created_by_display_name::text AS created_by_display_name,
+  ca.approved_by_external_id::text AS approved_by_external_id,
+  ca.approved_by_display_name::text AS approved_by_display_name,
+  ca.asset_ref_kind::text AS asset_ref_kind,
+  ca.asset_ref_external_id::text AS asset_ref_external_id,
+  ca.scope_json::jsonb AS scope_json
+FROM credential_artifacts ca
+WHERE ca.expired_at IS NULL
+  AND ca.last_observed_run_id IS NOT NULL
+  AND lower(trim(ca.source_kind)) = lower(trim($1::text))
+  AND lower(trim(ca.source_name)) = lower(trim($2::text))
+ORDER BY ca.id ASC
+`
+
+type ListCredentialArtifactRiskInputsBySourceParams struct {
+	SourceKind string `json:"source_kind"`
+	SourceName string `json:"source_name"`
+}
+
+type ListCredentialArtifactRiskInputsBySourceRow struct {
+	CredentialArtifactID  int64              `json:"credential_artifact_id"`
+	SourceKind            string             `json:"source_kind"`
+	SourceName            string             `json:"source_name"`
+	CredentialKind        string             `json:"credential_kind"`
+	Status                string             `json:"status"`
+	ExpiresAtSource       pgtype.Timestamptz `json:"expires_at_source"`
+	LastUsedAtSource      pgtype.Timestamptz `json:"last_used_at_source"`
+	CreatedAtSource       pgtype.Timestamptz `json:"created_at_source"`
+	CreatedByExternalID   string             `json:"created_by_external_id"`
+	CreatedByDisplayName  string             `json:"created_by_display_name"`
+	ApprovedByExternalID  string             `json:"approved_by_external_id"`
+	ApprovedByDisplayName string             `json:"approved_by_display_name"`
+	AssetRefKind          string             `json:"asset_ref_kind"`
+	AssetRefExternalID    string             `json:"asset_ref_external_id"`
+	ScopeJson             []byte             `json:"scope_json"`
+}
+
+func (q *Queries) ListCredentialArtifactRiskInputsBySource(ctx context.Context, arg ListCredentialArtifactRiskInputsBySourceParams) ([]ListCredentialArtifactRiskInputsBySourceRow, error) {
+	rows, err := q.db.Query(ctx, listCredentialArtifactRiskInputsBySource, arg.SourceKind, arg.SourceName)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListCredentialArtifactRiskInputsBySourceRow
+	for rows.Next() {
+		var i ListCredentialArtifactRiskInputsBySourceRow
+		if err := rows.Scan(
+			&i.CredentialArtifactID,
+			&i.SourceKind,
+			&i.SourceName,
+			&i.CredentialKind,
+			&i.Status,
+			&i.ExpiresAtSource,
+			&i.LastUsedAtSource,
+			&i.CreatedAtSource,
+			&i.CreatedByExternalID,
+			&i.CreatedByDisplayName,
+			&i.ApprovedByExternalID,
+			&i.ApprovedByDisplayName,
+			&i.AssetRefKind,
+			&i.AssetRefExternalID,
+			&i.ScopeJson,
 		); err != nil {
 			return nil, err
 		}
@@ -1363,6 +1551,18 @@ SELECT (
   )
   OR EXISTS (
     SELECT 1
+    FROM credential_artifacts ca
+    LEFT JOIN credential_artifact_risk_read_models risk
+      ON risk.credential_artifact_id = ca.id
+    WHERE ca.expired_at IS NULL
+      AND ca.last_observed_run_id IS NOT NULL
+      AND (
+        risk.credential_artifact_id IS NULL
+        OR risk.policy_packs_json = '[]'::jsonb
+      )
+  )
+  OR EXISTS (
+    SELECT 1
     FROM non_human_principals nhp
     WHERE nhp.projection_refreshed_at IS NULL
       OR nhp.policy_packs_json = '[]'::jsonb
@@ -1447,6 +1647,63 @@ func (q *Queries) UpsertConnectorSourceState(ctx context.Context, arg UpsertConn
 		arg.FreshUntilAt,
 	)
 	return err
+}
+
+const upsertCredentialArtifactRiskReadModelsBulk = `-- name: UpsertCredentialArtifactRiskReadModelsBulk :execrows
+WITH input AS (
+  SELECT
+    i,
+    ($1::bigint[])[i] AS credential_artifact_id,
+    ($2::text[])[i] AS risk_level,
+    ($3::int[])[i] AS risk_rank,
+    ($4::jsonb[])[i] AS risk_signals_json,
+    ($5::jsonb[])[i] AS policy_packs_json
+  FROM generate_subscripts($1::bigint[], 1) AS s(i)
+)
+INSERT INTO credential_artifact_risk_read_models (
+  credential_artifact_id,
+  risk_level,
+  risk_rank,
+  risk_signals_json,
+  policy_packs_json,
+  projection_refreshed_at
+)
+SELECT
+  input.credential_artifact_id,
+  input.risk_level,
+  input.risk_rank,
+  input.risk_signals_json,
+  input.policy_packs_json,
+  now()
+FROM input
+ON CONFLICT (credential_artifact_id) DO UPDATE SET
+  risk_level = EXCLUDED.risk_level,
+  risk_rank = EXCLUDED.risk_rank,
+  risk_signals_json = EXCLUDED.risk_signals_json,
+  policy_packs_json = EXCLUDED.policy_packs_json,
+  projection_refreshed_at = now()
+`
+
+type UpsertCredentialArtifactRiskReadModelsBulkParams struct {
+	CredentialArtifactIds []int64  `json:"credential_artifact_ids"`
+	RiskLevels            []string `json:"risk_levels"`
+	RiskRanks             []int32  `json:"risk_ranks"`
+	RiskSignalsJsons      [][]byte `json:"risk_signals_jsons"`
+	PolicyPacksJsons      [][]byte `json:"policy_packs_jsons"`
+}
+
+func (q *Queries) UpsertCredentialArtifactRiskReadModelsBulk(ctx context.Context, arg UpsertCredentialArtifactRiskReadModelsBulkParams) (int64, error) {
+	result, err := q.db.Exec(ctx, upsertCredentialArtifactRiskReadModelsBulk,
+		arg.CredentialArtifactIds,
+		arg.RiskLevels,
+		arg.RiskRanks,
+		arg.RiskSignalsJsons,
+		arg.PolicyPacksJsons,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const upsertNonHumanPrincipalReadModelsBulk = `-- name: UpsertNonHumanPrincipalReadModelsBulk :execrows

--- a/internal/http/handlers/connected_apps.go
+++ b/internal/http/handlers/connected_apps.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -195,7 +194,6 @@ func (h *Handlers) HandleAppAssetExport(c *echo.Context) error {
 	}
 
 	ctx := c.Request().Context()
-	now := time.Now().UTC()
 	summary, err := h.Q.GetAppAssetPostureByID(ctx, appID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -213,7 +211,6 @@ func (h *Handlers) HandleAppAssetExport(c *echo.Context) error {
 	}
 
 	grants, err := h.Q.ListCredentialArtifactsForAssetRef(ctx, gen.ListCredentialArtifactsForAssetRefParams{
-		EvaluatedAt:        pgTimestamptz(now),
 		SourceKind:         strings.TrimSpace(summary.SourceKind),
 		SourceName:         strings.TrimSpace(summary.SourceName),
 		AssetRefKind:       strings.TrimSpace(summary.AssetKind),
@@ -310,7 +307,6 @@ func (h *Handlers) HandleAppAssetGrantRevoke(c *echo.Context) error {
 	}
 
 	ctx := c.Request().Context()
-	now := time.Now().UTC()
 	summary, err := h.Q.GetAppAssetPostureByID(ctx, appID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -322,7 +318,7 @@ func (h *Handlers) HandleAppAssetGrantRevoke(c *echo.Context) error {
 		return RenderNotFound(c)
 	}
 
-	credential, err := h.Q.GetCredentialArtifactByID(ctx, gen.GetCredentialArtifactByIDParams{EvaluatedAt: pgTimestamptz(now), ID: credentialID})
+	credential, err := h.Q.GetCredentialArtifactByID(ctx, credentialID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return RenderNotFound(c)
@@ -535,7 +531,6 @@ func (h *Handlers) buildConnectedAppsViewData(ctx context.Context, layout viewmo
 func (h *Handlers) buildConnectedAppShowViewData(ctx context.Context, layout viewmodels.LayoutData, appID int64, opts connectedAppShowOptions) (viewmodels.ConnectedAppShowViewData, error) {
 	data := viewmodels.ConnectedAppShowViewData{}
 
-	now := time.Now().UTC()
 	summary, err := h.Q.GetAppAssetPostureByID(ctx, appID)
 	if err != nil {
 		return data, err
@@ -569,7 +564,6 @@ func (h *Handlers) buildConnectedAppShowViewData(ctx context.Context, layout vie
 	}
 
 	grantRows, err := h.Q.ListCredentialArtifactsForAssetRef(ctx, gen.ListCredentialArtifactsForAssetRefParams{
-		EvaluatedAt:        pgTimestamptz(now),
 		SourceKind:         strings.TrimSpace(summary.SourceKind),
 		SourceName:         strings.TrimSpace(summary.SourceName),
 		AssetRefKind:       strings.TrimSpace(summary.AssetKind),

--- a/internal/http/handlers/non_human_access.go
+++ b/internal/http/handlers/non_human_access.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"errors"
 	"net/url"
 	"strings"
@@ -373,63 +374,25 @@ func nonHumanAccountableOwnerLabel(ownerDisplayName, ownerPrimaryEmail, ownerPre
 }
 
 func nonHumanPrincipalRiskSignals(principal gen.NonHumanPrincipalReadModelsV) []viewmodels.NonHumanAccessRiskSignal {
-	signals := make([]viewmodels.NonHumanAccessRiskSignal, 0, 8)
-	if strings.TrimSpace(principal.OwnerPresence) == "unknown" {
-		signals = append(signals, viewmodels.NonHumanAccessRiskSignal{
-			Severity: "high",
-			Title:    "No accountable owner",
-			Evidence: "No accountable owner is assigned.",
+	if len(principal.RiskSignalsJson) == 0 {
+		return nil
+	}
+	var signals []viewmodels.NonHumanAccessRiskSignal
+	if err := json.Unmarshal(principal.RiskSignalsJson, &signals); err != nil {
+		return nil
+	}
+	filtered := signals[:0]
+	for _, signal := range signals {
+		if strings.TrimSpace(signal.Title) == "" {
+			continue
+		}
+		filtered = append(filtered, viewmodels.NonHumanAccessRiskSignal{
+			Severity: strings.TrimSpace(signal.Severity),
+			Title:    strings.TrimSpace(signal.Title),
+			Evidence: strings.TrimSpace(signal.Evidence),
 		})
 	}
-	if principal.HasCriticalCredential {
-		signals = append(signals, viewmodels.NonHumanAccessRiskSignal{
-			Severity: "critical",
-			Title:    "Linked credential is critical",
-			Evidence: "At least one linked credential is critical.",
-		})
-	} else if principal.HasHighRiskCredential {
-		signals = append(signals, viewmodels.NonHumanAccessRiskSignal{
-			Severity: "high",
-			Title:    "Linked credential is high risk",
-			Evidence: "At least one linked credential is high risk.",
-		})
-	}
-	if principal.HasExpiredCredential {
-		signals = append(signals, viewmodels.NonHumanAccessRiskSignal{
-			Severity: "high",
-			Title:    "Credential expired",
-			Evidence: "A linked credential is expired.",
-		})
-	}
-	if principal.HasExpiringCredential {
-		signals = append(signals, viewmodels.NonHumanAccessRiskSignal{
-			Severity: "medium",
-			Title:    "Credential expiring soon",
-			Evidence: "A linked credential expires within 30 days.",
-		})
-	}
-	if principal.HasUnusedCredential {
-		signals = append(signals, viewmodels.NonHumanAccessRiskSignal{
-			Severity: "medium",
-			Title:    "Credential unused",
-			Evidence: "A linked credential has been unused for over 90 days.",
-		})
-	}
-	if principal.HasStaleEvidence {
-		signals = append(signals, viewmodels.NonHumanAccessRiskSignal{
-			Severity: "medium",
-			Title:    "Source freshness is stale",
-			Evidence: "Supporting evidence or source freshness is stale.",
-		})
-	}
-	if strings.TrimSpace(principal.GovernanceState) == "unreviewed" && len(signals) > 0 {
-		signals = append(signals, viewmodels.NonHumanAccessRiskSignal{
-			Severity: "medium",
-			Title:    "Governance still unreviewed",
-			Evidence: "Risk signals are present while governance is still unreviewed.",
-		})
-	}
-	return signals
+	return filtered
 }
 
 func nonHumanBestAvailableAttribution(linkResolver *identityLinkResolver, rows []gen.ListNonHumanPrincipalCredentialsByRefRow) (string, string) {

--- a/internal/http/handlers/non_human_access.go
+++ b/internal/http/handlers/non_human_access.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/url"
 	"strings"
 
@@ -379,9 +380,10 @@ func nonHumanPrincipalRiskSignals(principal gen.NonHumanPrincipalReadModelsV) []
 	}
 	var signals []viewmodels.NonHumanAccessRiskSignal
 	if err := json.Unmarshal(principal.RiskSignalsJson, &signals); err != nil {
+		slog.Warn("failed to decode non-human principal risk signals", "principal_ref", principal.PrincipalRef, "error", err)
 		return nil
 	}
-	filtered := signals[:0]
+	filtered := make([]viewmodels.NonHumanAccessRiskSignal, 0, len(signals))
 	for _, signal := range signals {
 		if strings.TrimSpace(signal.Title) == "" {
 			continue

--- a/internal/http/handlers/non_human_access_test.go
+++ b/internal/http/handlers/non_human_access_test.go
@@ -1,0 +1,61 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/open-sspm/open-sspm/internal/db/gen"
+)
+
+func TestNonHumanPrincipalRiskSignalsUsesStoredPolicySignals(t *testing.T) {
+	t.Parallel()
+
+	signals := nonHumanPrincipalRiskSignals(gen.NonHumanPrincipalReadModelsV{
+		OwnerPresence:         "unknown",
+		HasCriticalCredential: true,
+		RiskSignalsJson: []byte(`[
+			{
+				"id": "missing_accountable_owner",
+				"domain": "identity",
+				"severity": "high",
+				"title": "No accountable owner",
+				"evidence": "No accountable owner is assigned."
+			}
+		]`),
+	})
+	if len(signals) != 1 {
+		t.Fatalf("len(signals) = %d, want 1; signals=%+v", len(signals), signals)
+	}
+	if signals[0].Severity != "high" || signals[0].Title != "No accountable owner" {
+		t.Fatalf("signals[0] = %+v, want stored policy signal", signals[0])
+	}
+}
+
+func TestNonHumanPrincipalRiskSignalsEmptyOrInvalidJSONIsSafe(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		principal gen.NonHumanPrincipalReadModelsV
+	}{
+		{
+			name: "empty",
+			principal: gen.NonHumanPrincipalReadModelsV{
+				OwnerPresence: "unknown",
+			},
+		},
+		{
+			name: "invalid",
+			principal: gen.NonHumanPrincipalReadModelsV{
+				RiskSignalsJson: []byte(`{"not":`),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if signals := nonHumanPrincipalRiskSignals(tc.principal); len(signals) != 0 {
+				t.Fatalf("len(signals) = %d, want 0; signals=%+v", len(signals), signals)
+			}
+		})
+	}
+}

--- a/internal/http/handlers/programmatic_access.go
+++ b/internal/http/handlers/programmatic_access.go
@@ -254,7 +254,6 @@ func (h *Handlers) HandleAppAssetShow(c *echo.Context) error {
 		return h.RenderError(c, err)
 	}
 
-	now := time.Now().UTC()
 	linkResolver := newIdentityLinkResolver(h, ctx)
 
 	ownerItems := make([]viewmodels.AppAssetOwnerItem, 0, len(owners))
@@ -275,7 +274,7 @@ func (h *Handlers) HandleAppAssetShow(c *echo.Context) error {
 		})
 	}
 
-	credentialRows, err := h.listCredentialArtifactsForAsset(ctx, asset, pgTimestamptz(now))
+	credentialRows, err := h.listCredentialArtifactsForAsset(ctx, asset)
 	if err != nil {
 		return h.RenderError(c, err)
 	}
@@ -576,10 +575,7 @@ func (h *Handlers) HandleCredentialShow(c *echo.Context) error {
 
 	ctx := c.Request().Context()
 	now := time.Now().UTC()
-	credential, err := h.Q.GetCredentialArtifactByID(ctx, gen.GetCredentialArtifactByIDParams{
-		EvaluatedAt: pgTimestamptz(now),
-		ID:          credentialID,
-	})
+	credential, err := h.Q.GetCredentialArtifactByID(ctx, credentialID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return RenderNotFound(c)
@@ -620,12 +616,8 @@ func (h *Handlers) HandleCredentialShow(c *echo.Context) error {
 	if displayName == "" {
 		displayName = strings.TrimSpace(credential.ExternalID)
 	}
-	credentialRisk, err := h.evaluateCredentialRisk(credential, now)
-	if err != nil {
-		return h.RenderError(c, err)
-	}
-	riskLevel := credentialRisk.RiskLevel
-	riskFindings := credentialRiskFindingsFromSignals(credentialRisk.Signals, credential.ExpiresAtSource, credential.LastUsedAtSource, now)
+	riskLevel := strings.TrimSpace(credential.RiskLevel)
+	riskFindings := credentialRiskFindingsFromSignals(credentialRiskSignalsFromStoredJSON(credential.RiskSignalsJson), credential.ExpiresAtSource, credential.LastUsedAtSource, now)
 	linkResolver := newIdentityLinkResolver(h, ctx)
 
 	data := viewmodels.CredentialShowViewData{
@@ -796,46 +788,6 @@ func pgTimestamptz(ts time.Time) pgtype.Timestamptz {
 	return pgtype.Timestamptz{Time: ts.UTC(), Valid: true}
 }
 
-func (h *Handlers) evaluateCredentialRisk(credential gen.GetCredentialArtifactByIDRow, now time.Time) (riskpolicy.CredentialResult, error) {
-	registry := h.RiskPolicies
-	if registry == nil {
-		var err error
-		registry, err = riskpolicy.BuiltinRegistry()
-		if err != nil {
-			return riskpolicy.CredentialResult{}, err
-		}
-	}
-	return registry.EvaluateCredential(credentialPolicyInput(credential, now))
-}
-
-func credentialPolicyInput(credential gen.GetCredentialArtifactByIDRow, now time.Time) riskpolicy.CredentialInput {
-	return riskpolicy.CredentialInput{
-		SourceKind:            credential.SourceKind,
-		SourceName:            credential.SourceName,
-		CredentialKind:        credential.CredentialKind,
-		Status:                credential.Status,
-		ExpiresAt:             timestamptzTimePtr(credential.ExpiresAtSource),
-		LastUsedAt:            timestamptzTimePtr(credential.LastUsedAtSource),
-		CreatedAt:             timestamptzTimePtr(credential.CreatedAtSource),
-		CreatedByExternalID:   credential.CreatedByExternalID,
-		CreatedByDisplayName:  credential.CreatedByDisplayName,
-		ApprovedByExternalID:  credential.ApprovedByExternalID,
-		ApprovedByDisplayName: credential.ApprovedByDisplayName,
-		AssetRefKind:          credential.AssetRefKind,
-		AssetRefExternalID:    credential.AssetRefExternalID,
-		ScopeJSON:             credential.ScopeJson,
-		EvaluatedAt:           now,
-	}
-}
-
-func timestamptzTimePtr(value pgtype.Timestamptz) *time.Time {
-	if !value.Valid {
-		return nil
-	}
-	t := value.Time.UTC()
-	return &t
-}
-
 func credentialRiskFindingsFromSignals(signals []riskpolicy.RiskSignal, expiresAt, lastUsedAt pgtype.Timestamptz, now time.Time) []viewmodels.CredentialRiskFinding {
 	findings := make([]viewmodels.CredentialRiskFinding, 0, len(signals))
 	for _, signal := range signals {
@@ -846,6 +798,27 @@ func credentialRiskFindingsFromSignals(signals []riskpolicy.RiskSignal, expiresA
 		})
 	}
 	return findings
+}
+
+func credentialRiskSignalsFromStoredJSON(raw []byte) []riskpolicy.RiskSignal {
+	if len(raw) == 0 {
+		return nil
+	}
+	var signals []riskpolicy.RiskSignal
+	if err := json.Unmarshal(raw, &signals); err != nil {
+		return nil
+	}
+	out := make([]riskpolicy.RiskSignal, 0, len(signals))
+	for _, signal := range signals {
+		signal.Severity = strings.TrimSpace(signal.Severity)
+		signal.Title = strings.TrimSpace(signal.Title)
+		signal.Evidence = strings.TrimSpace(signal.Evidence)
+		if signal.Severity == "" || signal.Title == "" {
+			continue
+		}
+		out = append(out, signal)
+	}
+	return out
 }
 
 func credentialSignalEvidence(signal riskpolicy.RiskSignal, expiresAt, lastUsedAt pgtype.Timestamptz, now time.Time) string {
@@ -1083,7 +1056,7 @@ func appAssetRefExternalID(assetKind, externalID string) string {
 	return assetKind + ":" + externalID
 }
 
-func (h *Handlers) listCredentialArtifactsForAsset(ctx context.Context, asset gen.AppAsset, evaluatedAt pgtype.Timestamptz) ([]gen.ListCredentialArtifactsForAssetRefRow, error) {
+func (h *Handlers) listCredentialArtifactsForAsset(ctx context.Context, asset gen.AppAsset) ([]gen.ListCredentialArtifactsForAssetRefRow, error) {
 	refs := appAssetCredentialRefs(asset)
 	if len(refs) == 0 {
 		return nil, nil
@@ -1091,7 +1064,6 @@ func (h *Handlers) listCredentialArtifactsForAsset(ctx context.Context, asset ge
 
 	credentialsByID := map[int64]gen.ListCredentialArtifactsForAssetRefRow{}
 	for _, ref := range refs {
-		ref.EvaluatedAt = evaluatedAt
 		rows, err := h.Q.ListCredentialArtifactsForAssetRef(ctx, ref)
 		if err != nil {
 			return nil, err

--- a/internal/http/handlers/programmatic_access_test.go
+++ b/internal/http/handlers/programmatic_access_test.go
@@ -43,18 +43,14 @@ func TestCredentialRiskReasons(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 2, 7, 12, 0, 0, 0, time.UTC)
-	credential := gen.GetCredentialArtifactByIDRow{
-		Status:           "active",
-		CredentialKind:   "github_pat_fine_grained",
-		ExpiresAtSource:  timestamptz(now.Add(2 * 24 * time.Hour)),
-		LastUsedAtSource: timestamptz(now.Add(-120 * 24 * time.Hour)),
-	}
-
-	result, err := (&Handlers{}).evaluateCredentialRisk(credential, now)
-	if err != nil {
-		t.Fatalf("evaluateCredentialRisk() error = %v", err)
-	}
-	findings := credentialRiskFindingsFromSignals(result.Signals, credential.ExpiresAtSource, credential.LastUsedAtSource, now)
+	expiresAt := timestamptz(now.Add(2 * 24 * time.Hour))
+	lastUsedAt := timestamptz(now.Add(-120 * 24 * time.Hour))
+	signals := credentialRiskSignalsFromStoredJSON([]byte(`[
+		{"id":"expiring_within_7_days","severity":"high","title":"Credential expires within 7 days"},
+		{"id":"unused_over_90_days","severity":"high","title":"Credential has not been used in over 90 days"},
+		{"id":"missing_creator","severity":"high","title":"Creator attribution is missing"}
+	]`))
+	findings := credentialRiskFindingsFromSignals(signals, expiresAt, lastUsedAt, now)
 	if len(findings) < 3 {
 		t.Fatalf("expected multiple findings, got %v", findings)
 	}
@@ -70,18 +66,11 @@ func TestCredentialRiskReasonsUseFutureAwareExpiryLabel(t *testing.T) {
 
 	now := time.Date(2026, 2, 7, 12, 0, 0, 0, time.UTC)
 
-	credential := gen.GetCredentialArtifactByIDRow{
-		Status:              "active",
-		CredentialKind:      "entra_client_secret",
-		CreatedByExternalID: "owner@example.com",
-		ExpiresAtSource:     timestamptz(now.Add(4 * 24 * time.Hour)),
-	}
-
-	result, err := (&Handlers{}).evaluateCredentialRisk(credential, now)
-	if err != nil {
-		t.Fatalf("evaluateCredentialRisk() error = %v", err)
-	}
-	findings := credentialRiskFindingsFromSignals(result.Signals, credential.ExpiresAtSource, credential.LastUsedAtSource, now)
+	expiresAt := timestamptz(now.Add(4 * 24 * time.Hour))
+	signals := credentialRiskSignalsFromStoredJSON([]byte(`[
+		{"id":"expiring_within_7_days","severity":"high","title":"Credential expires within 7 days"}
+	]`))
+	findings := credentialRiskFindingsFromSignals(signals, expiresAt, pgtype.Timestamptz{}, now)
 
 	for _, finding := range findings {
 		if finding.Title == "Credential expires within 7 days" {

--- a/internal/readmodels/projector.go
+++ b/internal/readmodels/projector.go
@@ -106,6 +106,12 @@ func (p *Projector) RefreshNonHumanPrincipalSourceReadModels(ctx context.Context
 	})
 }
 
+func (p *Projector) RefreshAllNonHumanPrincipalReadModels(ctx context.Context) error {
+	return p.withQueries(ctx, func(q *gen.Queries) error {
+		return refreshAllNonHumanPrincipalReadModels(ctx, q)
+	})
+}
+
 func (p *Projector) StoredReadModelsNeedRebuild(ctx context.Context) (bool, error) {
 	if p == nil || p.q == nil {
 		return false, nil
@@ -127,8 +133,7 @@ func (p *Projector) RebuildAllReadModels(ctx context.Context) error {
 		if err := refreshAllSaaSAppRiskReadModels(ctx, q); err != nil {
 			return err
 		}
-		_, err := q.RefreshAllNonHumanPrincipalReadModelsSafely(ctx)
-		return err
+		return refreshAllNonHumanPrincipalReadModels(ctx, q)
 	})
 }
 
@@ -249,6 +254,34 @@ type saasAppRiskInputRow struct {
 	connectorBindingEnabled       bool
 	connectorBindingStale         bool
 	connectorBindingHealthy       bool
+}
+
+type nonHumanPrincipalRiskInputRow struct {
+	principalRef                 string
+	identityID                   int64
+	appAssetID                   int64
+	principalType                string
+	sourceKind                   string
+	sourceName                   string
+	displayName                  string
+	secondaryName                string
+	primaryEmail                 string
+	linkedAssetsCount            int64
+	linkedCredentialsCount       int64
+	lastSeenAt                   pgtype.Timestamptz
+	activityState                string
+	freshnessState               string
+	governanceState              string
+	accountableOwnerIdentityID   int64
+	accountableOwnerDisplayName  string
+	accountableOwnerPrimaryEmail string
+	ownerPresence                string
+	hasCriticalCredential        bool
+	hasHighRiskCredential        bool
+	hasExpiredCredential         bool
+	hasExpiringCredential        bool
+	hasUnusedCredential          bool
+	hasStaleEvidence             bool
 }
 
 func refreshAllSaaSAppRiskReadModels(ctx context.Context, q *gen.Queries) error {
@@ -445,6 +478,14 @@ func datePtr(value pgtype.Date) *time.Time {
 	return &t
 }
 
+func timestamptzPtr(value pgtype.Timestamptz) *time.Time {
+	if !value.Valid {
+		return nil
+	}
+	t := value.Time.UTC()
+	return &t
+}
+
 func refreshAppAssetSource(ctx context.Context, q *gen.Queries, sourceKind, sourceName string) error {
 	sourceKind = normalizeSourceKind(sourceKind)
 	sourceName = strings.TrimSpace(sourceName)
@@ -464,11 +505,207 @@ func refreshNonHumanPrincipalSource(ctx context.Context, q *gen.Queries, sourceK
 	if sourceKind == "" || sourceName == "" {
 		return nil
 	}
-	_, err := q.RefreshNonHumanPrincipalReadModelsBySourceSafely(ctx, gen.RefreshNonHumanPrincipalReadModelsBySourceParams{
+	arg := gen.ListNonHumanPrincipalRiskInputsBySourceParams{
 		SourceKind: sourceKind,
 		SourceName: sourceName,
-	})
+	}
+	rows, err := q.ListNonHumanPrincipalRiskInputsBySource(ctx, arg)
+	if err != nil {
+		return err
+	}
+	inputs := make([]nonHumanPrincipalRiskInputRow, 0, len(rows))
+	for _, row := range rows {
+		inputs = append(inputs, nonHumanPrincipalRiskInputRowFromSourceRow(row))
+	}
+	if err := q.DeleteNonHumanPrincipalPolicyReadModelsBySource(ctx, gen.DeleteNonHumanPrincipalPolicyReadModelsBySourceParams(arg)); err != nil {
+		return err
+	}
+	return refreshNonHumanPrincipalReadModels(ctx, q, inputs)
+}
+
+func refreshAllNonHumanPrincipalReadModels(ctx context.Context, q *gen.Queries) error {
+	rows, err := q.ListAllNonHumanPrincipalRiskInputs(ctx)
+	if err != nil {
+		return err
+	}
+	inputs := make([]nonHumanPrincipalRiskInputRow, 0, len(rows))
+	for _, row := range rows {
+		inputs = append(inputs, nonHumanPrincipalRiskInputRowFromAllRow(row))
+	}
+	if err := q.DeleteAllNonHumanPrincipalReadModels(ctx); err != nil {
+		return err
+	}
+	return refreshNonHumanPrincipalReadModels(ctx, q, inputs)
+}
+
+func refreshNonHumanPrincipalReadModels(ctx context.Context, q *gen.Queries, rows []nonHumanPrincipalRiskInputRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	registry, err := riskpolicy.BuiltinRegistry()
+	if err != nil {
+		return err
+	}
+
+	params := gen.UpsertNonHumanPrincipalReadModelsBulkParams{
+		PrincipalRefs:                 make([]string, 0, len(rows)),
+		IdentityIds:                   make([]int64, 0, len(rows)),
+		AppAssetIds:                   make([]int64, 0, len(rows)),
+		PrincipalTypes:                make([]string, 0, len(rows)),
+		SourceKinds:                   make([]string, 0, len(rows)),
+		SourceNames:                   make([]string, 0, len(rows)),
+		DisplayNames:                  make([]string, 0, len(rows)),
+		SecondaryNames:                make([]string, 0, len(rows)),
+		LinkedAssetsCounts:            make([]int64, 0, len(rows)),
+		LinkedCredentialsCounts:       make([]int64, 0, len(rows)),
+		LastSeenAts:                   make([]pgtype.Timestamptz, 0, len(rows)),
+		ActivityStates:                make([]string, 0, len(rows)),
+		FreshnessStates:               make([]string, 0, len(rows)),
+		GovernanceStates:              make([]string, 0, len(rows)),
+		AccountableOwnerIdentityIds:   make([]int64, 0, len(rows)),
+		AccountableOwnerDisplayNames:  make([]string, 0, len(rows)),
+		AccountableOwnerPrimaryEmails: make([]string, 0, len(rows)),
+		OwnerPresences:                make([]string, 0, len(rows)),
+		HasCriticalCredentials:        make([]bool, 0, len(rows)),
+		HasHighRiskCredentials:        make([]bool, 0, len(rows)),
+		HasExpiredCredentials:         make([]bool, 0, len(rows)),
+		HasExpiringCredentials:        make([]bool, 0, len(rows)),
+		HasUnusedCredentials:          make([]bool, 0, len(rows)),
+		HasStaleEvidences:             make([]bool, 0, len(rows)),
+		RiskReasonCounts:              make([]int32, 0, len(rows)),
+		RiskLevels:                    make([]string, 0, len(rows)),
+		RiskSignalsJsons:              make([][]byte, 0, len(rows)),
+		PolicyPacksJsons:              make([][]byte, 0, len(rows)),
+	}
+	for _, row := range rows {
+		result, err := registry.EvaluateIdentity(nonHumanPrincipalPolicyInput(row))
+		if err != nil {
+			return err
+		}
+		riskSignalsJSON, err := json.Marshal(result.Signals)
+		if err != nil {
+			return err
+		}
+		policyPacksJSON, err := json.Marshal(result.PolicyPacks)
+		if err != nil {
+			return err
+		}
+
+		params.PrincipalRefs = append(params.PrincipalRefs, row.principalRef)
+		params.IdentityIds = append(params.IdentityIds, row.identityID)
+		params.AppAssetIds = append(params.AppAssetIds, row.appAssetID)
+		params.PrincipalTypes = append(params.PrincipalTypes, row.principalType)
+		params.SourceKinds = append(params.SourceKinds, row.sourceKind)
+		params.SourceNames = append(params.SourceNames, row.sourceName)
+		params.DisplayNames = append(params.DisplayNames, row.displayName)
+		params.SecondaryNames = append(params.SecondaryNames, row.secondaryName)
+		params.LinkedAssetsCounts = append(params.LinkedAssetsCounts, row.linkedAssetsCount)
+		params.LinkedCredentialsCounts = append(params.LinkedCredentialsCounts, row.linkedCredentialsCount)
+		params.LastSeenAts = append(params.LastSeenAts, row.lastSeenAt)
+		params.ActivityStates = append(params.ActivityStates, row.activityState)
+		params.FreshnessStates = append(params.FreshnessStates, row.freshnessState)
+		params.GovernanceStates = append(params.GovernanceStates, row.governanceState)
+		params.AccountableOwnerIdentityIds = append(params.AccountableOwnerIdentityIds, row.accountableOwnerIdentityID)
+		params.AccountableOwnerDisplayNames = append(params.AccountableOwnerDisplayNames, row.accountableOwnerDisplayName)
+		params.AccountableOwnerPrimaryEmails = append(params.AccountableOwnerPrimaryEmails, row.accountableOwnerPrimaryEmail)
+		params.OwnerPresences = append(params.OwnerPresences, row.ownerPresence)
+		params.HasCriticalCredentials = append(params.HasCriticalCredentials, row.hasCriticalCredential)
+		params.HasHighRiskCredentials = append(params.HasHighRiskCredentials, row.hasHighRiskCredential)
+		params.HasExpiredCredentials = append(params.HasExpiredCredentials, row.hasExpiredCredential)
+		params.HasExpiringCredentials = append(params.HasExpiringCredentials, row.hasExpiringCredential)
+		params.HasUnusedCredentials = append(params.HasUnusedCredentials, row.hasUnusedCredential)
+		params.HasStaleEvidences = append(params.HasStaleEvidences, row.hasStaleEvidence)
+		params.RiskReasonCounts = append(params.RiskReasonCounts, int32(result.RiskReasonCount))
+		params.RiskLevels = append(params.RiskLevels, result.RiskLevel)
+		params.RiskSignalsJsons = append(params.RiskSignalsJsons, riskSignalsJSON)
+		params.PolicyPacksJsons = append(params.PolicyPacksJsons, policyPacksJSON)
+	}
+
+	_, err = q.UpsertNonHumanPrincipalReadModelsBulk(ctx, params)
 	return err
+}
+
+func nonHumanPrincipalPolicyInput(row nonHumanPrincipalRiskInputRow) riskpolicy.IdentityInput {
+	return riskpolicy.IdentityInput{
+		IdentityID:             row.identityID,
+		PrincipalRef:           row.principalRef,
+		PrincipalType:          row.principalType,
+		SourceKind:             row.sourceKind,
+		SourceName:             row.sourceName,
+		DisplayName:            row.displayName,
+		PrimaryEmail:           row.primaryEmail,
+		LastSeenAt:             timestamptzPtr(row.lastSeenAt),
+		OwnerPresence:          row.ownerPresence,
+		GovernanceState:        row.governanceState,
+		LinkedAssetsCount:      row.linkedAssetsCount,
+		LinkedCredentialsCount: row.linkedCredentialsCount,
+		HasCriticalCredential:  row.hasCriticalCredential,
+		HasHighRiskCredential:  row.hasHighRiskCredential,
+		HasExpiredCredential:   row.hasExpiredCredential,
+		HasExpiringCredential:  row.hasExpiringCredential,
+		HasUnusedCredential:    row.hasUnusedCredential,
+		HasStaleEvidence:       row.hasStaleEvidence,
+	}
+}
+
+func nonHumanPrincipalRiskInputRowFromAllRow(row gen.ListAllNonHumanPrincipalRiskInputsRow) nonHumanPrincipalRiskInputRow {
+	return nonHumanPrincipalRiskInputRow{
+		principalRef:                 row.PrincipalRef,
+		identityID:                   row.IdentityID,
+		appAssetID:                   row.AppAssetID,
+		principalType:                row.PrincipalType,
+		sourceKind:                   row.SourceKind,
+		sourceName:                   row.SourceName,
+		displayName:                  row.DisplayName,
+		secondaryName:                row.SecondaryName,
+		primaryEmail:                 row.PrimaryEmail,
+		linkedAssetsCount:            row.LinkedAssetsCount,
+		linkedCredentialsCount:       row.LinkedCredentialsCount,
+		lastSeenAt:                   row.LastSeenAt,
+		activityState:                row.ActivityState,
+		freshnessState:               row.FreshnessState,
+		governanceState:              row.GovernanceState,
+		accountableOwnerIdentityID:   row.AccountableOwnerIdentityID,
+		accountableOwnerDisplayName:  row.AccountableOwnerDisplayName,
+		accountableOwnerPrimaryEmail: row.AccountableOwnerPrimaryEmail,
+		ownerPresence:                row.OwnerPresence,
+		hasCriticalCredential:        row.HasCriticalCredential,
+		hasHighRiskCredential:        row.HasHighRiskCredential,
+		hasExpiredCredential:         row.HasExpiredCredential,
+		hasExpiringCredential:        row.HasExpiringCredential,
+		hasUnusedCredential:          row.HasUnusedCredential,
+		hasStaleEvidence:             row.HasStaleEvidence,
+	}
+}
+
+func nonHumanPrincipalRiskInputRowFromSourceRow(row gen.ListNonHumanPrincipalRiskInputsBySourceRow) nonHumanPrincipalRiskInputRow {
+	return nonHumanPrincipalRiskInputRow{
+		principalRef:                 row.PrincipalRef,
+		identityID:                   row.IdentityID,
+		appAssetID:                   row.AppAssetID,
+		principalType:                row.PrincipalType,
+		sourceKind:                   row.SourceKind,
+		sourceName:                   row.SourceName,
+		displayName:                  row.DisplayName,
+		secondaryName:                row.SecondaryName,
+		primaryEmail:                 row.PrimaryEmail,
+		linkedAssetsCount:            row.LinkedAssetsCount,
+		linkedCredentialsCount:       row.LinkedCredentialsCount,
+		lastSeenAt:                   row.LastSeenAt,
+		activityState:                row.ActivityState,
+		freshnessState:               row.FreshnessState,
+		governanceState:              row.GovernanceState,
+		accountableOwnerIdentityID:   row.AccountableOwnerIdentityID,
+		accountableOwnerDisplayName:  row.AccountableOwnerDisplayName,
+		accountableOwnerPrimaryEmail: row.AccountableOwnerPrimaryEmail,
+		ownerPresence:                row.OwnerPresence,
+		hasCriticalCredential:        row.HasCriticalCredential,
+		hasHighRiskCredential:        row.HasHighRiskCredential,
+		hasExpiredCredential:         row.HasExpiredCredential,
+		hasExpiringCredential:        row.HasExpiringCredential,
+		hasUnusedCredential:          row.HasUnusedCredential,
+		hasStaleEvidence:             row.HasStaleEvidence,
+	}
 }
 
 func FreshnessWindow(cfg RefreshConfig, kind string) time.Duration {

--- a/internal/readmodels/projector.go
+++ b/internal/readmodels/projector.go
@@ -94,6 +94,18 @@ func (p *Projector) RefreshSaaSAppRiskReadModelByID(ctx context.Context, saasApp
 	})
 }
 
+func (p *Projector) RefreshCredentialArtifactRiskReadModelsBySource(ctx context.Context, sourceKind, sourceName string) error {
+	return p.withQueries(ctx, func(q *gen.Queries) error {
+		return refreshCredentialArtifactRiskReadModelsBySource(ctx, q, sourceKind, sourceName)
+	})
+}
+
+func (p *Projector) RefreshAllCredentialArtifactRiskReadModels(ctx context.Context) error {
+	return p.withQueries(ctx, func(q *gen.Queries) error {
+		return refreshAllCredentialArtifactRiskReadModels(ctx, q)
+	})
+}
+
 func (p *Projector) RefreshAppAssetSource(ctx context.Context, sourceKind, sourceName string) error {
 	return p.withQueries(ctx, func(q *gen.Queries) error {
 		return refreshAppAssetSource(ctx, q, sourceKind, sourceName)
@@ -131,6 +143,9 @@ func (p *Projector) RebuildAllReadModels(ctx context.Context) error {
 			return err
 		}
 		if err := refreshAllSaaSAppRiskReadModels(ctx, q); err != nil {
+			return err
+		}
+		if err := refreshAllCredentialArtifactRiskReadModels(ctx, q); err != nil {
 			return err
 		}
 		return refreshAllNonHumanPrincipalReadModels(ctx, q)
@@ -282,6 +297,24 @@ type nonHumanPrincipalRiskInputRow struct {
 	hasExpiringCredential        bool
 	hasUnusedCredential          bool
 	hasStaleEvidence             bool
+}
+
+type credentialArtifactRiskInputRow struct {
+	credentialArtifactID  int64
+	sourceKind            string
+	sourceName            string
+	credentialKind        string
+	status                string
+	expiresAtSource       pgtype.Timestamptz
+	lastUsedAtSource      pgtype.Timestamptz
+	createdAtSource       pgtype.Timestamptz
+	createdByExternalID   string
+	createdByDisplayName  string
+	approvedByExternalID  string
+	approvedByDisplayName string
+	assetRefKind          string
+	assetRefExternalID    string
+	scopeJSON             []byte
 }
 
 func refreshAllSaaSAppRiskReadModels(ctx context.Context, q *gen.Queries) error {
@@ -467,6 +500,147 @@ func saasPolicyInput(row saasAppRiskInputRow) riskpolicy.SaaSInput {
 		ConnectorBindingEnabled:       row.connectorBindingEnabled,
 		ConnectorBindingStale:         row.connectorBindingStale,
 		ConnectorBindingHealthy:       row.connectorBindingHealthy,
+	}
+}
+
+func refreshAllCredentialArtifactRiskReadModels(ctx context.Context, q *gen.Queries) error {
+	rows, err := q.ListAllCredentialArtifactRiskInputs(ctx)
+	if err != nil {
+		return err
+	}
+	inputs := make([]credentialArtifactRiskInputRow, 0, len(rows))
+	for _, row := range rows {
+		inputs = append(inputs, credentialArtifactRiskInputRowFromAllRow(row))
+	}
+	if err := q.DeleteAllCredentialArtifactRiskReadModels(ctx); err != nil {
+		return err
+	}
+	return refreshCredentialArtifactRiskReadModels(ctx, q, inputs)
+}
+
+func refreshCredentialArtifactRiskReadModelsBySource(ctx context.Context, q *gen.Queries, sourceKind, sourceName string) error {
+	sourceKind = normalizeSourceKind(sourceKind)
+	sourceName = strings.TrimSpace(sourceName)
+	if sourceKind == "" || sourceName == "" {
+		return nil
+	}
+	arg := gen.ListCredentialArtifactRiskInputsBySourceParams{
+		SourceKind: sourceKind,
+		SourceName: sourceName,
+	}
+	rows, err := q.ListCredentialArtifactRiskInputsBySource(ctx, arg)
+	if err != nil {
+		return err
+	}
+	inputs := make([]credentialArtifactRiskInputRow, 0, len(rows))
+	for _, row := range rows {
+		inputs = append(inputs, credentialArtifactRiskInputRowFromSourceRow(row))
+	}
+	if err := q.DeleteCredentialArtifactRiskReadModelsBySource(ctx, gen.DeleteCredentialArtifactRiskReadModelsBySourceParams(arg)); err != nil {
+		return err
+	}
+	return refreshCredentialArtifactRiskReadModels(ctx, q, inputs)
+}
+
+func refreshCredentialArtifactRiskReadModels(ctx context.Context, q *gen.Queries, rows []credentialArtifactRiskInputRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	registry, err := riskpolicy.BuiltinRegistry()
+	if err != nil {
+		return err
+	}
+
+	evaluatedAt := time.Now().UTC()
+	params := gen.UpsertCredentialArtifactRiskReadModelsBulkParams{
+		CredentialArtifactIds: make([]int64, 0, len(rows)),
+		RiskLevels:            make([]string, 0, len(rows)),
+		RiskRanks:             make([]int32, 0, len(rows)),
+		RiskSignalsJsons:      make([][]byte, 0, len(rows)),
+		PolicyPacksJsons:      make([][]byte, 0, len(rows)),
+	}
+	for _, row := range rows {
+		result, err := registry.EvaluateCredential(credentialArtifactPolicyInput(row, evaluatedAt))
+		if err != nil {
+			return err
+		}
+		riskSignalsJSON, err := json.Marshal(result.Signals)
+		if err != nil {
+			return err
+		}
+		policyPacksJSON, err := json.Marshal(result.PolicyPacks)
+		if err != nil {
+			return err
+		}
+
+		params.CredentialArtifactIds = append(params.CredentialArtifactIds, row.credentialArtifactID)
+		params.RiskLevels = append(params.RiskLevels, result.RiskLevel)
+		params.RiskRanks = append(params.RiskRanks, int32(result.RiskRank))
+		params.RiskSignalsJsons = append(params.RiskSignalsJsons, riskSignalsJSON)
+		params.PolicyPacksJsons = append(params.PolicyPacksJsons, policyPacksJSON)
+	}
+
+	_, err = q.UpsertCredentialArtifactRiskReadModelsBulk(ctx, params)
+	return err
+}
+
+func credentialArtifactPolicyInput(row credentialArtifactRiskInputRow, evaluatedAt time.Time) riskpolicy.CredentialInput {
+	return riskpolicy.CredentialInput{
+		SourceKind:            row.sourceKind,
+		SourceName:            row.sourceName,
+		CredentialKind:        row.credentialKind,
+		Status:                row.status,
+		ExpiresAt:             timestamptzPtr(row.expiresAtSource),
+		LastUsedAt:            timestamptzPtr(row.lastUsedAtSource),
+		CreatedAt:             timestamptzPtr(row.createdAtSource),
+		CreatedByExternalID:   row.createdByExternalID,
+		CreatedByDisplayName:  row.createdByDisplayName,
+		ApprovedByExternalID:  row.approvedByExternalID,
+		ApprovedByDisplayName: row.approvedByDisplayName,
+		AssetRefKind:          row.assetRefKind,
+		AssetRefExternalID:    row.assetRefExternalID,
+		ScopeJSON:             row.scopeJSON,
+		EvaluatedAt:           evaluatedAt,
+	}
+}
+
+func credentialArtifactRiskInputRowFromAllRow(row gen.ListAllCredentialArtifactRiskInputsRow) credentialArtifactRiskInputRow {
+	return credentialArtifactRiskInputRow{
+		credentialArtifactID:  row.CredentialArtifactID,
+		sourceKind:            row.SourceKind,
+		sourceName:            row.SourceName,
+		credentialKind:        row.CredentialKind,
+		status:                row.Status,
+		expiresAtSource:       row.ExpiresAtSource,
+		lastUsedAtSource:      row.LastUsedAtSource,
+		createdAtSource:       row.CreatedAtSource,
+		createdByExternalID:   row.CreatedByExternalID,
+		createdByDisplayName:  row.CreatedByDisplayName,
+		approvedByExternalID:  row.ApprovedByExternalID,
+		approvedByDisplayName: row.ApprovedByDisplayName,
+		assetRefKind:          row.AssetRefKind,
+		assetRefExternalID:    row.AssetRefExternalID,
+		scopeJSON:             row.ScopeJson,
+	}
+}
+
+func credentialArtifactRiskInputRowFromSourceRow(row gen.ListCredentialArtifactRiskInputsBySourceRow) credentialArtifactRiskInputRow {
+	return credentialArtifactRiskInputRow{
+		credentialArtifactID:  row.CredentialArtifactID,
+		sourceKind:            row.SourceKind,
+		sourceName:            row.SourceName,
+		credentialKind:        row.CredentialKind,
+		status:                row.Status,
+		expiresAtSource:       row.ExpiresAtSource,
+		lastUsedAtSource:      row.LastUsedAtSource,
+		createdAtSource:       row.CreatedAtSource,
+		createdByExternalID:   row.CreatedByExternalID,
+		createdByDisplayName:  row.CreatedByDisplayName,
+		approvedByExternalID:  row.ApprovedByExternalID,
+		approvedByDisplayName: row.ApprovedByDisplayName,
+		assetRefKind:          row.AssetRefKind,
+		assetRefExternalID:    row.AssetRefExternalID,
+		scopeJSON:             row.ScopeJson,
 	}
 }
 

--- a/internal/readmodels/projector_integration_test.go
+++ b/internal/readmodels/projector_integration_test.go
@@ -379,6 +379,9 @@ func TestProjectorNonHumanPolicyRiskFeedsFiltersSortAndMetrics(t *testing.T) {
 		}
 
 		projector := NewProjector(pool, nil, RefreshConfig{})
+		if err := projector.RefreshAllCredentialArtifactRiskReadModels(ctx); err != nil {
+			t.Fatalf("RefreshAllCredentialArtifactRiskReadModels(): %v", err)
+		}
 		if err := projector.RefreshAllNonHumanPrincipalReadModels(ctx); err != nil {
 			t.Fatalf("RefreshAllNonHumanPrincipalReadModels(): %v", err)
 		}

--- a/internal/readmodels/projector_integration_test.go
+++ b/internal/readmodels/projector_integration_test.go
@@ -2,6 +2,7 @@ package readmodels
 
 import (
 	"context"
+	"encoding/json"
 	"strconv"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/open-sspm/open-sspm/internal/connectors/configstore"
 	"github.com/open-sspm/open-sspm/internal/db/gen"
+	"github.com/open-sspm/open-sspm/internal/riskpolicy"
 	"github.com/open-sspm/open-sspm/internal/testdb"
 )
 
@@ -119,8 +121,8 @@ func TestProjectorRefreshConnectorSourceStateDoesNotLetDiscoveryFreshnessKeepNon
 			t.Fatalf("RefreshConnectorSourceState(): %v", err)
 		}
 
-		if _, err := q.RefreshAllNonHumanPrincipalReadModelsSafely(ctx); err != nil {
-			t.Fatalf("RefreshAllNonHumanPrincipalReadModelsSafely(): %v", err)
+		if err := projector.RefreshAllNonHumanPrincipalReadModels(ctx); err != nil {
+			t.Fatalf("RefreshAllNonHumanPrincipalReadModels(): %v", err)
 		}
 
 		principal, err := q.GetNonHumanPrincipalByRef(ctx, "app-asset-"+int64String(appAssetID))
@@ -132,6 +134,326 @@ func TestProjectorRefreshConnectorSourceStateDoesNotLetDiscoveryFreshnessKeepNon
 		}
 		if !principal.HasStaleEvidence {
 			t.Fatalf("has_stale_evidence = false, want true")
+		}
+	})
+}
+
+func TestProjectorRefreshAllNonHumanPrincipalReadModelsEvaluatesAndStoresPolicy(t *testing.T) {
+	t.Parallel()
+
+	withReadModelsTestDatabase(t, func(ctx context.Context, pool *pgxpool.Pool, q *gen.Queries, migrator *migrate.Migrate) {
+		migrateUpReadModels(t, migrator)
+
+		sourceKind := "entra"
+		sourceName := "11111111-1111-1111-1111-111111111111"
+		now := time.Now().UTC().Truncate(time.Second)
+		runID := insertReadModelsSyncRun(t, ctx, pool, sourceKind, sourceName, now.Add(-4*time.Hour))
+		upsertConfiguredSourceState(t, ctx, pool, sourceKind, sourceName, now.Add(-4*time.Hour), now.Add(-90*time.Minute))
+
+		appAssetID := upsertReadModelsAppAsset(t, ctx, q, runID, sourceKind, sourceName, "entra_service_principal", "svc-policy", "Policy Service Principal")
+
+		if _, err := q.RefreshAllAppAssetReadModels(ctx); err != nil {
+			t.Fatalf("RefreshAllAppAssetReadModels(): %v", err)
+		}
+
+		projector := NewProjector(pool, nil, RefreshConfig{})
+		if err := projector.RefreshAllNonHumanPrincipalReadModels(ctx); err != nil {
+			t.Fatalf("RefreshAllNonHumanPrincipalReadModels(): %v", err)
+		}
+
+		principal, err := q.GetNonHumanPrincipalByRef(ctx, "app-asset-"+int64String(appAssetID))
+		if err != nil {
+			t.Fatalf("GetNonHumanPrincipalByRef(): %v", err)
+		}
+		expected, err := riskpolicy.EvaluateIdentity(riskpolicy.IdentityInput{
+			IdentityID:             principal.IdentityID,
+			PrincipalRef:           principal.PrincipalRef,
+			PrincipalType:          principal.PrincipalType,
+			SourceKind:             principal.SourceKind,
+			SourceName:             principal.SourceName,
+			DisplayName:            principal.DisplayName,
+			PrimaryEmail:           principal.SecondaryName,
+			LastSeenAt:             timestamptzPtr(principal.LastSeenAt),
+			OwnerPresence:          principal.OwnerPresence,
+			GovernanceState:        principal.GovernanceState,
+			LinkedAssetsCount:      principal.LinkedAssetsCount,
+			LinkedCredentialsCount: principal.LinkedCredentialsCount,
+			HasCriticalCredential:  principal.HasCriticalCredential,
+			HasHighRiskCredential:  principal.HasHighRiskCredential,
+			HasExpiredCredential:   principal.HasExpiredCredential,
+			HasExpiringCredential:  principal.HasExpiringCredential,
+			HasUnusedCredential:    principal.HasUnusedCredential,
+			HasStaleEvidence:       principal.HasStaleEvidence,
+		})
+		if err != nil {
+			t.Fatalf("EvaluateIdentity(): %v", err)
+		}
+		if principal.RiskLevel != expected.RiskLevel {
+			t.Fatalf("stored risk_level = %q, policy risk_level = %q", principal.RiskLevel, expected.RiskLevel)
+		}
+		if principal.RiskReasonCount != int32(expected.RiskReasonCount) {
+			t.Fatalf("stored risk_reason_count = %d, policy risk_reason_count = %d", principal.RiskReasonCount, expected.RiskReasonCount)
+		}
+		if principal.RiskLevel != "high" || principal.RiskReasonCount != 3 {
+			t.Fatalf("stored policy risk = %q/%d, want high/3", principal.RiskLevel, principal.RiskReasonCount)
+		}
+
+		var signals []riskpolicy.RiskSignal
+		if err := json.Unmarshal(principal.RiskSignalsJson, &signals); err != nil {
+			t.Fatalf("unmarshal risk_signals_json: %v", err)
+		}
+		if len(signals) != expected.RiskReasonCount {
+			t.Fatalf("risk_signals_json length = %d, want %d", len(signals), expected.RiskReasonCount)
+		}
+		var packs []riskpolicy.PolicyPackRef
+		if err := json.Unmarshal(principal.PolicyPacksJson, &packs); err != nil {
+			t.Fatalf("unmarshal policy_packs_json: %v", err)
+		}
+		if len(packs) != len(expected.PolicyPacks) || packs[0].ID != expected.PolicyPacks[0].ID {
+			t.Fatalf("policy_packs_json = %+v, want %+v", packs, expected.PolicyPacks)
+		}
+	})
+}
+
+func TestProjectorRefreshNonHumanPrincipalSourceReadModelsKeepsUnrelatedRowsUntouched(t *testing.T) {
+	t.Parallel()
+
+	withReadModelsTestDatabase(t, func(ctx context.Context, pool *pgxpool.Pool, q *gen.Queries, migrator *migrate.Migrate) {
+		migrateUpReadModels(t, migrator)
+
+		now := time.Now().UTC().Truncate(time.Second)
+		githubRunID := insertReadModelsSyncRun(t, ctx, pool, "github", "acme", now)
+		datadogRunID := insertReadModelsSyncRun(t, ctx, pool, "datadog", "us5.datadoghq.com", now)
+
+		upsertConfiguredSourceState(t, ctx, pool, "github", "acme", now.Add(-10*time.Minute), now.Add(time.Hour))
+		upsertConfiguredSourceState(t, ctx, pool, "datadog", "us5.datadoghq.com", now.Add(-10*time.Minute), now.Add(time.Hour))
+
+		githubAssetID := upsertReadModelsAppAsset(t, ctx, q, githubRunID, "github", "acme", "github_app", "github-actions", "GitHub Actions")
+		datadogAssetID := upsertReadModelsAppAsset(t, ctx, q, datadogRunID, "datadog", "us5.datadoghq.com", "datadog_app_key", "datadog-app-key", "Datadog App Key")
+
+		if _, err := q.RefreshAllAppAssetReadModels(ctx); err != nil {
+			t.Fatalf("RefreshAllAppAssetReadModels(): %v", err)
+		}
+
+		projector := NewProjector(pool, nil, RefreshConfig{})
+		if err := projector.RefreshAllNonHumanPrincipalReadModels(ctx); err != nil {
+			t.Fatalf("RefreshAllNonHumanPrincipalReadModels(): %v", err)
+		}
+
+		affectedRef := "app-asset-" + int64String(githubAssetID)
+		unaffectedRef := "app-asset-" + int64String(datadogAssetID)
+		affectedSentinel := now.Add(-48 * time.Hour)
+		unaffectedSentinel := now.Add(-24 * time.Hour)
+
+		if _, err := pool.Exec(ctx, `
+			UPDATE non_human_principals
+			SET projection_refreshed_at = CASE principal_ref
+				WHEN $1 THEN $2
+				WHEN $3 THEN $4
+				ELSE projection_refreshed_at
+			END
+			WHERE principal_ref IN ($1, $3)
+		`, affectedRef, affectedSentinel, unaffectedRef, unaffectedSentinel); err != nil {
+			t.Fatalf("seed non_human_principals projection_refreshed_at: %v", err)
+		}
+
+		if err := projector.RefreshNonHumanPrincipalSourceReadModels(ctx, "github", "acme"); err != nil {
+			t.Fatalf("RefreshNonHumanPrincipalSourceReadModels(): %v", err)
+		}
+
+		affectedRefreshedAt := fetchNonHumanProjectionRefreshedAt(t, ctx, pool, affectedRef)
+		unaffectedRefreshedAt := fetchNonHumanProjectionRefreshedAt(t, ctx, pool, unaffectedRef)
+		if !affectedRefreshedAt.Valid || affectedRefreshedAt.Time.Equal(affectedSentinel) {
+			t.Fatalf("affected projection_refreshed_at = %+v, want refreshed timestamp", affectedRefreshedAt)
+		}
+		if !unaffectedRefreshedAt.Valid || !unaffectedRefreshedAt.Time.Equal(unaffectedSentinel) {
+			t.Fatalf("unaffected projection_refreshed_at = %+v, want %v", unaffectedRefreshedAt, unaffectedSentinel)
+		}
+
+		affected, err := q.GetNonHumanPrincipalByRef(ctx, affectedRef)
+		if err != nil {
+			t.Fatalf("GetNonHumanPrincipalByRef(affected): %v", err)
+		}
+		if affected.RiskLevel != "high" || affected.RiskReasonCount != 1 {
+			t.Fatalf("affected policy risk = %q/%d, want high/1", affected.RiskLevel, affected.RiskReasonCount)
+		}
+	})
+}
+
+func TestProjectorNonHumanPolicyRiskFeedsFiltersSortAndMetrics(t *testing.T) {
+	t.Parallel()
+
+	withReadModelsTestDatabase(t, func(ctx context.Context, pool *pgxpool.Pool, q *gen.Queries, migrator *migrate.Migrate) {
+		migrateUpReadModels(t, migrator)
+
+		now := time.Now().UTC().Truncate(time.Second)
+		ownerID := insertReadModelsIdentity(t, ctx, pool, "human", "owner@example.com", "Owner Example")
+		githubRunID := insertReadModelsSyncRun(t, ctx, pool, "github", "acme", now)
+		entraRunID := insertReadModelsSyncRun(t, ctx, pool, "entra", "tenant-1", now)
+		datadogRunID := insertReadModelsSyncRun(t, ctx, pool, "datadog", "rogue", now)
+
+		upsertConfiguredSourceState(t, ctx, pool, "github", "acme", now.Add(-15*time.Minute), now.Add(time.Hour))
+		upsertConfiguredSourceState(t, ctx, pool, "entra", "tenant-1", now.Add(-15*time.Minute), now.Add(time.Hour))
+
+		criticalAssetID := upsertReadModelsAppAsset(t, ctx, q, githubRunID, "github", "acme", "github_app", "critical-app", "Critical GitHub App")
+		highAssetID := upsertReadModelsAppAsset(t, ctx, q, githubRunID, "github", "acme", "github_app", "high-app", "High GitHub App")
+		mediumAssetID := upsertReadModelsAppAsset(t, ctx, q, entraRunID, "entra", "tenant-1", "entra_service_principal", "medium-sp", "Medium Service Principal")
+		lowAssetID := upsertReadModelsAppAsset(t, ctx, q, entraRunID, "entra", "tenant-1", "entra_service_principal", "low-sp", "Low Service Principal")
+		rogueAssetID := upsertReadModelsAppAsset(t, ctx, q, datadogRunID, "datadog", "rogue", "datadog_app_key", "rogue-key", "Rogue Datadog Key")
+
+		for _, appAssetID := range []int64{mediumAssetID, lowAssetID} {
+			if _, err := q.UpsertAppAssetGovernance(ctx, gen.UpsertAppAssetGovernanceParams{
+				AppAssetID:      appAssetID,
+				GovernanceState: "approved",
+				OwnerIdentityID: pgtype.Int8{Int64: ownerID, Valid: true},
+			}); err != nil {
+				t.Fatalf("UpsertAppAssetGovernance(%d): %v", appAssetID, err)
+			}
+		}
+
+		criticalCredential := readModelsCredentialArtifactSeed{
+			SourceKind:           "github",
+			SourceName:           "acme",
+			AssetRefKind:         "app_asset",
+			AssetRefExternalID:   "github_app:critical-app",
+			CredentialKind:       "generic_api_key",
+			ExternalID:           "critical-expired",
+			DisplayName:          "Critical Expired Credential",
+			Status:               "active",
+			ExpiresAtSource:      now.Add(-24 * time.Hour),
+			CreatedByExternalID:  "owner@example.com",
+			CreatedByDisplayName: "Owner Example",
+		}
+		highCredential := readModelsCredentialArtifactSeed{
+			SourceKind:         "github",
+			SourceName:         "acme",
+			AssetRefKind:       "app_asset",
+			AssetRefExternalID: "github_app:high-app",
+			CredentialKind:     "generic_api_key",
+			ExternalID:         "high-unattributed",
+			DisplayName:        "High Unattributed Credential",
+			Status:             "active",
+			LastUsedAtSource:   now.Add(-120 * 24 * time.Hour),
+		}
+		mediumCredential := readModelsCredentialArtifactSeed{
+			SourceKind:           "entra",
+			SourceName:           "tenant-1",
+			AssetRefKind:         "app_asset",
+			AssetRefExternalID:   "entra_service_principal:medium-sp",
+			CredentialKind:       "generic_api_key",
+			ExternalID:           "medium-expiring",
+			DisplayName:          "Medium Expiring Credential",
+			Status:               "active",
+			ExpiresAtSource:      now.Add(20 * 24 * time.Hour),
+			CreatedByExternalID:  "owner@example.com",
+			CreatedByDisplayName: "Owner Example",
+		}
+		rogueCredential := readModelsCredentialArtifactSeed{
+			SourceKind:         "datadog",
+			SourceName:         "rogue",
+			AssetRefKind:       "app_asset",
+			AssetRefExternalID: "datadog_app_key:rogue-key",
+			CredentialKind:     "generic_api_key",
+			ExternalID:         "rogue-expired",
+			DisplayName:        "Rogue Expired Credential",
+			Status:             "active",
+			ExpiresAtSource:    now.Add(-24 * time.Hour),
+		}
+		for _, fixture := range []struct {
+			runID int64
+			seed  readModelsCredentialArtifactSeed
+		}{
+			{runID: githubRunID, seed: criticalCredential},
+			{runID: githubRunID, seed: highCredential},
+			{runID: entraRunID, seed: mediumCredential},
+			{runID: datadogRunID, seed: rogueCredential},
+		} {
+			insertReadModelsCredentialArtifact(t, ctx, pool, fixture.runID, fixture.seed)
+		}
+
+		if _, err := q.RefreshAllAppAssetReadModels(ctx); err != nil {
+			t.Fatalf("RefreshAllAppAssetReadModels(): %v", err)
+		}
+
+		projector := NewProjector(pool, nil, RefreshConfig{})
+		if err := projector.RefreshAllNonHumanPrincipalReadModels(ctx); err != nil {
+			t.Fatalf("RefreshAllNonHumanPrincipalReadModels(): %v", err)
+		}
+
+		configuredSourceKinds := []string{"github", "entra"}
+		configuredSourceNames := []string{"acme", "tenant-1"}
+		criticalRef := "app-asset-" + int64String(criticalAssetID)
+		highRef := "app-asset-" + int64String(highAssetID)
+		mediumRef := "app-asset-" + int64String(mediumAssetID)
+		lowRef := "app-asset-" + int64String(lowAssetID)
+		rogueRef := "app-asset-" + int64String(rogueAssetID)
+
+		rows, err := q.ListNonHumanPrincipalsPageByFilters(ctx, gen.ListNonHumanPrincipalsPageByFiltersParams{
+			ConfiguredSourceKinds: configuredSourceKinds,
+			ConfiguredSourceNames: configuredSourceNames,
+			PageLimit:             10,
+		})
+		if err != nil {
+			t.Fatalf("ListNonHumanPrincipalsPageByFilters(all configured): %v", err)
+		}
+		rowRefs := principalRefsFromRows(rows)
+		assertPrincipalRefs(t, rowRefs, []string{criticalRef, highRef, mediumRef, lowRef})
+		assertNoPrincipalRef(t, rowRefs, rogueRef)
+
+		highRows, err := q.ListNonHumanPrincipalsPageByFilters(ctx, gen.ListNonHumanPrincipalsPageByFiltersParams{
+			ConfiguredSourceKinds: configuredSourceKinds,
+			ConfiguredSourceNames: configuredSourceNames,
+			RiskLevel:             "high",
+			PageLimit:             10,
+		})
+		if err != nil {
+			t.Fatalf("ListNonHumanPrincipalsPageByFilters(high): %v", err)
+		}
+		assertPrincipalRefs(t, principalRefsFromRows(highRows), []string{highRef})
+
+		githubRows, err := q.ListNonHumanPrincipalsPageByFilters(ctx, gen.ListNonHumanPrincipalsPageByFiltersParams{
+			ConfiguredSourceKinds: configuredSourceKinds,
+			ConfiguredSourceNames: configuredSourceNames,
+			SourceKind:            "github",
+			PageLimit:             10,
+		})
+		if err != nil {
+			t.Fatalf("ListNonHumanPrincipalsPageByFilters(github): %v", err)
+		}
+		assertPrincipalRefs(t, principalRefsFromRows(githubRows), []string{criticalRef, highRef})
+
+		criticalCount, err := q.CountNonHumanPrincipalsByFilters(ctx, gen.CountNonHumanPrincipalsByFiltersParams{
+			ConfiguredSourceKinds: configuredSourceKinds,
+			ConfiguredSourceNames: configuredSourceNames,
+			RiskLevel:             "critical",
+		})
+		if err != nil {
+			t.Fatalf("CountNonHumanPrincipalsByFilters(critical): %v", err)
+		}
+		if criticalCount != 1 {
+			t.Fatalf("critical count = %d, want 1", criticalCount)
+		}
+
+		ownerCoverage, err := q.CountConfiguredNonHumanPrincipalOwnerCoverage(ctx)
+		if err != nil {
+			t.Fatalf("CountConfiguredNonHumanPrincipalOwnerCoverage(): %v", err)
+		}
+		if ownerCoverage.PrincipalCount != 4 || ownerCoverage.WithOwnerCount != 2 {
+			t.Fatalf("owner coverage = %+v, want 4 principals and 2 with owner", ownerCoverage)
+		}
+
+		wantHighRiskCredentials, wantHighRiskCredentialsWithAttribution := expectedHighRiskCredentialAttributionFromPolicy(t, now, []readModelsCredentialMetricCase{
+			{seed: criticalCredential, hasAttribution: true},
+			{seed: highCredential, hasAttribution: false},
+			{seed: mediumCredential, hasAttribution: true},
+		})
+		credentialCoverage, err := q.CountConfiguredNonHumanHighRiskCredentialAttribution(ctx)
+		if err != nil {
+			t.Fatalf("CountConfiguredNonHumanHighRiskCredentialAttribution(): %v", err)
+		}
+		if credentialCoverage.HighRiskCredentialCount != wantHighRiskCredentials ||
+			credentialCoverage.HighRiskWithAttributionCount != wantHighRiskCredentialsWithAttribution {
+			t.Fatalf("credential coverage = %+v, want %d/%d", credentialCoverage, wantHighRiskCredentials, wantHighRiskCredentialsWithAttribution)
 		}
 	})
 }
@@ -305,6 +627,166 @@ func upsertReadModelsAppAsset(t *testing.T, ctx context.Context, q *gen.Queries,
 	return appAsset.ID
 }
 
+func insertReadModelsIdentity(t *testing.T, ctx context.Context, pool *pgxpool.Pool, kind, email, displayName string) int64 {
+	t.Helper()
+
+	var id int64
+	err := pool.QueryRow(ctx, `
+		INSERT INTO identities (kind, display_name, primary_email, created_at, updated_at)
+		VALUES ($1, $2, $3, now(), now())
+		RETURNING id
+	`, kind, displayName, email).Scan(&id)
+	if err != nil {
+		t.Fatalf("insert identity %s: %v", email, err)
+	}
+	return id
+}
+
+type readModelsCredentialArtifactSeed struct {
+	SourceKind            string
+	SourceName            string
+	AssetRefKind          string
+	AssetRefExternalID    string
+	CredentialKind        string
+	ExternalID            string
+	DisplayName           string
+	Status                string
+	ExpiresAtSource       time.Time
+	LastUsedAtSource      time.Time
+	CreatedByExternalID   string
+	CreatedByDisplayName  string
+	ApprovedByExternalID  string
+	ApprovedByDisplayName string
+}
+
+func insertReadModelsCredentialArtifact(t *testing.T, ctx context.Context, pool *pgxpool.Pool, runID int64, seed readModelsCredentialArtifactSeed) int64 {
+	t.Helper()
+
+	var id int64
+	err := pool.QueryRow(ctx, `
+		INSERT INTO credential_artifacts (
+			source_kind,
+			source_name,
+			asset_ref_kind,
+			asset_ref_external_id,
+			credential_kind,
+			external_id,
+			display_name,
+			scope_json,
+			raw_json,
+			status,
+			seen_in_run_id,
+			seen_at,
+			last_observed_run_id,
+			last_observed_at,
+			expires_at_source,
+			last_used_at_source,
+			created_by_kind,
+			created_by_external_id,
+			created_by_display_name,
+			approved_by_kind,
+			approved_by_external_id,
+			approved_by_display_name,
+			updated_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, '{}'::jsonb, '{}'::jsonb, $8, $9, now(), $9, now(), $10, $11, 'user', $12, $13, 'user', $14, $15, now())
+		RETURNING id
+	`, seed.SourceKind, seed.SourceName, seed.AssetRefKind, seed.AssetRefExternalID, seed.CredentialKind, seed.ExternalID, seed.DisplayName, seed.Status, runID, readModelsNullableTime(seed.ExpiresAtSource), readModelsNullableTime(seed.LastUsedAtSource), seed.CreatedByExternalID, seed.CreatedByDisplayName, seed.ApprovedByExternalID, seed.ApprovedByDisplayName).Scan(&id)
+	if err != nil {
+		t.Fatalf("insert credential artifact %s/%s: %v", seed.SourceKind, seed.ExternalID, err)
+	}
+	return id
+}
+
+func readModelsNullableTime(value time.Time) any {
+	if value.IsZero() {
+		return nil
+	}
+	return value.UTC()
+}
+
+type readModelsCredentialMetricCase struct {
+	seed           readModelsCredentialArtifactSeed
+	hasAttribution bool
+}
+
+func expectedHighRiskCredentialAttributionFromPolicy(t *testing.T, evaluatedAt time.Time, cases []readModelsCredentialMetricCase) (int64, int64) {
+	t.Helper()
+
+	var highRiskCount, highRiskWithAttributionCount int64
+	for _, tc := range cases {
+		result, err := riskpolicy.EvaluateCredential(readModelsCredentialPolicyInput(tc.seed, evaluatedAt))
+		if err != nil {
+			t.Fatalf("EvaluateCredential(%s): %v", tc.seed.ExternalID, err)
+		}
+		if result.RiskRank < riskpolicy.SeverityRank(riskpolicy.SeverityHigh) {
+			continue
+		}
+		highRiskCount++
+		if tc.hasAttribution {
+			highRiskWithAttributionCount++
+		}
+	}
+	return highRiskCount, highRiskWithAttributionCount
+}
+
+func readModelsCredentialPolicyInput(seed readModelsCredentialArtifactSeed, evaluatedAt time.Time) riskpolicy.CredentialInput {
+	return riskpolicy.CredentialInput{
+		SourceKind:            seed.SourceKind,
+		SourceName:            seed.SourceName,
+		CredentialKind:        seed.CredentialKind,
+		Status:                seed.Status,
+		ExpiresAt:             readModelsTimePtr(seed.ExpiresAtSource),
+		LastUsedAt:            readModelsTimePtr(seed.LastUsedAtSource),
+		CreatedByExternalID:   seed.CreatedByExternalID,
+		CreatedByDisplayName:  seed.CreatedByDisplayName,
+		ApprovedByExternalID:  seed.ApprovedByExternalID,
+		ApprovedByDisplayName: seed.ApprovedByDisplayName,
+		AssetRefKind:          seed.AssetRefKind,
+		AssetRefExternalID:    seed.AssetRefExternalID,
+		EvaluatedAt:           evaluatedAt,
+	}
+}
+
+func readModelsTimePtr(value time.Time) *time.Time {
+	if value.IsZero() {
+		return nil
+	}
+	normalized := value.UTC()
+	return &normalized
+}
+
+func principalRefsFromRows(rows []gen.ListNonHumanPrincipalsPageByFiltersRow) []string {
+	refs := make([]string, 0, len(rows))
+	for _, row := range rows {
+		refs = append(refs, row.PrincipalRef)
+	}
+	return refs
+}
+
+func assertPrincipalRefs(t *testing.T, got, want []string) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("principal refs = %#v, want %#v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("principal refs = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func assertNoPrincipalRef(t *testing.T, got []string, unwanted string) {
+	t.Helper()
+
+	for _, ref := range got {
+		if ref == unwanted {
+			t.Fatalf("principal refs = %#v, did not expect %q", got, unwanted)
+		}
+	}
+}
+
 func upsertReadModelsSaaSApp(t *testing.T, ctx context.Context, pool *pgxpool.Pool, q *gen.Queries, canonicalKey, displayName, primaryDomain, vendorName string, observedAt time.Time) int64 {
 	t.Helper()
 
@@ -386,6 +868,47 @@ func upsertReadModelsPrivilegedSaaSAppEvent(t *testing.T, ctx context.Context, q
 	}); err != nil {
 		t.Fatalf("PromoteSaaSAppEventsSeenInRunBySource(%s): %v", canonicalKey, err)
 	}
+}
+
+func upsertConfiguredSourceState(t *testing.T, ctx context.Context, pool *pgxpool.Pool, sourceKind, sourceName string, lastSuccessAt, freshUntilAt time.Time) {
+	t.Helper()
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO connector_source_state (
+			source_kind,
+			source_name,
+			enabled,
+			configured,
+			discovery_enabled,
+			last_success_at,
+			fresh_until_at,
+			updated_at
+		)
+		VALUES ($1, $2, true, true, true, $3, $4, now())
+		ON CONFLICT (source_kind, source_name) DO UPDATE SET
+			enabled = EXCLUDED.enabled,
+			configured = EXCLUDED.configured,
+			discovery_enabled = EXCLUDED.discovery_enabled,
+			last_success_at = EXCLUDED.last_success_at,
+			fresh_until_at = EXCLUDED.fresh_until_at,
+			updated_at = now()
+	`, sourceKind, sourceName, lastSuccessAt.UTC(), freshUntilAt.UTC()); err != nil {
+		t.Fatalf("upsert connector_source_state %s/%s: %v", sourceKind, sourceName, err)
+	}
+}
+
+func fetchNonHumanProjectionRefreshedAt(t *testing.T, ctx context.Context, pool *pgxpool.Pool, principalRef string) pgtype.Timestamptz {
+	t.Helper()
+
+	var refreshedAt pgtype.Timestamptz
+	if err := pool.QueryRow(ctx, `
+		SELECT projection_refreshed_at
+		FROM non_human_principals
+		WHERE principal_ref = $1
+	`, principalRef).Scan(&refreshedAt); err != nil {
+		t.Fatalf("select non_human_principals projection_refreshed_at: %v", err)
+	}
+	return refreshedAt
 }
 
 func fetchConnectorSourceStateTimes(t *testing.T, ctx context.Context, pool *pgxpool.Pool, sourceKind, sourceName string) (time.Time, time.Time) {

--- a/internal/readmodels/projector_integration_test.go
+++ b/internal/readmodels/projector_integration_test.go
@@ -157,6 +157,9 @@ func TestProjectorRefreshAllNonHumanPrincipalReadModelsEvaluatesAndStoresPolicy(
 		}
 
 		projector := NewProjector(pool, nil, RefreshConfig{})
+		if err := projector.RefreshAllCredentialArtifactRiskReadModels(ctx); err != nil {
+			t.Fatalf("RefreshAllCredentialArtifactRiskReadModels(): %v", err)
+		}
 		if err := projector.RefreshAllNonHumanPrincipalReadModels(ctx); err != nil {
 			t.Fatalf("RefreshAllNonHumanPrincipalReadModels(): %v", err)
 		}
@@ -454,6 +457,73 @@ func TestProjectorNonHumanPolicyRiskFeedsFiltersSortAndMetrics(t *testing.T) {
 		if credentialCoverage.HighRiskCredentialCount != wantHighRiskCredentials ||
 			credentialCoverage.HighRiskWithAttributionCount != wantHighRiskCredentialsWithAttribution {
 			t.Fatalf("credential coverage = %+v, want %d/%d", credentialCoverage, wantHighRiskCredentials, wantHighRiskCredentialsWithAttribution)
+		}
+	})
+}
+
+func TestProjectorRefreshCredentialArtifactRiskReadModelsBySourceEvaluatesAndStoresPolicy(t *testing.T) {
+	t.Parallel()
+
+	withReadModelsTestDatabase(t, func(ctx context.Context, pool *pgxpool.Pool, q *gen.Queries, migrator *migrate.Migrate) {
+		migrateUpReadModels(t, migrator)
+
+		now := time.Now().UTC().Truncate(time.Second)
+		runID := insertReadModelsSyncRun(t, ctx, pool, "github", "acme", now)
+		otherRunID := insertReadModelsSyncRun(t, ctx, pool, "entra", "tenant-1", now)
+		credentialID := insertReadModelsCredentialArtifact(t, ctx, pool, runID, readModelsCredentialArtifactSeed{
+			SourceKind:         "github",
+			SourceName:         "acme",
+			AssetRefKind:       "app_asset",
+			AssetRefExternalID: "github_app:automation",
+			CredentialKind:     "generic_api_key",
+			ExternalID:         "stale-key",
+			DisplayName:        "Stale Key",
+			Status:             "active",
+			LastUsedAtSource:   now.Add(-120 * 24 * time.Hour),
+		})
+		otherCredentialID := insertReadModelsCredentialArtifact(t, ctx, pool, otherRunID, readModelsCredentialArtifactSeed{
+			SourceKind:         "entra",
+			SourceName:         "tenant-1",
+			AssetRefKind:       "app_asset",
+			AssetRefExternalID: "entra_service_principal:automation",
+			CredentialKind:     "entra_client_secret",
+			ExternalID:         "other-secret",
+			DisplayName:        "Other Secret",
+			Status:             "active",
+			ExpiresAtSource:    now.Add(-24 * time.Hour),
+		})
+
+		projector := NewProjector(pool, nil, RefreshConfig{})
+		if err := projector.RefreshCredentialArtifactRiskReadModelsBySource(ctx, "github", "acme"); err != nil {
+			t.Fatalf("RefreshCredentialArtifactRiskReadModelsBySource(): %v", err)
+		}
+
+		var riskLevel string
+		var riskRank, signalCount, policyPackCount int
+		if err := pool.QueryRow(ctx, `
+			SELECT risk_level, risk_rank, jsonb_array_length(risk_signals_json), jsonb_array_length(policy_packs_json)
+			FROM credential_artifact_risk_read_models
+			WHERE credential_artifact_id = $1
+		`, credentialID).Scan(&riskLevel, &riskRank, &signalCount, &policyPackCount); err != nil {
+			t.Fatalf("select credential_artifact_risk_read_models: %v", err)
+		}
+		if riskLevel != "high" || riskRank != riskpolicy.SeverityRank(riskpolicy.SeverityHigh) {
+			t.Fatalf("stored credential risk = %q/%d, want high/%d", riskLevel, riskRank, riskpolicy.SeverityRank(riskpolicy.SeverityHigh))
+		}
+		if signalCount == 0 || policyPackCount == 0 {
+			t.Fatalf("stored credential policy output has signals=%d packs=%d, want both present", signalCount, policyPackCount)
+		}
+
+		var otherRiskRows int
+		if err := pool.QueryRow(ctx, `
+			SELECT count(*)
+			FROM credential_artifact_risk_read_models
+			WHERE credential_artifact_id = $1
+		`, otherCredentialID).Scan(&otherRiskRows); err != nil {
+			t.Fatalf("select other credential risk rows: %v", err)
+		}
+		if otherRiskRows != 0 {
+			t.Fatalf("other source credential risk rows = %d, want 0", otherRiskRows)
 		}
 	})
 }

--- a/internal/riskpolicy/evaluator.go
+++ b/internal/riskpolicy/evaluator.go
@@ -43,9 +43,10 @@ type CredentialInput struct {
 }
 
 type CredentialResult struct {
-	RiskLevel string
-	RiskRank  int
-	Signals   []RiskSignal
+	RiskLevel   string
+	RiskRank    int
+	PolicyPacks []PolicyPackRef
+	Signals     []RiskSignal
 }
 
 func EvaluateCredential(input CredentialInput) (CredentialResult, error) {
@@ -76,6 +77,7 @@ func (r *Registry) EvaluateCredential(input CredentialInput) (CredentialResult, 
 			continue
 		}
 		foundPack = true
+		result.PolicyPacks = appendPolicyPackRef(result.PolicyPacks, pack.Policy.Metadata)
 		if pack.Policy.Spec.Aggregation.RiskLevel.Default != "" {
 			defaultLevel = MaxSeverity(defaultLevel, pack.Policy.Spec.Aggregation.RiskLevel.Default)
 		}

--- a/internal/riskpolicy/evaluator.go
+++ b/internal/riskpolicy/evaluator.go
@@ -9,14 +9,14 @@ import (
 )
 
 type RiskSignal struct {
-	ID                string
-	Domain            Domain
-	Severity          string
-	ScoreDelta        int
-	Title             string
-	Evidence          string
-	PolicyPackID      string
-	PolicyPackVersion string
+	ID                string `json:"id"`
+	Domain            Domain `json:"domain"`
+	Severity          string `json:"severity"`
+	ScoreDelta        int    `json:"score_delta,omitempty"`
+	Title             string `json:"title"`
+	Evidence          string `json:"evidence,omitempty"`
+	PolicyPackID      string `json:"policy_pack_id"`
+	PolicyPackVersion string `json:"policy_pack_version"`
 }
 
 type PolicyPackRef struct {

--- a/internal/riskpolicy/evaluator_test.go
+++ b/internal/riskpolicy/evaluator_test.go
@@ -1,13 +1,8 @@
 package riskpolicy
 
 import (
-	"context"
 	"testing"
 	"time"
-
-	"github.com/golang-migrate/migrate/v4"
-	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/open-sspm/open-sspm/internal/testdb"
 )
 
 func TestEvaluateCredentialGoldenCases(t *testing.T) {
@@ -30,6 +25,9 @@ func TestEvaluateCredentialGoldenCases(t *testing.T) {
 			}
 			if result.RiskRank != SeverityRank(tc.wantLevel) {
 				t.Fatalf("RiskRank = %d, want %d", result.RiskRank, SeverityRank(tc.wantLevel))
+			}
+			if len(result.PolicyPacks) != 1 || result.PolicyPacks[0].ID != "builtin-credential-risk" {
+				t.Fatalf("PolicyPacks = %+v, want builtin credential pack", result.PolicyPacks)
 			}
 			gotSignalIDs := make([]string, 0, len(result.Signals))
 			for _, signal := range result.Signals {
@@ -65,47 +63,6 @@ func TestEvaluateCredentialRejectsMalformedScopeJSON(t *testing.T) {
 	if err == nil {
 		t.Fatal("EvaluateCredential() error = nil, want malformed scope_json error")
 	}
-}
-
-func TestEvaluateCredentialMatchesSQLFunction(t *testing.T) {
-	t.Parallel()
-
-	registry, err := LoadBuiltin()
-	if err != nil {
-		t.Fatalf("LoadBuiltin() error = %v", err)
-	}
-
-	testdb.WithDatabase(t, testdb.Options{NamePrefix: "opensspm_riskpolicy"}, func(ctx context.Context, pool *pgxpool.Pool, migrator *migrate.Migrate) {
-		testdb.MigrateUp(t, migrator)
-
-		for _, tc := range credentialGoldenCases() {
-			t.Run(tc.name, func(t *testing.T) {
-				result, err := registry.EvaluateCredential(tc.input)
-				if err != nil {
-					t.Fatalf("EvaluateCredential() error = %v", err)
-				}
-
-				var sqlLevel string
-				err = pool.QueryRow(ctx, `
-					SELECT credential_artifact_risk_level($1, $2, $3, $4, $5, $6, $7)
-				`,
-					tc.input.Status,
-					tc.input.CredentialKind,
-					nullableTime(tc.input.ExpiresAt),
-					nullableTime(tc.input.LastUsedAt),
-					tc.input.CreatedByExternalID,
-					tc.input.ApprovedByExternalID,
-					tc.input.EvaluatedAt,
-				).Scan(&sqlLevel)
-				if err != nil {
-					t.Fatalf("credential_artifact_risk_level() error = %v", err)
-				}
-				if result.RiskLevel != sqlLevel {
-					t.Fatalf("policy RiskLevel = %q, SQL risk_level = %q", result.RiskLevel, sqlLevel)
-				}
-			})
-		}
-	})
 }
 
 type credentialGoldenCase struct {

--- a/internal/riskpolicy/identity_evaluator.go
+++ b/internal/riskpolicy/identity_evaluator.go
@@ -1,0 +1,158 @@
+package riskpolicy
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+type IdentityInput struct {
+	IdentityID             int64
+	PrincipalRef           string
+	PrincipalType          string
+	SourceKind             string
+	SourceName             string
+	DisplayName            string
+	PrimaryEmail           string
+	LastSeenAt             *time.Time
+	OwnerPresence          string
+	GovernanceState        string
+	LinkedAssetsCount      int64
+	LinkedCredentialsCount int64
+	CredentialSignals      []string
+	HasCriticalCredential  bool
+	HasHighRiskCredential  bool
+	HasExpiredCredential   bool
+	HasExpiringCredential  bool
+	HasUnusedCredential    bool
+	HasStaleEvidence       bool
+}
+
+type IdentityResult struct {
+	RiskLevel       string
+	RiskRank        int
+	RiskReasonCount int
+	PolicyPacks     []PolicyPackRef
+	Signals         []RiskSignal
+}
+
+func EvaluateIdentity(input IdentityInput) (IdentityResult, error) {
+	registry, err := BuiltinRegistry()
+	if err != nil {
+		return IdentityResult{}, err
+	}
+	return registry.EvaluateIdentity(input)
+}
+
+func (r *Registry) EvaluateIdentity(input IdentityInput) (IdentityResult, error) {
+	if r == nil {
+		return IdentityResult{}, errors.New("risk policy registry is nil")
+	}
+
+	input = normalizeIdentityInput(input)
+	result := IdentityResult{
+		Signals: make([]RiskSignal, 0, 6),
+	}
+	defaultLevel := SeverityLow
+	var matchedPack *CompiledPack
+	for i := range r.packs {
+		if r.packs[i].Policy.Metadata.Domain != DomainIdentity || r.packs[i].Policy.Spec.Inputs.Schema != "identity_risk_input.v1" {
+			continue
+		}
+		if matchedPack != nil {
+			return IdentityResult{}, errors.New("multiple identity risk policy packs found for identity_risk_input.v1")
+		}
+		matchedPack = &r.packs[i]
+	}
+	if matchedPack == nil {
+		return IdentityResult{}, errors.New("identity risk policy pack not found")
+	}
+
+	pack := *matchedPack
+	result.PolicyPacks = appendPolicyPackRef(result.PolicyPacks, pack.Policy.Metadata)
+	if pack.Policy.Spec.Aggregation.RiskLevel.Default != "" {
+		defaultLevel = pack.Policy.Spec.Aggregation.RiskLevel.Default
+	}
+
+	activation := identityActivation(input, pack.Policy.Spec.Constants)
+	for _, rule := range pack.Policy.Spec.Rules {
+		matched, err := pack.evaluateBool(rule.ID, activation)
+		if err != nil {
+			return IdentityResult{}, err
+		}
+		if !matched {
+			continue
+		}
+
+		result.Signals = append(result.Signals, RiskSignal{
+			ID:                rule.ID,
+			Domain:            DomainIdentity,
+			Severity:          rule.Severity,
+			ScoreDelta:        rule.ScoreDelta,
+			Title:             rule.Title,
+			Evidence:          rule.Evidence,
+			PolicyPackID:      pack.Policy.Metadata.ID,
+			PolicyPackVersion: pack.Policy.Metadata.Version,
+		})
+		result.RiskLevel = MaxSeverity(result.RiskLevel, rule.Severity)
+	}
+
+	if result.RiskLevel == "" {
+		result.RiskLevel = defaultLevel
+	}
+	if pack.Policy.Spec.Aggregation.RiskReasonCount.Strategy == "count_matching_rules" {
+		result.RiskReasonCount = len(result.Signals)
+	}
+	result.RiskRank = SeverityRank(result.RiskLevel)
+	return result, nil
+}
+
+func normalizeIdentityInput(input IdentityInput) IdentityInput {
+	input.PrincipalRef = strings.TrimSpace(input.PrincipalRef)
+	input.PrincipalType = strings.ToLower(strings.TrimSpace(input.PrincipalType))
+	input.SourceKind = strings.ToLower(strings.TrimSpace(input.SourceKind))
+	input.SourceName = strings.TrimSpace(input.SourceName)
+	input.DisplayName = strings.TrimSpace(input.DisplayName)
+	input.PrimaryEmail = strings.ToLower(strings.TrimSpace(input.PrimaryEmail))
+	input.LastSeenAt = normalizeTimePtr(input.LastSeenAt)
+	input.OwnerPresence = strings.ToLower(strings.TrimSpace(input.OwnerPresence))
+	if input.OwnerPresence == "" {
+		input.OwnerPresence = "unknown"
+	}
+	input.GovernanceState = strings.ToLower(strings.TrimSpace(input.GovernanceState))
+	if input.GovernanceState == "" {
+		input.GovernanceState = "unreviewed"
+	}
+	for i := range input.CredentialSignals {
+		input.CredentialSignals[i] = strings.ToLower(strings.TrimSpace(input.CredentialSignals[i]))
+	}
+	return input
+}
+
+func identityActivation(input IdentityInput, constants map[string][]string) map[string]any {
+	activation := map[string]any{
+		"identity_id":              input.IdentityID,
+		"principal_ref":            input.PrincipalRef,
+		"principal_type":           input.PrincipalType,
+		"source_kind":              input.SourceKind,
+		"source_name":              input.SourceName,
+		"display_name":             input.DisplayName,
+		"primary_email":            input.PrimaryEmail,
+		"last_seen_at":             nullableTime(input.LastSeenAt),
+		"owner_presence":           input.OwnerPresence,
+		"governance_state":         input.GovernanceState,
+		"linked_assets_count":      input.LinkedAssetsCount,
+		"linked_credentials_count": input.LinkedCredentialsCount,
+		"credential_signals":       cloneSlice(input.CredentialSignals),
+		"has_critical_credential":  input.HasCriticalCredential,
+		"has_high_risk_credential": input.HasHighRiskCredential,
+		"has_expired_credential":   input.HasExpiredCredential,
+		"has_expiring_credential":  input.HasExpiringCredential,
+		"has_unused_credential":    input.HasUnusedCredential,
+		"has_stale_evidence":       input.HasStaleEvidence,
+	}
+	for name, values := range constants {
+		activation[name] = cloneSlice(values)
+	}
+	return activation
+}

--- a/internal/riskpolicy/identity_evaluator_test.go
+++ b/internal/riskpolicy/identity_evaluator_test.go
@@ -172,6 +172,17 @@ func identityGoldenCases() []identityGoldenCase {
 			wantSignalIDs:   []string{"linked_critical_credential"},
 		},
 		{
+			name: "critical linked credential with aggregate high flag",
+			input: with(func(input *IdentityInput) {
+				input.LinkedCredentialsCount = 1
+				input.HasCriticalCredential = true
+				input.HasHighRiskCredential = true
+			}),
+			wantLevel:       SeverityCritical,
+			wantReasonCount: 1,
+			wantSignalIDs:   []string{"linked_critical_credential"},
+		},
+		{
 			name: "unknown owner",
 			input: with(func(input *IdentityInput) {
 				input.OwnerPresence = "unknown"

--- a/internal/riskpolicy/identity_evaluator_test.go
+++ b/internal/riskpolicy/identity_evaluator_test.go
@@ -1,0 +1,292 @@
+package riskpolicy
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEvaluateIdentityGoldenCases(t *testing.T) {
+	t.Parallel()
+
+	registry, err := LoadBuiltin()
+	if err != nil {
+		t.Fatalf("LoadBuiltin() error = %v", err)
+	}
+
+	for _, tc := range identityGoldenCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := registry.EvaluateIdentity(tc.input)
+			if err != nil {
+				t.Fatalf("EvaluateIdentity() error = %v", err)
+			}
+			if result.RiskLevel != tc.wantLevel {
+				t.Fatalf("RiskLevel = %q, want %q; signals=%+v", result.RiskLevel, tc.wantLevel, result.Signals)
+			}
+			if result.RiskRank != SeverityRank(tc.wantLevel) {
+				t.Fatalf("RiskRank = %d, want %d", result.RiskRank, SeverityRank(tc.wantLevel))
+			}
+			if result.RiskReasonCount != tc.wantReasonCount {
+				t.Fatalf("RiskReasonCount = %d, want %d; signals=%+v", result.RiskReasonCount, tc.wantReasonCount, result.Signals)
+			}
+			if len(result.PolicyPacks) != 1 || result.PolicyPacks[0].ID != "builtin-identity-risk" || result.PolicyPacks[0].Version == "" {
+				t.Fatalf("PolicyPacks = %+v, want builtin identity pack metadata", result.PolicyPacks)
+			}
+
+			gotSignalIDs := make([]string, 0, len(result.Signals))
+			for _, signal := range result.Signals {
+				gotSignalIDs = append(gotSignalIDs, signal.ID)
+				if signal.Domain != DomainIdentity {
+					t.Fatalf("signal domain = %q, want identity", signal.Domain)
+				}
+				if signal.PolicyPackID == "" || signal.PolicyPackVersion == "" {
+					t.Fatalf("signal missing source policy metadata: %+v", signal)
+				}
+			}
+			if !sameStringSet(gotSignalIDs, tc.wantSignalIDs) {
+				t.Fatalf("signal IDs = %v, want %v", gotSignalIDs, tc.wantSignalIDs)
+			}
+		})
+	}
+}
+
+func TestEvaluateIdentityRejectsDuplicateGlobalPacks(t *testing.T) {
+	t.Parallel()
+
+	registry, err := LoadDocuments(map[string][]byte{
+		"a.yaml": []byte(`
+api_version: risk.open-sspm.io/v1
+kind: RiskPolicyPack
+metadata:
+  id: a
+  version: 1.0.0
+  domain: identity
+spec:
+  inputs:
+    schema: identity_risk_input.v1
+  rules:
+    - id: low
+      severity: low
+      when: "true"
+      title: Low risk
+`),
+		"b.yaml": []byte(`
+api_version: risk.open-sspm.io/v1
+kind: RiskPolicyPack
+metadata:
+  id: b
+  version: 1.0.0
+  domain: identity
+spec:
+  inputs:
+    schema: identity_risk_input.v1
+  rules:
+    - id: low
+      severity: low
+      when: "true"
+      title: Low risk
+`),
+	})
+	if err != nil {
+		t.Fatalf("LoadDocuments() error = %v", err)
+	}
+
+	_, err = registry.EvaluateIdentity(IdentityInput{})
+	if err == nil {
+		t.Fatal("EvaluateIdentity() error = nil, want duplicate pack error")
+	}
+	if !strings.Contains(err.Error(), "multiple identity risk policy packs") {
+		t.Fatalf("EvaluateIdentity() error = %v, want duplicate pack error", err)
+	}
+}
+
+func TestEvaluateIdentityNormalizesInput(t *testing.T) {
+	t.Parallel()
+
+	registry, err := LoadBuiltin()
+	if err != nil {
+		t.Fatalf("LoadBuiltin() error = %v", err)
+	}
+
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	result, err := registry.EvaluateIdentity(IdentityInput{
+		PrincipalType:        " SERVICE ",
+		SourceKind:           " ENTRA ",
+		SourceName:           " Tenant ",
+		PrimaryEmail:         " SVC@example.COM ",
+		LastSeenAt:           timePtr(now),
+		OwnerPresence:        " UNKNOWN ",
+		GovernanceState:      " REVIEWED ",
+		CredentialSignals:    []string{" Linked_Expired_Credential "},
+		HasExpiredCredential: true,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateIdentity() error = %v", err)
+	}
+	if result.RiskLevel != SeverityHigh {
+		t.Fatalf("RiskLevel = %q, want high", result.RiskLevel)
+	}
+	if !sameStringSet(signalIDs(result.Signals), []string{"missing_accountable_owner", "linked_expired_credential"}) {
+		t.Fatalf("signal IDs = %v, want owner and expired credential signals", signalIDs(result.Signals))
+	}
+}
+
+type identityGoldenCase struct {
+	name            string
+	input           IdentityInput
+	wantLevel       string
+	wantReasonCount int
+	wantSignalIDs   []string
+}
+
+func identityGoldenCases() []identityGoldenCase {
+	base := IdentityInput{
+		IdentityID:        42,
+		PrincipalRef:      "identity-42",
+		PrincipalType:     "service",
+		SourceKind:        "entra",
+		SourceName:        "tenant-1",
+		DisplayName:       "svc-deploy",
+		PrimaryEmail:      "svc-deploy@example.com",
+		OwnerPresence:     "owned",
+		GovernanceState:   "reviewed",
+		LinkedAssetsCount: 1,
+	}
+	with := func(mutator func(*IdentityInput)) IdentityInput {
+		input := base
+		mutator(&input)
+		return input
+	}
+
+	return []identityGoldenCase{
+		{
+			name: "critical linked credential",
+			input: with(func(input *IdentityInput) {
+				input.LinkedCredentialsCount = 1
+				input.HasCriticalCredential = true
+			}),
+			wantLevel:       SeverityCritical,
+			wantReasonCount: 1,
+			wantSignalIDs:   []string{"linked_critical_credential"},
+		},
+		{
+			name: "unknown owner",
+			input: with(func(input *IdentityInput) {
+				input.OwnerPresence = "unknown"
+			}),
+			wantLevel:       SeverityHigh,
+			wantReasonCount: 1,
+			wantSignalIDs:   []string{"missing_accountable_owner"},
+		},
+		{
+			name: "high risk linked credential",
+			input: with(func(input *IdentityInput) {
+				input.LinkedCredentialsCount = 1
+				input.HasHighRiskCredential = true
+			}),
+			wantLevel:       SeverityHigh,
+			wantReasonCount: 1,
+			wantSignalIDs:   []string{"linked_high_risk_credential"},
+		},
+		{
+			name: "expired linked credential",
+			input: with(func(input *IdentityInput) {
+				input.LinkedCredentialsCount = 1
+				input.HasExpiredCredential = true
+			}),
+			wantLevel:       SeverityHigh,
+			wantReasonCount: 1,
+			wantSignalIDs:   []string{"linked_expired_credential"},
+		},
+		{
+			name: "unreviewed high risk credential",
+			input: with(func(input *IdentityInput) {
+				input.GovernanceState = "unreviewed"
+				input.LinkedCredentialsCount = 1
+				input.HasHighRiskCredential = true
+			}),
+			wantLevel:       SeverityHigh,
+			wantReasonCount: 2,
+			wantSignalIDs:   []string{"linked_high_risk_credential", "unreviewed_risky_principal"},
+		},
+		{
+			name: "unreviewed expiring evidence is high",
+			input: with(func(input *IdentityInput) {
+				input.GovernanceState = "unreviewed"
+				input.LinkedCredentialsCount = 1
+				input.HasExpiringCredential = true
+			}),
+			wantLevel:       SeverityHigh,
+			wantReasonCount: 2,
+			wantSignalIDs:   []string{"unreviewed_risky_principal", "stale_or_unused_evidence"},
+		},
+		{
+			name: "unreviewed unused evidence is high",
+			input: with(func(input *IdentityInput) {
+				input.GovernanceState = "unreviewed"
+				input.LinkedCredentialsCount = 1
+				input.HasUnusedCredential = true
+			}),
+			wantLevel:       SeverityHigh,
+			wantReasonCount: 2,
+			wantSignalIDs:   []string{"unreviewed_risky_principal", "stale_or_unused_evidence"},
+		},
+		{
+			name: "reviewed expiring evidence is medium",
+			input: with(func(input *IdentityInput) {
+				input.LinkedCredentialsCount = 1
+				input.HasExpiringCredential = true
+			}),
+			wantLevel:       SeverityMedium,
+			wantReasonCount: 1,
+			wantSignalIDs:   []string{"stale_or_unused_evidence"},
+		},
+		{
+			name: "reviewed unused evidence is medium",
+			input: with(func(input *IdentityInput) {
+				input.LinkedCredentialsCount = 1
+				input.HasUnusedCredential = true
+			}),
+			wantLevel:       SeverityMedium,
+			wantReasonCount: 1,
+			wantSignalIDs:   []string{"stale_or_unused_evidence"},
+		},
+		{
+			name: "reviewed stale evidence is medium",
+			input: with(func(input *IdentityInput) {
+				input.HasStaleEvidence = true
+			}),
+			wantLevel:       SeverityMedium,
+			wantReasonCount: 1,
+			wantSignalIDs:   []string{"stale_or_unused_evidence"},
+		},
+		{
+			name: "in review expiring evidence remains medium",
+			input: with(func(input *IdentityInput) {
+				input.GovernanceState = "in_review"
+				input.LinkedCredentialsCount = 1
+				input.HasExpiringCredential = true
+			}),
+			wantLevel:       SeverityMedium,
+			wantReasonCount: 1,
+			wantSignalIDs:   []string{"stale_or_unused_evidence"},
+		},
+		{
+			name:            "low risk owned principal",
+			input:           base,
+			wantLevel:       SeverityLow,
+			wantReasonCount: 0,
+			wantSignalIDs:   nil,
+		},
+	}
+}
+
+func signalIDs(signals []RiskSignal) []string {
+	ids := make([]string, 0, len(signals))
+	for _, signal := range signals {
+		ids = append(ids, signal.ID)
+	}
+	return ids
+}

--- a/internal/riskpolicy/policies/identity.v1.yaml
+++ b/internal/riskpolicy/policies/identity.v1.yaml
@@ -18,7 +18,7 @@ spec:
       title: No accountable owner
     - id: linked_high_risk_credential
       severity: high
-      when: has_high_risk_credential
+      when: has_high_risk_credential && !has_critical_credential
       title: Linked credential is high risk
     - id: linked_expired_credential
       severity: high

--- a/internal/riskpolicy/policies/identity.v1.yaml
+++ b/internal/riskpolicy/policies/identity.v1.yaml
@@ -26,7 +26,7 @@ spec:
       title: Linked credential is expired
     - id: unreviewed_risky_principal
       severity: high
-      when: governance_state != "reviewed" && (has_high_risk_credential || has_expired_credential || has_stale_evidence)
+      when: governance_state == "unreviewed" && (has_high_risk_credential || has_expired_credential || has_expiring_credential || has_unused_credential || has_stale_evidence)
       title: Unreviewed principal has risky evidence
     - id: stale_or_unused_evidence
       severity: medium


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires non-human principal read-model refresh to the CEL-based identity evaluator: two new DB migrations add `risk_signals_json` / `policy_packs_json` columns to `non_human_principals`, new SQL queries expose the projection data as evaluator inputs, and the projector fetches, evaluates, and bulk-upserts risk outputs atomically inside a transaction. Two previously flagged P2s (silent JSON unmarshal discard and in-place filter alias) are correctly resolved in this PR.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all changes are transactionally guarded and the only open items are P2 documentation/future-proofing concerns.

No P0 or P1 findings. The two remaining P2s (primary_email aliased from secondary_name now in the live CEL path, and CredentialSignals always empty) have no current mis-evaluation impact since no active rules consume those fields.

db/queries/read_models.sql (primary_email alias) and internal/readmodels/projector.go (CredentialSignals gap) warrant a quick follow-up when identity policy rules are extended.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/readmodels/projector.go | Adds full non-human principal risk model refresh: fetch from projection view, delete-all (atomic via transaction), bulk upsert with evaluator output; per-source path follows the same pattern. `CredentialSignals` is always empty in the identity input (P2). |
| db/queries/read_models.sql | Adds ListAllNonHumanPrincipalRiskInputs, ListNonHumanPrincipalRiskInputsBySource, UpsertNonHumanPrincipalReadModelsBulk, and delete helpers; `primary_email` is aliased from `secondary_name` with a comment acknowledging the design, now actively fed to CEL (P2). |
| db/migrations/000049_non_human_policy_signal_storage.up.sql | Adds risk_signals_json and policy_packs_json columns to non_human_principals, creates a composite index on (source_kind, source_name, risk_level, owner_presence, governance_state, freshness_state), and recreates the read models view to expose the new columns. |
| internal/riskpolicy/identity_evaluator.go | EvaluateIdentity correctly matches the single identity_risk_input.v1 pack, normalizes input, evaluates all rules, computes max severity and reason count; error on missing or duplicate packs is clean. |
| internal/http/handlers/non_human_access.go | nonHumanPrincipalRiskSignals now logs the unmarshal error (previous P2 fixed) and uses a fresh slice instead of signals[:0] (previous P2 fixed); clean implementation. |
| cmd/open-sspm/read_models.go | Adds RefreshAllCredentialArtifactRiskReadModels and RefreshAllNonHumanPrincipalReadModels to the startup refresh path; each runs in its own transaction, consistent with the existing multi-step pattern. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Startup as Startup / Sync Hook
    participant Projector as readmodels.Projector
    participant DB as PostgreSQL (pgx tx)
    participant View as non_human_principal_projection_v
    participant Evaluator as riskpolicy.Registry.EvaluateIdentity
    participant Table as non_human_principals

    Startup->>Projector: RefreshAllNonHumanPrincipalReadModels(ctx)
    Projector->>DB: BEGIN TRANSACTION
    DB->>View: ListAllNonHumanPrincipalRiskInputs
    View-->>DB: []riskInputRows (with secondary_name as primary_email)
    DB-->>Projector: rows
    loop for each row
        Projector->>Evaluator: EvaluateIdentity(IdentityInput)
        Evaluator-->>Projector: IdentityResult {RiskLevel, Signals, PolicyPacks}
    end
    Projector->>DB: DeleteAllNonHumanPrincipalReadModels
    DB->>Table: DELETE FROM non_human_principals
    Projector->>DB: UpsertNonHumanPrincipalReadModelsBulk
    DB->>Table: INSERT ON CONFLICT DO UPDATE
    DB-->>Projector: COMMIT
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `internal/http/handlers/non_human_access.go`, line 1159-1171 ([link](https://github.com/open-sspm/open-sspm/blob/081543337b9adb739c5cbeeb9d5f976142714d6d/internal/http/handlers/non_human_access.go#L1159-L1171)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **In-place filter shares backing array with `signals`**

   `filtered := signals[:0]` creates a slice that shares the same underlying array as `signals`. While safe here because `signals` is a local value-copied range variable and `filtered` never grows beyond `signals` length, this pattern is subtly aliasing and easy to misread. A clean alternative avoids any shared backing array:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/http/handlers/non_human_access.go
   Line: 1159-1171

   Comment:
   **In-place filter shares backing array with `signals`**

   `filtered := signals[:0]` creates a slice that shares the same underlying array as `signals`. While safe here because `signals` is a local value-copied range variable and `filtered` never grows beyond `signals` length, this pattern is subtly aliasing and easy to misread. A clean alternative avoids any shared backing array:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `internal/http/handlers/non_human_access.go`, line 1137-1138 ([link](https://github.com/open-sspm/open-sspm/blob/081543337b9adb739c5cbeeb9d5f976142714d6d/internal/http/handlers/non_human_access.go#L1137-L1138)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **JSON unmarshal error silently discarded**

   When `json.Unmarshal` fails (e.g., corrupted `risk_signals_json` in the DB), the function returns `nil` with no log or observable signal. The caller and the UI will show an empty risk signals list with no indication that anything went wrong, making this class of corruption invisible in production. Consider at least logging the error before returning `nil`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/http/handlers/non_human_access.go
   Line: 1137-1138

   Comment:
   **JSON unmarshal error silently discarded**

   When `json.Unmarshal` fails (e.g., corrupted `risk_signals_json` in the DB), the function returns `nil` with no log or observable signal. The caller and the UI will show an empty risk signals list with no indication that anything went wrong, making this class of corruption invisible in production. Consider at least logging the error before returning `nil`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `db/queries/read_models.sql`, line 211-212 ([link](https://github.com/open-sspm/open-sspm/blob/081543337b9adb739c5cbeeb9d5f976142714d6d/db/queries/read_models.sql#L211-L212)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`primary_email` aliased from `secondary_name`**

   Both `ListAllNonHumanPrincipalRiskInputs` and `ListNonHumanPrincipalRiskInputsBySource` select `pr.secondary_name::text AS primary_email`, so `IdentityInput.PrimaryEmail` passed to CEL evaluation is always identical to `secondary_name`. None of the current rules in `identity.v1.yaml` consume `primary_email`, so there is no immediate mis-evaluation — but if a future rule is added that uses `primary_email`, it will silently receive `secondary_name` instead of a real email address. If `secondary_name` is intentionally the canonical email for non-human identities, a comment explaining this design choice would prevent future confusion.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: db/queries/read_models.sql
   Line: 211-212

   Comment:
   **`primary_email` aliased from `secondary_name`**

   Both `ListAllNonHumanPrincipalRiskInputs` and `ListNonHumanPrincipalRiskInputsBySource` select `pr.secondary_name::text AS primary_email`, so `IdentityInput.PrimaryEmail` passed to CEL evaluation is always identical to `secondary_name`. None of the current rules in `identity.v1.yaml` consume `primary_email`, so there is no immediate mis-evaluation — but if a future rule is added that uses `primary_email`, it will silently receive `secondary_name` instead of a real email address. If `secondary_name` is intentionally the canonical email for non-human identities, a comment explaining this design choice would prevent future confusion.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: db/queries/read_models.sql
Line: 683

Comment:
**`primary_email` aliased from `secondary_name` now feeds CEL evaluation**

The SQL comment acknowledges the design choice, but now that `primary_email` is actively mapped into `IdentityInput.PrimaryEmail` and exposed to CEL rules via `identityActivation`, any future rule that checks `primary_email` will silently receive the `secondary_name` value (which may be an external ID fallback, not an email address). This is low-risk today since `identity.v1.yaml` contains no rule that tests `primary_email`, but the exposure surface is now live. A follow-up task to either derive the real email at the projection level or document in the policy schema that `primary_email` equals `secondary_name` for non-human principals would reduce future confusion.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/readmodels/projector.go
Line: 802-823

Comment:
**`CredentialSignals` always empty for non-human principals**

`IdentityInput.CredentialSignals []string` is never populated in `nonHumanPrincipalPolicyInput` (the `nonHumanPrincipalRiskInputRow` struct has no corresponding field, and no SQL column is selected for it). CEL receives `credential_signals` as an empty list for every non-human principal. No current rule in `identity.v1.yaml` consumes `credential_signals`, so evaluation is unaffected today, but any future rule that tests membership in `credential_signals` will always see `[]`. If this field is intentionally unused for non-human identities, a comment saying so would prevent future confusion.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Log malformed non-human risk signals and..."](https://github.com/open-sspm/open-sspm/commit/859c91d695850213ef195ae8adf04a4ae6550853) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29714166)</sub>

<!-- /greptile_comment -->