### PR TITLE
feat: expose rules in settings

### DIFF
--- a/internal/http/handlers/settings.go
+++ b/internal/http/handlers/settings.go
@@ -78,13 +78,13 @@ func riskPolicyPackSummaries(registry *riskpolicy.Registry) []viewmodels.RiskPol
 	if registry == nil {
 		return nil
 	}
-	packs := registry.Packs()
-	summaries := make([]viewmodels.RiskPolicyPackSummary, 0, len(packs))
-	for _, pack := range packs {
+	metadatas := registry.PackMetadatas()
+	summaries := make([]viewmodels.RiskPolicyPackSummary, 0, len(metadatas))
+	for _, metadata := range metadatas {
 		summaries = append(summaries, viewmodels.RiskPolicyPackSummary{
-			Domain:  string(pack.Metadata.Domain),
-			ID:      pack.Metadata.ID,
-			Version: pack.Metadata.Version,
+			Domain:  string(metadata.Domain),
+			ID:      metadata.ID,
+			Version: metadata.Version,
 		})
 	}
 	sort.SliceStable(summaries, func(i, j int) bool {

--- a/internal/http/handlers/settings.go
+++ b/internal/http/handlers/settings.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/labstack/echo/v5"
@@ -13,6 +14,7 @@ import (
 	"github.com/open-sspm/open-sspm/internal/http/views"
 	"github.com/open-sspm/open-sspm/internal/identity"
 	"github.com/open-sspm/open-sspm/internal/readmodels"
+	"github.com/open-sspm/open-sspm/internal/riskpolicy"
 	"github.com/open-sspm/open-sspm/internal/sync"
 )
 
@@ -65,9 +67,40 @@ func (h *Handlers) HandleSettings(c *echo.Context) error {
 		SyncDiscoveryEnabled:  h.Cfg.SyncDiscoveryEnabled,
 		ResyncEnabled:         h.Syncer != nil,
 		ResyncBanner:          banner,
+		RiskPolicyPacks:       riskPolicyPackSummaries(h.RiskPolicies),
+		RiskPolicyExpressions: riskPolicyExpressionCount(h.RiskPolicies),
 	}
 
 	return h.RenderComponent(c, views.SettingsPage(data))
+}
+
+func riskPolicyPackSummaries(registry *riskpolicy.Registry) []viewmodels.RiskPolicyPackSummary {
+	if registry == nil {
+		return nil
+	}
+	packs := registry.Packs()
+	summaries := make([]viewmodels.RiskPolicyPackSummary, 0, len(packs))
+	for _, pack := range packs {
+		summaries = append(summaries, viewmodels.RiskPolicyPackSummary{
+			Domain:  string(pack.Metadata.Domain),
+			ID:      pack.Metadata.ID,
+			Version: pack.Metadata.Version,
+		})
+	}
+	sort.SliceStable(summaries, func(i, j int) bool {
+		if summaries[i].Domain != summaries[j].Domain {
+			return summaries[i].Domain < summaries[j].Domain
+		}
+		return summaries[i].ID < summaries[j].ID
+	})
+	return summaries
+}
+
+func riskPolicyExpressionCount(registry *riskpolicy.Registry) int {
+	if registry == nil {
+		return 0
+	}
+	return registry.CompiledExpressionCount()
 }
 
 // HandleConnectors renders the connectors page.

--- a/internal/http/handlers/settings_test.go
+++ b/internal/http/handlers/settings_test.go
@@ -1,0 +1,42 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/open-sspm/open-sspm/internal/riskpolicy"
+)
+
+func TestRiskPolicyPackSummariesAreSortedForSettings(t *testing.T) {
+	t.Parallel()
+
+	registry, err := riskpolicy.LoadBuiltin()
+	if err != nil {
+		t.Fatalf("LoadBuiltin() error = %v", err)
+	}
+
+	summaries := riskPolicyPackSummaries(registry)
+	if len(summaries) != registry.PackCount() {
+		t.Fatalf("summaries len = %d, want %d", len(summaries), registry.PackCount())
+	}
+	if got := riskPolicyExpressionCount(registry); got != registry.CompiledExpressionCount() || got == 0 {
+		t.Fatalf("riskPolicyExpressionCount() = %d, want %d", got, registry.CompiledExpressionCount())
+	}
+
+	for i := 1; i < len(summaries); i++ {
+		previous := summaries[i-1]
+		current := summaries[i]
+		if previous.Domain > current.Domain || previous.Domain == current.Domain && previous.ID > current.ID {
+			t.Fatalf("summaries not sorted at %d: %+v before %+v", i, previous, current)
+		}
+	}
+
+	foundCredential := false
+	for _, summary := range summaries {
+		if summary.Domain == "credential" && summary.ID == "builtin-credential-risk" && summary.Version != "" {
+			foundCredential = true
+		}
+	}
+	if !foundCredential {
+		t.Fatalf("summaries missing built-in credential policy: %+v", summaries)
+	}
+}

--- a/internal/http/viewmodels/settings.go
+++ b/internal/http/viewmodels/settings.go
@@ -6,6 +6,12 @@ type ResyncBanner struct {
 	Message string
 }
 
+type RiskPolicyPackSummary struct {
+	Domain  string
+	ID      string
+	Version string
+}
+
 type SettingsViewData struct {
 	Layout                LayoutData
 	SyncInterval          string
@@ -13,4 +19,6 @@ type SettingsViewData struct {
 	SyncDiscoveryEnabled  bool
 	ResyncEnabled         bool
 	ResyncBanner          *ResyncBanner
+	RiskPolicyPacks       []RiskPolicyPackSummary
+	RiskPolicyExpressions int
 }

--- a/internal/http/views/settings.templ
+++ b/internal/http/views/settings.templ
@@ -4,45 +4,82 @@ import "github.com/open-sspm/open-sspm/internal/http/viewmodels"
 
 templ SettingsPage(data viewmodels.SettingsViewData) {
 	@Layout(data.Layout) {
-		@PageHeader("") {
-			<a class="btn-sm-outline" href="/settings/connector-health">Connector health</a>
-		}
-
 		if data.ResyncBanner != nil {
 			@Alert(data.ResyncBanner.Title, IsAlertDestructive(data.ResyncBanner.Class)) {
 				<p>{ data.ResyncBanner.Message }</p>
 			}
 		}
 
-		<section class="grid gap-6 lg:grid-cols-2">
-			<article class="card">
-				<header>
-					<h2>Resync data</h2>
-					<p>Run a sync immediately.</p>
-				</header>
-				<section class="space-y-3">
-					if data.SyncDiscoveryEnabled {
-						<p class="text-muted-foreground">
-							Trigger immediate full + discovery sync lanes. Full sync refreshes identities and app access; discovery sync ingests discovery signals for enabled connectors.
-						</p>
-					} else {
-						<p class="text-muted-foreground">
-							Trigger the immediate full sync lane. Discovery sync is disabled on this server.
-						</p>
-					}
-					<div class="flex flex-wrap items-center gap-4">
-						<form method="post" action="/settings/resync">
-							@CSRFInput(data.Layout.CSRFToken)
-							<button type="submit" class="btn-primary" disabled?={ !data.ResyncEnabled }>Resync now</button>
-						</form>
+		<section class="space-y-8">
+			<section class="space-y-3">
+				<div class="flex flex-col gap-3 border-b border-border pb-3 md:flex-row md:items-end md:justify-between">
+					<div>
+						<h2 class="text-base font-semibold">System operations</h2>
+						<p class="text-sm text-muted-foreground">Run sync lanes and inspect connector health.</p>
+					</div>
+					<a class="btn-sm-outline" href="/settings/connector-health">Connector health</a>
+				</div>
+				<div class="flex flex-col gap-4 rounded-md border border-border bg-card px-4 py-4 md:flex-row md:items-center md:justify-between">
+					<div class="min-w-0">
+						<div class="flex flex-wrap items-center gap-x-3 gap-y-1">
+							<h3 class="text-sm font-semibold">Sync</h3>
+							if data.SyncDiscoveryEnabled {
+								<span class="text-xs text-muted-foreground">{ "Full " }{ data.SyncInterval }{ " · Discovery " }{ data.SyncDiscoveryInterval }</span>
+							} else {
+								<span class="text-xs text-muted-foreground">{ "Full " }{ data.SyncInterval }{ " · Discovery disabled" }</span>
+							}
+						</div>
 						if data.SyncDiscoveryEnabled {
-							<div class="text-sm text-muted-foreground">{ "Worker intervals (if running): full " }{ data.SyncInterval }{ " · discovery " }{ data.SyncDiscoveryInterval }</div>
+							<p class="mt-1 text-sm text-muted-foreground">Refresh identities, app access, and discovery signals.</p>
 						} else {
-							<div class="text-sm text-muted-foreground">{ "Worker interval (if running): " }{ data.SyncInterval }</div>
+							<p class="mt-1 text-sm text-muted-foreground">Refresh identities and app access.</p>
 						}
 					</div>
-				</section>
-			</article>
+					<div class="shrink-0">
+						<form method="post" action="/settings/resync">
+							@CSRFInput(data.Layout.CSRFToken)
+							<button type="submit" class="btn-sm-primary" disabled?={ !data.ResyncEnabled }>Resync now</button>
+						</form>
+					</div>
+				</div>
+			</section>
+
+			<section class="space-y-3">
+				<div class="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+					<div>
+						<h2 class="text-base font-semibold">Risk policies</h2>
+						<p class="text-sm text-muted-foreground">Built-in policy packs loaded by this server.</p>
+					</div>
+					<div class="text-xs text-muted-foreground">
+						{ FormatInt(len(data.RiskPolicyPacks)) }{ pluralizeSuffix(len(data.RiskPolicyPacks), " pack", " packs") }{ " · " }{ FormatInt(data.RiskPolicyExpressions) }{ pluralizeSuffix(data.RiskPolicyExpressions, " CEL expression", " CEL expressions") }
+					</div>
+				</div>
+				if len(data.RiskPolicyPacks) > 0 {
+					@ColumnsTable("") {
+						<table class="table osspm-table-fixed osspm-table-compact osspm-table-list align-top">
+							<caption class="sr-only">Active risk policy packs loaded by this server.</caption>
+							<thead>
+								<tr>
+									<th class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Domain</th>
+									<th class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Policy pack</th>
+									<th class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Version</th>
+								</tr>
+							</thead>
+							<tbody>
+								for _, pack := range data.RiskPolicyPacks {
+									<tr>
+										<td class="text-muted-foreground whitespace-nowrap">{ pack.Domain }</td>
+										<td class="font-medium">{ pack.ID }</td>
+										<td class="text-muted-foreground whitespace-nowrap">{ pack.Version }</td>
+									</tr>
+								}
+							</tbody>
+						</table>
+					}
+				} else {
+					<p class="text-sm text-muted-foreground">No policy packs loaded.</p>
+				}
+			</section>
 
 		</section>
 	}

--- a/internal/http/views/settings_templ.go
+++ b/internal/http/views/settings_templ.go
@@ -43,34 +43,8 @@ func SettingsPage(data viewmodels.SettingsViewData) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Var3 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-				if !templ_7745c5c3_IsBuffer {
-					defer func() {
-						templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-						if templ_7745c5c3_Err == nil {
-							templ_7745c5c3_Err = templ_7745c5c3_BufErr
-						}
-					}()
-				}
-				ctx = templ.InitializeContext(ctx)
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<a class=\"btn-sm-outline\" href=\"/settings/connector-health\">Connector health</a>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				return nil
-			})
-			templ_7745c5c3_Err = PageHeader("").Render(templ.WithChildren(ctx, templ_7745c5c3_Var3), templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, " ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
 			if data.ResyncBanner != nil {
-				templ_7745c5c3_Var4 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+				templ_7745c5c3_Var3 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 					templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 					templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 					if !templ_7745c5c3_IsBuffer {
@@ -82,46 +56,132 @@ func SettingsPage(data viewmodels.SettingsViewData) templ.Component {
 						}()
 					}
 					ctx = templ.InitializeContext(ctx)
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<p>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<p>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var5 string
-					templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(data.ResyncBanner.Message)
+					var templ_7745c5c3_Var4 string
+					templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(data.ResyncBanner.Message)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 13, Col: 34}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 9, Col: 34}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</p>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</p>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					return nil
 				})
-				templ_7745c5c3_Err = Alert(data.ResyncBanner.Title, IsAlertDestructive(data.ResyncBanner.Class)).Render(templ.WithChildren(ctx, templ_7745c5c3_Var4), templ_7745c5c3_Buffer)
+				templ_7745c5c3_Err = Alert(data.ResyncBanner.Title, IsAlertDestructive(data.ResyncBanner.Class)).Render(templ.WithChildren(ctx, templ_7745c5c3_Var3), templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, " <section class=\"grid gap-6 lg:grid-cols-2\"><article class=\"card\"><header><h2>Resync data</h2><p>Run a sync immediately.</p></header><section class=\"space-y-3\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, " <section class=\"space-y-8\"><section class=\"space-y-3\"><div class=\"flex flex-col gap-3 border-b border-border pb-3 md:flex-row md:items-end md:justify-between\"><div><h2 class=\"text-base font-semibold\">System operations</h2><p class=\"text-sm text-muted-foreground\">Run sync lanes and inspect connector health.</p></div><a class=\"btn-sm-outline\" href=\"/settings/connector-health\">Connector health</a></div><div class=\"flex flex-col gap-4 rounded-md border border-border bg-card px-4 py-4 md:flex-row md:items-center md:justify-between\"><div class=\"min-w-0\"><div class=\"flex flex-wrap items-center gap-x-3 gap-y-1\"><h3 class=\"text-sm font-semibold\">Sync</h3>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if data.SyncDiscoveryEnabled {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<p class=\"text-muted-foreground\">Trigger immediate full + discovery sync lanes. Full sync refreshes identities and app access; discovery sync ingests discovery signals for enabled connectors.</p>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<span class=\"text-xs text-muted-foreground\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var5 string
+				templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs("Full ")
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 27, Col: 61}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var6 string
+				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(data.SyncInterval)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 27, Col: 82}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var7 string
+				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(" · Discovery ")
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 27, Col: 102}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var8 string
+				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(data.SyncDiscoveryInterval)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 27, Col: 132}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<p class=\"text-muted-foreground\">Trigger the immediate full sync lane. Discovery sync is disabled on this server.</p>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<span class=\"text-xs text-muted-foreground\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var9 string
+				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs("Full ")
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 29, Col: 61}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var10 string
+				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(data.SyncInterval)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 29, Col: 82}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var11 string
+				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(" · Discovery disabled")
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 29, Col: 110}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div class=\"flex flex-wrap items-center gap-4\"><form method=\"post\" action=\"/settings/resync\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if data.SyncDiscoveryEnabled {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<p class=\"mt-1 text-sm text-muted-foreground\">Refresh identities, app access, and discovery signals.</p>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			} else {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<p class=\"mt-1 text-sm text-muted-foreground\">Refresh identities and app access.</p>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</div><div class=\"shrink-0\"><form method=\"post\" action=\"/settings/resync\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -129,94 +189,148 @@ func SettingsPage(data viewmodels.SettingsViewData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<button type=\"submit\" class=\"btn-primary\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<button type=\"submit\" class=\"btn-sm-primary\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if !data.ResyncEnabled {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, " disabled")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, " disabled")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, ">Resync now</button></form>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, ">Resync now</button></form></div></div></section><section class=\"space-y-3\"><div class=\"flex flex-col gap-2 md:flex-row md:items-end md:justify-between\"><div><h2 class=\"text-base font-semibold\">Risk policies</h2><p class=\"text-sm text-muted-foreground\">Built-in policy packs loaded by this server.</p></div><div class=\"text-xs text-muted-foreground\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if data.SyncDiscoveryEnabled {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<div class=\"text-sm text-muted-foreground\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var6 string
-				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs("Worker intervals (if running): full ")
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 39, Col: 90}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var7 string
-				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(data.SyncInterval)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 39, Col: 111}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var8 string
-				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(" · discovery ")
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 39, Col: 131}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var9 string
-				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(data.SyncDiscoveryInterval)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 39, Col: 161}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</div>")
+			var templ_7745c5c3_Var12 string
+			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt(len(data.RiskPolicyPacks)))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 54, Col: 44}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var13 string
+			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(pluralizeSuffix(len(data.RiskPolicyPacks), " pack", " packs"))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 54, Col: 109}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var14 string
+			templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(" · ")
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 54, Col: 119}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var15 string
+			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt(data.RiskPolicyExpressions))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 54, Col: 160}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var16 string
+			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(pluralizeSuffix(data.RiskPolicyExpressions, " CEL expression", " CEL expressions"))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 54, Col: 246}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</div></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if len(data.RiskPolicyPacks) > 0 {
+				templ_7745c5c3_Var17 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+					templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+					templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+					if !templ_7745c5c3_IsBuffer {
+						defer func() {
+							templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+							if templ_7745c5c3_Err == nil {
+								templ_7745c5c3_Err = templ_7745c5c3_BufErr
+							}
+						}()
+					}
+					ctx = templ.InitializeContext(ctx)
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<table class=\"table osspm-table-fixed osspm-table-compact osspm-table-list align-top\"><caption class=\"sr-only\">Active risk policy packs loaded by this server.</caption> <thead><tr><th class=\"text-xs font-medium uppercase tracking-wide text-muted-foreground\">Domain</th><th class=\"text-xs font-medium uppercase tracking-wide text-muted-foreground\">Policy pack</th><th class=\"text-xs font-medium uppercase tracking-wide text-muted-foreground\">Version</th></tr></thead> <tbody>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					for _, pack := range data.RiskPolicyPacks {
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<tr><td class=\"text-muted-foreground whitespace-nowrap\">")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						var templ_7745c5c3_Var18 string
+						templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(pack.Domain)
+						if templ_7745c5c3_Err != nil {
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 71, Col: 75}
+						}
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</td><td class=\"font-medium\">")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						var templ_7745c5c3_Var19 string
+						templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(pack.ID)
+						if templ_7745c5c3_Err != nil {
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 72, Col: 43}
+						}
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</td><td class=\"text-muted-foreground whitespace-nowrap\">")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						var templ_7745c5c3_Var20 string
+						templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(pack.Version)
+						if templ_7745c5c3_Err != nil {
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 73, Col: 76}
+						}
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</td></tr>")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</tbody></table>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					return nil
+				})
+				templ_7745c5c3_Err = ColumnsTable("").Render(templ.WithChildren(ctx, templ_7745c5c3_Var17), templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<div class=\"text-sm text-muted-foreground\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var10 string
-				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs("Worker interval (if running): ")
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 41, Col: 84}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var11 string
-				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(data.SyncInterval)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `settings.templ`, Line: 41, Col: 105}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<p class=\"text-sm text-muted-foreground\">No policy packs loaded.</p>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div></section></article></section>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</section></section>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/internal/http/views/settings_test.go
+++ b/internal/http/views/settings_test.go
@@ -1,0 +1,45 @@
+package views
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/open-sspm/open-sspm/internal/http/viewmodels"
+)
+
+func TestSettingsPageRendersRiskPolicyPacks(t *testing.T) {
+	t.Parallel()
+
+	var body bytes.Buffer
+	err := SettingsPage(viewmodels.SettingsViewData{
+		Layout: viewmodels.LayoutData{
+			Title: "Settings",
+		},
+		RiskPolicyPacks: []viewmodels.RiskPolicyPackSummary{
+			{Domain: "credential", ID: "builtin-credential-risk", Version: "1.0.0"},
+			{Domain: "saas", ID: "builtin-saas-risk", Version: "1.0.0"},
+		},
+		RiskPolicyExpressions: 12,
+	}).Render(context.Background(), &body)
+	if err != nil {
+		t.Fatalf("render settings page: %v", err)
+	}
+
+	html := body.String()
+	for _, want := range []string{
+		"System operations",
+		"Connector health",
+		"Risk policies",
+		"Built-in policy packs loaded by this server.",
+		"2 packs",
+		"12 CEL expressions",
+		"builtin-credential-risk",
+		"builtin-saas-risk",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("settings page should render %q: %s", want, html)
+		}
+	}
+}

--- a/internal/riskpolicy/loader.go
+++ b/internal/riskpolicy/loader.go
@@ -95,6 +95,17 @@ func (r *Registry) Packs() []PolicyPack {
 	return packs
 }
 
+func (r *Registry) PackMetadatas() []PolicyMetadata {
+	if r == nil {
+		return nil
+	}
+	metadatas := make([]PolicyMetadata, 0, len(r.packs))
+	for _, pack := range r.packs {
+		metadatas = append(metadatas, pack.Policy.Metadata)
+	}
+	return metadatas
+}
+
 func (r *Registry) PackCount() int {
 	if r == nil {
 		return 0

--- a/internal/riskpolicy/policy_test.go
+++ b/internal/riskpolicy/policy_test.go
@@ -23,6 +23,10 @@ func TestLoadBuiltinPolicies(t *testing.T) {
 	for _, pack := range registry.Packs() {
 		byID[pack.Metadata.ID] = pack
 	}
+	metadataByID := make(map[string]PolicyMetadata)
+	for _, metadata := range registry.PackMetadatas() {
+		metadataByID[metadata.ID] = metadata
+	}
 	for _, id := range []string{
 		"builtin-credential-risk",
 		"builtin-saas-risk",
@@ -31,6 +35,9 @@ func TestLoadBuiltinPolicies(t *testing.T) {
 	} {
 		if _, ok := byID[id]; !ok {
 			t.Fatalf("missing built-in policy pack %q", id)
+		}
+		if metadata := metadataByID[id]; metadata.ID == "" || metadata.Version == "" || metadata.Domain == "" {
+			t.Fatalf("missing built-in policy metadata %q: %+v", id, metadata)
 		}
 	}
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes the loaded risk policy packs on the settings page, showing pack domain, ID, version, and total compiled CEL expression count. It adds two handler-level helper functions (`riskPolicyPackSummaries`, `riskPolicyExpressionCount`), a new `RiskPolicyPackSummary` view model, a redesigned settings template, and corresponding tests.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all findings are style/quality suggestions with no runtime defects.

Only P2 findings: a vacuous test condition and unnecessary full-pack allocation. No logic errors, security issues, or missing nil guards.

internal/http/handlers/settings_test.go — misleading test condition

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/http/handlers/settings.go | Adds two helper functions to build risk policy summaries; correctly nil-guards the registry and sorts stably by domain then ID. |
| internal/http/handlers/settings_test.go | New test for sorting and pack content; first disjunct of the expression-count assertion is tautologically false, making it test only that the count is non-zero. |
| internal/http/viewmodels/settings.go | Adds RiskPolicyPackSummary struct and two new fields to SettingsViewData; straightforward and correct. |
| internal/http/views/settings.templ | Redesigns the settings page layout; adds a risk policies section with a table of packs. All user-supplied values are properly escaped. |
| internal/http/views/settings_templ.go | Auto-generated from settings.templ; consistent with the template changes. |
| internal/http/views/settings_test.go | Render test for the new risk policies section; asserts user-visible text content. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant Handler as HandleSettings
    participant Registry as riskpolicy.Registry
    participant Template as SettingsPage (templ)

    Browser->>Handler: GET /settings
    Handler->>Registry: Packs()
    Registry-->>Handler: []PolicyPack (deep copy)
    Handler->>Handler: riskPolicyPackSummaries() → sort by domain/ID
    Handler->>Registry: CompiledExpressionCount()
    Registry-->>Handler: int
    Handler->>Template: SettingsViewData{RiskPolicyPacks, RiskPolicyExpressions, ...}
    Template-->>Browser: HTML with policy pack table
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/http/handlers/settings_test.go`, line 90-92 ([link](https://github.com/open-sspm/open-sspm/blob/10419122b302dbbc2454793b5da0f224dca7196c/internal/http/handlers/settings_test.go#L90-L92)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Tautological first disjunct in assertion**

   `got != registry.CompiledExpressionCount()` will always be `false` because both sides call the exact same method on the same receiver — making the `||` branch only ever fail when `got == 0`. The test effectively only guards against a zero count, which may be the intent, but the phrasing is misleading and the `Fatalf` message implies a mismatch check that can never trigger.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/http/handlers/settings_test.go
   Line: 90-92

   Comment:
   **Tautological first disjunct in assertion**

   `got != registry.CompiledExpressionCount()` will always be `false` because both sides call the exact same method on the same receiver — making the `||` branch only ever fail when `got == 0`. The test effectively only guards against a zero count, which may be the intent, but the phrasing is misleading and the `Fatalf` message implies a mismatch check that can never trigger.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/http/handlers/settings_test.go
Line: 90-92

Comment:
**Tautological first disjunct in assertion**

`got != registry.CompiledExpressionCount()` will always be `false` because both sides call the exact same method on the same receiver — making the `||` branch only ever fail when `got == 0`. The test effectively only guards against a zero count, which may be the intent, but the phrasing is misleading and the `Fatalf` message implies a mismatch check that can never trigger.

```suggestion
	if got := riskPolicyExpressionCount(registry); got == 0 {
		t.Fatalf("riskPolicyExpressionCount() = 0, want > 0")
	}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/http/handlers/settings.go
Line: 78-87

Comment:
**Unnecessary deep-copy of full PolicyPack slice**

`registry.Packs()` performs a full deep-clone of every `PolicyPack` (including `Spec.Constants`, `Spec.Rules`, `Spec.ScopedRules`, etc.) even though only three metadata fields are consumed here. On a large registry this allocates a lot of memory that is immediately discarded. Consider adding a lighter `PackMetas()` accessor on `Registry`, or at minimum noting the allocation cost in a comment so future readers don't miss the redundancy.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: expose rules in settings"](https://github.com/open-sspm/open-sspm/commit/10419122b302dbbc2454793b5da0f224dca7196c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29717596)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->