### PR TITLE
refactor: split binaries, api vs the frontend

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -4,7 +4,7 @@ tmp_dir = "tmp"
 [build]
   cmd = "templ generate -path internal/http/views -lazy && go build -o ./tmp/open-sspm ./cmd/open-sspm"
   bin = "tmp/open-sspm"
-  full_bin = "./tmp/open-sspm serve"
+  full_bin = "./tmp/open-sspm api"
   include_ext = ["go", "templ", "css"]
   exclude_dir = ["tmp", "node_modules"]
   exclude_regex = ["_test.go", "_templ.go"]

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -137,6 +137,7 @@ jobs:
           systemctl stop open-sspm || true
           systemctl stop open-sspm-worker || true
           systemctl stop open-sspm-discovery-worker || true
+          systemctl stop open-sspm-ingest-worker || true
 
           if [ -z "${DATABASE_URL:-}" ]; then
             echo "DATABASE_URL is not set (expected in /etc/open-sspm.env)" >&2
@@ -172,6 +173,7 @@ jobs:
 
           systemctl disable open-sspm-worker || true
           systemctl disable open-sspm-discovery-worker || true
+          systemctl disable open-sspm-ingest-worker || true
           systemctl enable open-sspm
           systemctl restart open-sspm
           systemctl status open-sspm --no-pager -l || true

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Open-SSPM is a small “who has access to what” service. It syncs identities f
 - Login: `admin@admin.com` / `admin`
 
 ## Features
-- HTTP server (`open-sspm serve`) + background full sync worker (`open-sspm worker`) + background discovery worker (`open-sspm worker-discovery`) + one-off syncs (`open-sspm sync`, `open-sspm sync-discovery`) + in-app “Resync” (queued async by default).
+- API/web server (`open-sspm api`) + background full sync worker (`open-sspm worker`) + background discovery worker (`open-sspm worker-discovery`) + background ingest worker (`open-sspm worker-ingest`) + one-off syncs (`open-sspm sync`, `open-sspm sync-discovery`) + in-app “Resync” (queued async by default).
 - Okta: users, groups, apps, and assignments (IdP source).
 - Microsoft Entra ID: users plus application/service principal governance metadata.
 - Google Workspace: users, groups, admin roles, OAuth app/grant inventory, and token audit activity.
@@ -33,8 +33,8 @@ Open-SSPM is a small “who has access to what” service. It syncs identities f
 2. Start Postgres: `just dev-up`
 3. Run migrations: `just migrate`
 4. Install JS deps + build CSS: `npm install && just ui`
-5. Run the server: `just run`
-6. Run background workers: `just worker` (full lane) and `go run ./cmd/open-sspm worker-discovery` (discovery lane).
+5. Run the API/web server: `just run`
+6. Run background workers: `just worker` (full lane), `just worker-discovery` (discovery lane), and `just worker-ingest` (push ingest).
 7. Generate a stable connector secret key and export it before configuring connectors:
    - `export CONNECTOR_SECRET_KEY="$(openssl rand -base64 32)"`
 8. Open `http://localhost:8080`, configure connectors under Settings → Connectors, then run a sync (Settings → Resync queues workers by default, or use `just sync` for one-off inline execution).
@@ -49,7 +49,8 @@ After seeding, run an Okta sync and open `http://localhost:8080/findings/ruleset
 ## Dev workflows
 - Live-reload server: `just dev` (requires `air` + `templ`)
 - Run background full sync worker: `just worker`
-- Run background discovery sync worker: `go run ./cmd/open-sspm worker-discovery`
+- Run background discovery sync worker: `just worker-discovery`
+- Run background ingest worker: `just worker-ingest`
 - Watch CSS: `just ui-watch`
 - Sync vendored runtime JS: `npm run vendor:sync` (also runs automatically after `npm install` / `npm ci`)
 - Check vendored runtime JS drift: `npm run vendor:check`
@@ -68,7 +69,7 @@ After seeding, run an Okta sync and open `http://localhost:8080/findings/ruleset
 - Connector credentials: configured in-app under Settings → Connectors. Public connector metadata stays in Postgres, and secret values are stored separately in encrypted form using `CONNECTOR_SECRET_KEY` / `CONNECTOR_SECRET_KEY_FILE`.
 - AWS Identity Center uses the AWS SDK default credentials chain (env/shared config/role), not DB-stored keys.
 - SaaS discovery is per-connector (`discovery_enabled`) for Okta, Entra, and Google Workspace.
-  - Okta discovery uses System Log access; optional Event Hook and EventBridge receivers run in `open-sspm serve` for push-assisted discovery.
+  - Okta discovery uses System Log access; optional Event Hook and EventBridge receivers run in `open-sspm api` and queue push-assisted discovery work for `open-sspm worker-ingest`.
   - Entra discovery uses sign-in and OAuth grant APIs (`AuditLog.Read.All`, `Directory.Read.All`, `DelegatedPermissionGrant.Read.All`).
   - Google Workspace discovery uses Reports API login/token activity and token inventory.
 
@@ -109,7 +110,7 @@ After seeding, run an Okta sync and open `http://localhost:8080/findings/ruleset
 ## Security notes
 - Open-SSPM includes in-app authentication (email/password) using server-side sessions stored in Postgres.
 - Avoid logging connector secrets.
-- Set a stable base64-encoded 32-byte `CONNECTOR_SECRET_KEY` (or `CONNECTOR_SECRET_KEY_FILE`) anywhere you run `serve`, `worker`, or sync commands. Losing that key means stored connector secrets must be re-entered.
+- Set a stable base64-encoded 32-byte `CONNECTOR_SECRET_KEY` (or `CONNECTOR_SECRET_KEY_FILE`) anywhere you run `api`, `worker`, `worker-discovery`, `worker-ingest`, or sync commands. Losing that key means stored connector secrets must be re-entered.
 
 ## Contributing
 

--- a/cmd/open-sspm/metrics.go
+++ b/cmd/open-sspm/metrics.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/open-sspm/open-sspm/internal/db/gen"
 	"github.com/open-sspm/open-sspm/internal/discovery"
+	oktaingest "github.com/open-sspm/open-sspm/internal/ingest/okta"
 	"github.com/open-sspm/open-sspm/internal/nonhumanaccess"
 )
 
@@ -16,5 +17,11 @@ func discoveryMetricsRefresh(q *gen.Queries) func(context.Context) error {
 			return err
 		}
 		return nonhumanaccess.RefreshMetrics(ctx, q, now)
+	}
+}
+
+func oktaPushMetricsRefresh(q *gen.Queries) func(context.Context) error {
+	return func(ctx context.Context) error {
+		return oktaingest.RefreshMetrics(ctx, q)
 	}
 }

--- a/cmd/open-sspm/root.go
+++ b/cmd/open-sspm/root.go
@@ -9,9 +9,11 @@ import (
 )
 
 var structuredLoggingCommandNames = map[string]struct{}{
+	"api":                    {},
 	"serve":                  {},
 	"worker":                 {},
 	"worker-discovery":       {},
+	"worker-ingest":          {},
 	"sync":                   {},
 	"sync-discovery":         {},
 	"migrate":                {},
@@ -99,9 +101,11 @@ func setCommandExecutionContext(ctx commandExecutionContext) {
 
 func init() {
 	rootCmd.AddCommand(
+		apiCmd,
 		serveCmd,
 		workerCmd,
 		workerDiscoveryCmd,
+		workerIngestCmd,
 		syncCmd,
 		syncDiscoveryCmd,
 		migrateCmd,

--- a/cmd/open-sspm/serve.go
+++ b/cmd/open-sspm/serve.go
@@ -24,19 +24,40 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var serveCmd = &cobra.Command{
-	Use:   "serve",
-	Short: "Run the HTTP server.",
+var apiCmd = &cobra.Command{
+	Use:   "api",
+	Short: "Run the API and web UI HTTP server.",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runServe()
+		return runAPI()
 	},
 }
 
-func runServe() error {
+var serveCmd = &cobra.Command{
+	Use:        "serve",
+	Short:      "Run the API and web UI HTTP server.",
+	Deprecated: "use api instead",
+	Args:       cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runAPIWithOptions(apiRunOptions{StartIngestWorker: true})
+	},
+}
+
+type apiRunOptions struct {
+	StartIngestWorker bool
+}
+
+func runAPI() error {
+	return runAPIWithOptions(apiRunOptions{})
+}
+
+func runAPIWithOptions(opts apiRunOptions) error {
 	cfg, err := config.Load()
 	if err != nil {
 		return err
+	}
+	if opts.StartIngestWorker {
+		slog.Warn("open-sspm serve is deprecated; use open-sspm api plus open-sspm worker-ingest")
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -121,7 +142,7 @@ func runServe() error {
 
 	errCh := make(chan error, 1)
 	metricsServer, metricsErrCh := metrics.StartServer(ctx, cfg.MetricsAddr, discoveryMetricsRefresh(queries))
-	if cfg.SyncDiscoveryEnabled {
+	if opts.StartIngestWorker && cfg.SyncDiscoveryEnabled {
 		go func() {
 			if err := oktaingest.RunLoop(ctx, queries, runtimeDeps.pool, oktaingest.DefaultConfig()); err != nil {
 				errCh <- err

--- a/cmd/open-sspm/serve.go
+++ b/cmd/open-sspm/serve.go
@@ -144,7 +144,7 @@ func runAPIWithOptions(opts apiRunOptions) error {
 	metricsServer, metricsErrCh := metrics.StartServer(ctx, cfg.MetricsAddr, discoveryMetricsRefresh(queries))
 	if opts.StartIngestWorker && cfg.SyncDiscoveryEnabled {
 		go func() {
-			if err := oktaingest.RunLoop(ctx, queries, runtimeDeps.pool, oktaingest.DefaultConfig()); err != nil {
+			if err := oktaingest.RunLoop(ctx, queries, runtimeDeps.pool, oktaingest.DefaultConfig()); err != nil && !errors.Is(err, context.Canceled) {
 				errCh <- err
 			}
 		}()

--- a/cmd/open-sspm/worker_ingest.go
+++ b/cmd/open-sspm/worker_ingest.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/open-sspm/open-sspm/internal/config"
+	oktaingest "github.com/open-sspm/open-sspm/internal/ingest/okta"
+	"github.com/open-sspm/open-sspm/internal/metrics"
+	"github.com/spf13/cobra"
+)
+
+var workerIngestCmd = &cobra.Command{
+	Use:   "worker-ingest",
+	Short: "Run background ingest queue processors.",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runWorkerIngest()
+	},
+}
+
+func runWorkerIngest() error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	if !cfg.SyncDiscoveryEnabled {
+		return errors.New("SYNC_DISCOVERY_ENABLED must be true to run the ingest worker")
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	runtimeDeps, err := openRuntimeDependencies(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	defer runtimeDeps.pool.Close()
+	queries := runtimeDeps.queries
+
+	metricsServer, metricsErrCh := metrics.StartServer(ctx, cfg.MetricsAddr, oktaPushMetricsRefresh(queries))
+	errCh := make(chan error, 1)
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		if err := oktaingest.RunLoop(ctx, queries, runtimeDeps.pool, oktaingest.DefaultConfig()); err != nil && !errors.Is(err, context.Canceled) {
+			errCh <- err
+		}
+	}()
+
+	slog.Info("ingest worker started")
+
+	var runErr error
+	if metricsErrCh == nil {
+		select {
+		case <-ctx.Done():
+		case runErr = <-errCh:
+			stop()
+		}
+	} else {
+		select {
+		case <-ctx.Done():
+		case runErr = <-errCh:
+			stop()
+		case err := <-metricsErrCh:
+			if err != nil {
+				slog.Error("metrics server failed", "err", err)
+				runErr = err
+				stop()
+			}
+		}
+	}
+
+	<-doneCh
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if metricsServer != nil {
+		_ = metricsServer.Shutdown(shutdownCtx)
+	}
+	return runErr
+}

--- a/demo/infra/DEPLOYMENT.md
+++ b/demo/infra/DEPLOYMENT.md
@@ -2,8 +2,8 @@
 
 Target:
 - a single Scaleway VM (Ubuntu 24.04) with local Postgres
-- `open-sspm` runs as a systemd service and serves HTTP on `127.0.0.1:8080`
-- optional `open-sspm-worker` and `open-sspm-discovery-worker` systemd services are provisioned but disabled by default
+- `open-sspm` runs `open-sspm api` as a systemd service and serves HTTP on `127.0.0.1:8080`
+- optional `open-sspm-worker`, `open-sspm-discovery-worker`, and `open-sspm-ingest-worker` systemd services are provisioned but disabled by default
 - nginx listens on `:80` and reverse-proxies to `open-sspm`
 
 This repo expects **runtime files** to exist on disk:
@@ -40,7 +40,7 @@ Extract it on the server into `/opt/open-sspm/`.
    - `demo/data/`
 4) Copy to the server over SSH (GitHub Actions secret key).
 5) Run on the server:
-   - stop `open-sspm`, `open-sspm-worker`, and `open-sspm-discovery-worker` (if running)
+   - stop `open-sspm`, `open-sspm-worker`, `open-sspm-discovery-worker`, and `open-sspm-ingest-worker` (if running)
    - reset the demo database (drop + recreate)
    - `open-sspm migrate`
    - `open-sspm seed-rules`

--- a/demo/infra/ansible/README.md
+++ b/demo/infra/ansible/README.md
@@ -2,7 +2,7 @@
 
 Bootstraps the Scaleway VM for the demo:
 - installs Postgres locally
-- prepares an `open-sspm` system user and service scaffolding (`open-sspm`, `open-sspm-worker`, `open-sspm-discovery-worker`)
+- prepares an `open-sspm` system user and service scaffolding (`open-sspm`, `open-sspm-worker`, `open-sspm-discovery-worker`, `open-sspm-ingest-worker`)
 
 This is intentionally minimal; the application binary/container is expected to be deployed by GitHub Actions.
 Worker services are provisioned but kept disabled/stopped by default.

--- a/demo/infra/ansible/deploy.yml
+++ b/demo/infra/ansible/deploy.yml
@@ -58,6 +58,7 @@
         - open-sspm
         - open-sspm-worker
         - open-sspm-discovery-worker
+        - open-sspm-ingest-worker
       failed_when: false
 
     - name: Reset static assets directory

--- a/demo/infra/ansible/site.yml
+++ b/demo/infra/ansible/site.yml
@@ -136,7 +136,7 @@
         state: restarted
         enabled: true
 
-    - name: Install open-sspm serve systemd unit (placeholder)
+    - name: Install open-sspm API systemd unit (placeholder)
       ansible.builtin.copy:
         dest: /etc/systemd/system/open-sspm.service
         owner: root
@@ -153,7 +153,7 @@
           Group=open-sspm
           WorkingDirectory=/opt/open-sspm
           EnvironmentFile=/etc/open-sspm.env
-          ExecStart=/usr/local/bin/open-sspm serve
+          ExecStart=/usr/local/bin/open-sspm api
           Restart=on-failure
           RestartSec=2
 
@@ -208,6 +208,30 @@
           [Install]
           WantedBy=multi-user.target
 
+    - name: Install open-sspm ingest worker systemd unit (placeholder)
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/open-sspm-ingest-worker.service
+        owner: root
+        group: root
+        mode: "0644"
+        content: |
+          [Unit]
+          Description=Open-SSPM Ingest Worker
+          After=network-online.target postgresql.service
+          Wants=network-online.target
+
+          [Service]
+          User=open-sspm
+          Group=open-sspm
+          WorkingDirectory=/opt/open-sspm
+          EnvironmentFile=/etc/open-sspm.env
+          ExecStart=/usr/local/bin/open-sspm worker-ingest
+          Restart=on-failure
+          RestartSec=2
+
+          [Install]
+          WantedBy=multi-user.target
+
     - name: Reload systemd
       ansible.builtin.systemd:
         daemon_reload: true
@@ -221,3 +245,4 @@
         - open-sspm
         - open-sspm-worker
         - open-sspm-discovery-worker
+        - open-sspm-ingest-worker

--- a/docs/config/connectors/okta.md
+++ b/docs/config/connectors/okta.md
@@ -124,7 +124,7 @@ SYNC_OKTA_INTERVAL=15m
 SYNC_OKTA_WORKERS=3
 ```
 
-Push processing runs in the `serve` process and does not require a separate API service. The inbox processor polls queued rows every five seconds, reclaims stuck `processing` rows after five minutes, retries transient failures with exponential backoff (up to 10 attempts), then deletes processed and ignored rows after 30 days and dead-letter rows after 90 days.
+Push delivery is received by the `api` process and queued in Postgres. Push processing runs in the `worker-ingest` process. The inbox processor polls queued rows every five seconds, reclaims stuck `processing` rows after five minutes, retries transient failures with exponential backoff (up to 10 attempts), then deletes processed and ignored rows after 30 days and dead-letter rows after 90 days.
 
 After enabling a push channel, run an Okta discovery sync from **Settings → Connector Health**. That backfills recent history through the System Log API and keeps the source from looking healthy on push delivery alone.
 
@@ -141,7 +141,7 @@ After enabling a push channel, run an Okta discovery sync from **Settings → Co
 
 ### Event Hook Verification Fails
 
-- Confirm the public HTTPS endpoint reaches the Open-SSPM `serve` process.
+- Confirm the public HTTPS endpoint reaches the Open-SSPM `api` process.
 - Confirm the Event Hook receiver is enabled.
 - If Okta sends an `Authorization` header during verification, confirm it matches the configured Event Hook secret.
 
@@ -150,6 +150,7 @@ After enabling a push channel, run an Okta discovery sync from **Settings → Co
 - Check the connector configuration card for push ingest status, queue depth, and dead-letter count.
 - Confirm the request path is `/ingest/okta/events` for Event Hooks or `/ingest/okta/eventbridge` for EventBridge.
 - Confirm the `Authorization` header exactly matches the configured secret.
+- Make sure `open-sspm worker-ingest` is running.
 - For EventBridge, confirm the envelope has `detail-type: "SystemLog"` and an Okta partner `source`.
 
 ### Discovery Data Missing

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -81,7 +81,7 @@ After setting configuration:
 1. Verify the database connection.
 2. Run migrations.
 3. Bootstrap the first admin user.
-4. Start `serve` and the worker processes.
+4. Start `api` and the worker processes.
 5. Configure connectors in the UI.
 6. Run an initial sync.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ just run
 # Open http://localhost:8080
 ```
 
-Run `just worker-discovery` in a third terminal if you want discovery syncs and `SYNC_DISCOVERY_ENABLED=1`.
+Run `just worker-discovery` in a third terminal if you want discovery syncs and `SYNC_DISCOVERY_ENABLED=1`. Run `just worker-ingest` as well if you enable push ingest such as Okta Event Hooks or EventBridge.
 
 See the [Installation Guide](/install/) for production deployment options and the full Docker-backed local setup.
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -77,7 +77,11 @@ just worker
 just worker-discovery
 ```
 
-The discovery worker is optional, but it must be running if you want SaaS discovery syncs and `SYNC_DISCOVERY_ENABLED=1`.
+```bash
+just worker-ingest
+```
+
+The discovery worker is optional, but it must be running if you want polling-based SaaS discovery syncs and `SYNC_DISCOVERY_ENABLED=1`. The ingest worker is optional unless you enable push ingest such as Okta Event Hooks or EventBridge.
 
 ### 8. Access the Web UI
 
@@ -89,7 +93,7 @@ The repository compose file currently defines:
 
 - `db` - PostgreSQL with a persisted local data volume
 
-That is why repo-local commands use `just run`, `just worker`, and `just worker-discovery` instead of `docker compose exec web ...`.
+That is why repo-local commands use `just run`, `just worker`, `just worker-discovery`, and `just worker-ingest` instead of `docker compose exec web ...`.
 
 ## Optional: Fully Containerized Compose Example
 
@@ -107,9 +111,9 @@ services:
     volumes:
       - db-data:/var/lib/postgresql/data
 
-  serve:
+  api:
     image: ghcr.io/open-sspm/open-sspm:latest
-    command: ["serve"]
+    command: ["api"]
     depends_on:
       - db
     environment:
@@ -137,6 +141,15 @@ services:
       DATABASE_URL: postgres://postgres:postgres@db:5432/opensspm?sslmode=disable
       CONNECTOR_SECRET_KEY: ${CONNECTOR_SECRET_KEY}
 
+  worker-ingest:
+    image: ghcr.io/open-sspm/open-sspm:latest
+    command: ["worker-ingest"]
+    depends_on:
+      - db
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@db:5432/opensspm?sslmode=disable
+      CONNECTOR_SECRET_KEY: ${CONNECTOR_SECRET_KEY}
+
 volumes:
   db-data:
 ```
@@ -144,8 +157,8 @@ volumes:
 For that sample file:
 
 ```bash
-docker compose run --rm serve migrate
-printf '%s\n' 'change-me-now' | docker compose run --rm -T serve users bootstrap-admin \
+docker compose run --rm api migrate
+printf '%s\n' 'change-me-now' | docker compose run --rm -T api users bootstrap-admin \
   --email admin@example.com \
   --password-stdin
 docker compose up -d
@@ -182,4 +195,10 @@ For discovery syncs, also run:
 
 ```bash
 just worker-discovery
+```
+
+For Okta push ingest, also run:
+
+```bash
+just worker-ingest
 ```

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -82,7 +82,7 @@ After installation:
 
 1. Run migrations.
 2. Create the first admin user.
-3. Start `serve` and the background worker processes.
+3. Start `api` and the background worker processes.
 4. Configure connectors in the web UI.
 5. Run an initial sync.
 

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -18,9 +18,10 @@ The chart does not deploy PostgreSQL. Use a managed or separately operated Postg
 
 The chart creates:
 
-- **Serve Deployment** - `open-sspm serve`
+- **API Deployment** - `open-sspm api`
 - **Worker Deployment** - `open-sspm worker`
 - **Discovery Worker Deployment** - `open-sspm worker-discovery` (enabled by default)
+- **Ingest Worker Deployment** - `open-sspm worker-ingest` (enabled by default when discovery is enabled)
 - **Service** - Network access for the web UI
 - **Ingress** (optional)
 - **Hook Jobs** - Migrations, optional rule seeding, and optional admin bootstrap
@@ -109,7 +110,7 @@ config:
   logLevel: info
   authCookieSecure: true
 
-serve:
+api:
   replicaCount: 1
   resources:
     limits:
@@ -133,6 +134,14 @@ discoveryWorker:
     limits:
       cpu: 500m
       memory: 512Mi
+
+ingestWorker:
+  enabled: true
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: 250m
+      memory: 256Mi
 
 ingress:
   enabled: true
@@ -215,10 +224,10 @@ serviceAccount:
 
 ### Trusted Proxy CIDRs
 
-If your direct upstream proxy uses public IPs, pass `TRUSTED_PROXY_CIDRS` via `serve.extraEnv`:
+If your direct upstream proxy uses public IPs, pass `TRUSTED_PROXY_CIDRS` via `api.extraEnv`:
 
 ```yaml
-serve:
+api:
   extraEnv:
     - name: TRUSTED_PROXY_CIDRS
       value: "35.191.0.0/16,130.211.0.0/22"
@@ -253,7 +262,7 @@ bootstrapAdmin:
 
 ```bash
 helm upgrade open-sspm ./helm/open-sspm -f values.yaml
-kubectl rollout status deployment/open-sspm-serve
+kubectl rollout status deployment/open-sspm-api
 ```
 
 ## Troubleshooting
@@ -267,9 +276,10 @@ kubectl get pods -l app.kubernetes.io/name=open-sspm
 ### View Logs
 
 ```bash
-kubectl logs -l app.kubernetes.io/component=serve
+kubectl logs -l app.kubernetes.io/component=api
 kubectl logs -l app.kubernetes.io/component=worker
 kubectl logs -l app.kubernetes.io/component=worker-discovery
+kubectl logs -l app.kubernetes.io/component=worker-ingest
 ```
 
 ### Database Connection Issues

--- a/docs/run/index.md
+++ b/docs/run/index.md
@@ -6,9 +6,10 @@ This guide covers day-to-day operation of Open-SSPM.
 
 | Command | Purpose | Normally Running? |
 |---------|---------|-------------------|
-| `open-sspm serve` | Web UI and API | Yes |
+| `open-sspm api` | Web UI and API | Yes |
 | `open-sspm worker` | Background full sync loop | Yes |
 | `open-sspm worker-discovery` | Background discovery sync loop | Optional |
+| `open-sspm worker-ingest` | Background push ingest queue processing | Optional |
 
 ## Starting the Application
 
@@ -34,7 +35,11 @@ just worker
 just worker-discovery
 ```
 
-The discovery worker is only needed when `SYNC_DISCOVERY_ENABLED=1` and you want discovery data.
+```bash
+just worker-ingest
+```
+
+The discovery worker is only needed when `SYNC_DISCOVERY_ENABLED=1` and you want polling-based discovery data. The ingest worker is needed when you enable push ingest such as Okta Event Hooks or EventBridge.
 
 ### Kubernetes
 
@@ -48,16 +53,17 @@ kubectl get pods -l app.kubernetes.io/name=open-sspm
 Scale a component:
 
 ```bash
-kubectl scale deployment open-sspm-serve --replicas=2
+kubectl scale deployment open-sspm-api --replicas=2
 kubectl scale deployment open-sspm-worker --replicas=1
 kubectl scale deployment open-sspm-worker-discovery --replicas=1
+kubectl scale deployment open-sspm-worker-ingest --replicas=1
 ```
 
 ## Stopping the Application
 
 ### Repo-Local Workflow
 
-- Stop `serve` and worker processes with `Ctrl-C` in each terminal.
+- Stop `api` and worker processes with `Ctrl-C` in each terminal.
 - Stop the local Postgres dependency with:
 
 ```bash
@@ -69,16 +75,17 @@ just dev-down
 Scale Deployments to zero:
 
 ```bash
-kubectl scale deployment open-sspm-serve --replicas=0
+kubectl scale deployment open-sspm-api --replicas=0
 kubectl scale deployment open-sspm-worker --replicas=0
 kubectl scale deployment open-sspm-worker-discovery --replicas=0
+kubectl scale deployment open-sspm-worker-ingest --replicas=0
 ```
 
 ## Viewing Logs
 
 ### Repo-Local Workflow
 
-`just run`, `just worker`, and `just worker-discovery` log directly to their terminal sessions.
+`just run`, `just worker`, `just worker-discovery`, and `just worker-ingest` log directly to their terminal sessions.
 
 For the local Postgres container:
 
@@ -89,9 +96,10 @@ docker compose logs db
 ### Kubernetes
 
 ```bash
-kubectl logs -l app.kubernetes.io/component=serve -f
+kubectl logs -l app.kubernetes.io/component=api -f
 kubectl logs -l app.kubernetes.io/component=worker -f
 kubectl logs -l app.kubernetes.io/component=worker-discovery -f
+kubectl logs -l app.kubernetes.io/component=worker-ingest -f
 ```
 
 ## Manual Sync Operations
@@ -195,13 +203,13 @@ just migrate
 just ui
 ```
 
-Then restart `serve` and the worker processes.
+Then restart `api` and the worker processes.
 
 ### Kubernetes
 
 ```bash
 helm upgrade open-sspm ./helm/open-sspm -f values.yaml
-kubectl rollout status deployment/open-sspm-serve
+kubectl rollout status deployment/open-sspm-api
 ```
 
 ## Troubleshooting
@@ -230,6 +238,14 @@ Check:
 1. `SYNC_DISCOVERY_ENABLED=1`
 2. `just worker-discovery` is running
 3. Discovery is enabled on the relevant IdP connector
+
+### Okta push ingest is not processing
+
+Check:
+
+1. `just worker-ingest` is running.
+2. The Okta Event Hook or EventBridge endpoint reaches the API process.
+3. The connector ingest mode and shared secret match the delivery channel.
 
 ### Database connection errors
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -7,9 +7,10 @@ This folder contains Helm charts for deploying Open-SSPM to Kubernetes.
 Location: `helm/open-sspm`
 
 Deploys:
-- `open-sspm serve` (HTTP/UI) as a Deployment + Service (+ optional Ingress)
+- `open-sspm api` (HTTP/UI/API) as a Deployment + Service (+ optional Ingress)
 - `open-sspm worker` (background full sync loop) as a Deployment
 - `open-sspm worker-discovery` (background SaaS discovery sync loop) as a Deployment (enabled by default)
+- `open-sspm worker-ingest` (background push ingest queue processing) as a Deployment (enabled by default when discovery is enabled)
 - Helm hook Jobs:
   - `open-sspm migrate` as a pre-install/pre-upgrade Job
   - `open-sspm seed-rules` as a pre-install Job (optionally also pre-upgrade)
@@ -167,10 +168,12 @@ kubectl port-forward svc/<service-name> 8080:80
 
 ### Worker lanes
 
+- API Deployment settings use `api.*`. The chart still accepts `serve.*` as a deprecated alias so existing values files keep working during upgrade.
 - Full sync worker interval is configured with `config.syncInterval`.
 - Discovery sync worker interval is configured with `config.syncDiscoveryInterval`.
 - Set `config.syncDiscoveryEnabled=false` to disable the discovery lane system-wide.
-- Set `discoveryWorker.enabled=false` to omit only the discovery worker Deployment. The chart also disables discovery queuing on `serve` when this is false so manual resyncs do not strand discovery jobs.
+- Set `discoveryWorker.enabled=false` to omit only the discovery worker Deployment. The chart also disables discovery queuing on `api` when this is false so manual resyncs do not strand discovery jobs.
+- Set `ingestWorker.enabled=false` to omit push ingest queue processing.
 
 ### Structured logging
 
@@ -188,9 +191,10 @@ kubectl port-forward svc/<service-name> 8080:80
 ### Metrics service component selector
 
 If `metrics.service.enabled=true`, choose which pod to target with `metrics.service.component`:
-- `serve`
+- `api`
 - `worker`
 - `worker-discovery`
+- `worker-ingest`
 
 ### UI authentication
 
@@ -229,7 +233,7 @@ Keep it `false` for plain HTTP / port-forward, otherwise the browser will not st
 
 `/login` rate limiting uses the client IP derived from `X-Forwarded-For`.
 By default, Open SSPM trusts private, link-local, and loopback upstream hops, which matches typical in-cluster ingress setups.
-If your direct upstream load balancer uses public IPs, pass `TRUSTED_PROXY_CIDRS` via `serve.extraEnv` so the app can trust those ingress CIDRs too.
+If your direct upstream load balancer uses public IPs, pass `TRUSTED_PROXY_CIDRS` via `api.extraEnv` so the app can trust those ingress CIDRs too.
 
 ### Dev-only seeding (`DEV_SEED_ADMIN`)
 

--- a/helm/open-sspm/templates/deployment-api.yaml
+++ b/helm/open-sspm/templates/deployment-api.yaml
@@ -1,26 +1,55 @@
+{{- $api := .Values.api | default dict -}}
+{{- $serve := .Values.serve | default dict -}}
+{{- $replicaCount := 1 -}}
+{{- $podAnnotations := dict -}}
+{{- $podLabels := dict -}}
+{{- $extraEnv := list -}}
+{{- $extraEnvFrom := list -}}
+{{- $resources := dict -}}
+{{- $nodeSelector := dict -}}
+{{- $tolerations := list -}}
+{{- $affinity := dict -}}
+{{- if hasKey $serve "replicaCount" }}{{- $replicaCount = $serve.replicaCount }}{{- end -}}
+{{- if hasKey $serve "podAnnotations" }}{{- $podAnnotations = $serve.podAnnotations }}{{- end -}}
+{{- if hasKey $serve "podLabels" }}{{- $podLabels = $serve.podLabels }}{{- end -}}
+{{- if hasKey $serve "extraEnv" }}{{- $extraEnv = $serve.extraEnv }}{{- end -}}
+{{- if hasKey $serve "extraEnvFrom" }}{{- $extraEnvFrom = $serve.extraEnvFrom }}{{- end -}}
+{{- if hasKey $serve "resources" }}{{- $resources = $serve.resources }}{{- end -}}
+{{- if hasKey $serve "nodeSelector" }}{{- $nodeSelector = $serve.nodeSelector }}{{- end -}}
+{{- if hasKey $serve "tolerations" }}{{- $tolerations = $serve.tolerations }}{{- end -}}
+{{- if hasKey $serve "affinity" }}{{- $affinity = $serve.affinity }}{{- end -}}
+{{- if hasKey $api "replicaCount" }}{{- $replicaCount = $api.replicaCount }}{{- end -}}
+{{- if hasKey $api "podAnnotations" }}{{- $podAnnotations = $api.podAnnotations }}{{- end -}}
+{{- if hasKey $api "podLabels" }}{{- $podLabels = $api.podLabels }}{{- end -}}
+{{- if hasKey $api "extraEnv" }}{{- $extraEnv = $api.extraEnv }}{{- end -}}
+{{- if hasKey $api "extraEnvFrom" }}{{- $extraEnvFrom = $api.extraEnvFrom }}{{- end -}}
+{{- if hasKey $api "resources" }}{{- $resources = $api.resources }}{{- end -}}
+{{- if hasKey $api "nodeSelector" }}{{- $nodeSelector = $api.nodeSelector }}{{- end -}}
+{{- if hasKey $api "tolerations" }}{{- $tolerations = $api.tolerations }}{{- end -}}
+{{- if hasKey $api "affinity" }}{{- $affinity = $api.affinity }}{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ printf "%s-serve" (include "open-sspm.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-api" (include "open-sspm.fullname" .) | trunc 63 | trimSuffix "-" }}
   labels:
     {{- include "open-sspm.labels" . | nindent 4 }}
-    app.kubernetes.io/component: serve
+    app.kubernetes.io/component: api
 spec:
-  replicas: {{ .Values.serve.replicaCount }}
+  replicas: {{ $replicaCount }}
   selector:
     matchLabels:
       {{- include "open-sspm.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: serve
+      app.kubernetes.io/component: api
   template:
     metadata:
-      {{- with .Values.serve.podAnnotations }}
+      {{- with $podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
         {{- include "open-sspm.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: serve
-        {{- with .Values.serve.podLabels }}
+        app.kubernetes.io/component: api
+        {{- with $podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
@@ -38,7 +67,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - serve
+            - api
           ports:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
@@ -98,10 +127,10 @@ spec:
             - name: SYNC_DATADOG_WORKERS
               value: {{ .Values.config.syncDatadogWorkers | quote }}
             {{- include "open-sspm.smtpEnv" . | nindent 12 }}
-            {{- with .Values.serve.extraEnv }}
+            {{- with $extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- with .Values.serve.extraEnvFrom }}
+          {{- with $extraEnvFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -109,19 +138,19 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.serve.resources }}
+          {{- with $resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- with .Values.serve.nodeSelector }}
+      {{- with $nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.serve.tolerations }}
+      {{- with $tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.serve.affinity }}
+      {{- with $affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm/open-sspm/templates/deployment-worker-ingest.yaml
+++ b/helm/open-sspm/templates/deployment-worker-ingest.yaml
@@ -1,0 +1,96 @@
+{{- if and .Values.ingestWorker.enabled .Values.config.syncDiscoveryEnabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ printf "%s-worker-ingest" (include "open-sspm.fullname" .) | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "open-sspm.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker-ingest
+spec:
+  replicas: {{ .Values.ingestWorker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "open-sspm.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker-ingest
+  template:
+    metadata:
+      {{- with .Values.ingestWorker.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "open-sspm.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: worker-ingest
+        {{- with .Values.ingestWorker.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "open-sspm.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: open-sspm
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - worker-ingest
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "database.existingSecret.name is required" .Values.database.existingSecret.name }}
+                  key: {{ required "database.existingSecret.key is required" .Values.database.existingSecret.key }}
+            {{- if .Values.connectorSecret.existingSecret.name }}
+            - name: CONNECTOR_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.connectorSecret.existingSecret.name }}
+                  key: {{ .Values.connectorSecret.existingSecret.key | quote }}
+            {{- end }}
+            - name: METRICS_ADDR
+              value: {{ .Values.config.metricsAddr | quote }}
+            - name: LOG_FORMAT
+              value: {{ .Values.config.logFormat | quote }}
+            - name: LOG_LEVEL
+              value: {{ .Values.config.logLevel | quote }}
+            - name: SYNC_DISCOVERY_ENABLED
+              value: {{ ternary "1" "0" .Values.config.syncDiscoveryEnabled | quote }}
+            {{- include "open-sspm.smtpEnv" . | nindent 12 }}
+            {{- with .Values.ingestWorker.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.ingestWorker.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.ingestWorker.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.ingestWorker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ingestWorker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ingestWorker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/open-sspm/templates/service.yaml
+++ b/helm/open-sspm/templates/service.yaml
@@ -13,4 +13,4 @@ spec:
       targetPort: {{ .Values.service.targetPort }}
   selector:
     {{- include "open-sspm.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: serve
+    app.kubernetes.io/component: api

--- a/helm/open-sspm/values.yaml
+++ b/helm/open-sspm/values.yaml
@@ -51,8 +51,8 @@ config:
   # Dev-only convenience: seeds admin@admin.com / admin if no auth_users exist.
   devSeedAdmin: false
   resyncEnabled: true
-  # Enables the discovery lane system-wide. When false, serve does not queue
-  # discovery work and the discovery worker Deployment is omitted.
+  # Enables the discovery lane system-wide. When false, api does not queue
+  # discovery work and discovery/ingest worker Deployments are omitted.
   syncDiscoveryEnabled: true
   syncInterval: 15m
   syncDiscoveryInterval: 15m
@@ -67,7 +67,7 @@ metrics:
   service:
     enabled: false
     port: 9090
-    # Which component to expose metrics for: serve, worker, or worker-discovery.
+    # Which component to expose metrics for: api, worker, worker-discovery, or worker-ingest.
     component: worker
     annotations: {}
 
@@ -90,6 +90,11 @@ ingress:
           pathType: Prefix
   tls: []
 
+# Preferred API deployment settings for new installs. When unset, the chart
+# falls back to the deprecated serve.* block below for upgrade compatibility.
+api: {}
+
+# Deprecated alias for API deployment settings. Use api.* for new values files.
 serve:
   replicaCount: 1
   podAnnotations: {}
@@ -113,6 +118,18 @@ worker:
   affinity: {}
 
 discoveryWorker:
+  enabled: true
+  replicaCount: 1
+  podAnnotations: {}
+  podLabels: {}
+  extraEnv: []
+  extraEnvFrom: []
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+ingestWorker:
   enabled: true
   replicaCount: 1
   podAnnotations: {}

--- a/justfile
+++ b/justfile
@@ -70,9 +70,13 @@ lint:
 # Application Commands
 #
 
-# Start the HTTP server
+# Start the API and web UI HTTP server
 run:
-    go run ./cmd/open-sspm serve
+    go run ./cmd/open-sspm api
+
+# Start the API and web UI HTTP server
+api:
+    go run ./cmd/open-sspm api
 
 # Run the background worker
 worker:
@@ -81,6 +85,10 @@ worker:
 # Run the background discovery worker
 worker-discovery:
     go run ./cmd/open-sspm worker-discovery
+
+# Run background ingest queue processors
+worker-ingest:
+    go run ./cmd/open-sspm worker-ingest
 
 # Run a one-off sync
 sync:


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR splits the monolithic `serve` command into a dedicated `api` command (HTTP/UI only) and a new `worker-ingest` command (Okta push-ingest queue processing). The old `serve` command is kept as a deprecated alias that embeds the ingest worker for backward compat.

- `cmd/open-sspm/worker_ingest.go` is a new standalone binary entrypoint with correct `doneCh` drain, `context.Canceled` filtering, and a metrics server; the new `api` command in `serve.go` is clean and only handles HTTP.
- The Helm chart is updated throughout: `deployment-serve.yaml` is renamed to `deployment-api.yaml` with a `serve.*`\u2192`api.*` precedence merge for existing values files, a new `deployment-worker-ingest.yaml` is added, and `service.yaml` is patched to select `api` pods.
- All docs, Ansible playbooks, CI workflows, and the `justfile` are updated consistently to reflect the new command names and worker topology.

<h3>Confidence Score: 3/5</h3>

Two real operational issues need attention before merging: a Kubernetes upgrade will momentarily drop traffic due to the Service selector rename, and the deprecated `serve` path can race between pool close and the ingest goroutine on shutdown.

The Service selector flip from `serve` to `api` in `service.yaml` guarantees a brief outage on any in-place `helm upgrade` — the old Deployment's pods are deselected before the new Deployment's pods pass readiness probes. Separately, `serve.go`'s deprecated path starts an ingest goroutine but returns without a `doneCh` drain, so `runtimeDeps.pool.Close()` can fire while the goroutine is mid-query; `worker_ingest.go` handles this correctly with an explicit drain.

`helm/open-sspm/templates/service.yaml` (selector rename → upgrade downtime) and `cmd/open-sspm/serve.go` (missing goroutine drain in deprecated path).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/open-sspm/serve.go | Introduces `apiCmd`/`runAPI()` and deprecates `serveCmd` with backward-compat `StartIngestWorker` option; `context.Canceled` filter now applied (previous P1 fixed), but the deprecated path still lacks a `doneCh` drain before pool close. |
| cmd/open-sspm/worker_ingest.go | New standalone `worker-ingest` command; correctly guards on `SyncDiscoveryEnabled`, uses `doneCh` to drain the RunLoop goroutine before pool close, and filters `context.Canceled`. |
| helm/open-sspm/templates/deployment-api.yaml | Renamed from `deployment-serve.yaml`; adds `serve.*`→`api.*` precedence merge for backward compat with existing values files. Logic is correct, `api.*` overrides `serve.*`. |
| helm/open-sspm/templates/service.yaml | Selector changed from `serve` to `api`; during `helm upgrade` this creates a window where the Service has no healthy endpoints, causing brief downtime. |
| helm/open-sspm/templates/deployment-worker-ingest.yaml | New Deployment for the `worker-ingest` process; correctly gated by both `ingestWorker.enabled` and `config.syncDiscoveryEnabled`, mirrors the discovery worker structure. |
| helm/open-sspm/values.yaml | Adds `api: {}` as the preferred key, retains `serve.*` defaults for upgrade compat, and introduces `ingestWorker.*` block; defaults are sensible and well-commented. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph "Before (serve)"
        A[open-sspm serve] -->|"HTTP + ingest loop (if SYNC_DISCOVERY_ENABLED)"| B[(Postgres)]
    end

    subgraph "After (split binaries)"
        C[open-sspm api] -->|"HTTP only"| B
        D[open-sspm worker-ingest] -->|"ingest queue processing"| B
        E[open-sspm worker] -->|"full sync loop"| B
        F[open-sspm worker-discovery] -->|"discovery sync loop"| B
    end

    subgraph "Deprecated backward compat"
        G["open-sspm serve (deprecated)"] -->|"StartIngestWorker=true embeds ingest loop"| B
    end

    subgraph "Kubernetes Service routing"
        SVC[Service selector: api] --> C
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `cmd/open-sspm/serve.go`, line 145-151 ([link](https://github.com/open-sspm/open-sspm/blob/9b93641a39e5b5ebae77d2c1a4400f2210c1142c/cmd/open-sspm/serve.go#L145-L151)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> The ingest goroutine in the deprecated `serve` path does not filter `context.Canceled`, unlike the equivalent goroutine in `worker_ingest.go`. When a graceful SIGTERM arrives, the context is cancelled, `oktaingest.RunLoop` returns `context.Canceled`, and that error is sent to `errCh`. Because the select in the shutdown path races between `<-ctx.Done()` and `<-errCh`, this non-deterministically causes the process to exit with a non-zero status — triggering a systemd restart or a container orchestrator failure for users still on the `serve` command.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: cmd/open-sspm/serve.go
   Line: 145-151

   Comment:
   The ingest goroutine in the deprecated `serve` path does not filter `context.Canceled`, unlike the equivalent goroutine in `worker_ingest.go`. When a graceful SIGTERM arrives, the context is cancelled, `oktaingest.RunLoop` returns `context.Canceled`, and that error is sent to `errCh`. Because the select in the shutdown path races between `<-ctx.Done()` and `<-errCh`, this non-deterministically causes the process to exit with a non-zero status — triggering a systemd restart or a container orchestrator failure for users still on the `serve` command.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `cmd/open-sspm/serve.go`, line 145-151 ([link](https://github.com/open-sspm/open-sspm/blob/191d88b2e1498ef346c268ea823cf5f60c05fbb0/cmd/open-sspm/serve.go#L145-L151)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Ingest goroutine not drained before pool close in deprecated `serve` path**

   When SIGTERM arrives on the deprecated `serve` path (with `StartIngestWorker: true`), the select unblocks on `<-ctx.Done()`, calls `shutdown()`, and returns. The two deferred calls then run in LIFO order: `stop()` (no-op — context is already done), then `runtimeDeps.pool.Close()`. The ingest goroutine may still be executing a database query at that point — the context is cancelled so pgx will abort the query, but there is no `doneCh` synchronization to confirm the goroutine has exited before the pool is torn down. By contrast, `worker_ingest.go` uses `<-doneCh` to guarantee the goroutine has finished before the pool and shutdown context are released. The inconsistency can produce spurious "pool closed" errors logged at process exit and a non-zero exit status visible to systemd/container orchestrators.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: cmd/open-sspm/serve.go
   Line: 145-151

   Comment:
   **Ingest goroutine not drained before pool close in deprecated `serve` path**

   When SIGTERM arrives on the deprecated `serve` path (with `StartIngestWorker: true`), the select unblocks on `<-ctx.Done()`, calls `shutdown()`, and returns. The two deferred calls then run in LIFO order: `stop()` (no-op — context is already done), then `runtimeDeps.pool.Close()`. The ingest goroutine may still be executing a database query at that point — the context is cancelled so pgx will abort the query, but there is no `doneCh` synchronization to confirm the goroutine has exited before the pool is torn down. By contrast, `worker_ingest.go` uses `<-doneCh` to guarantee the goroutine has finished before the pool and shutdown context are released. The inconsistency can produce spurious "pool closed" errors logged at process exit and a non-zero exit status visible to systemd/container orchestrators.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
helm/open-sspm/templates/service.yaml:14
**`helm upgrade` causes a traffic gap during the serve→api rename**

The Service's `selector` is patched to `app.kubernetes.io/component: api` in the same upgrade that deletes the old `open-sspm-serve` Deployment and creates the new `open-sspm-api` Deployment. Kubernetes applies these changes independently: the Service is updated first, instantly dropping all traffic because no pod carries the `api` label yet. The new Deployment's pods only become ready after their rollout, so there is a window — typically 10-30 s, depending on image pull time and readiness probes — where the Service has zero healthy endpoints. Users doing `helm upgrade` in place will experience a visible service interruption. The upgrade guide or a chart note should document this expected downtime so operators can plan a maintenance window or use an offline upgrade procedure.

### Issue 2 of 2
cmd/open-sspm/serve.go:145-151
**Ingest goroutine not drained before pool close in deprecated `serve` path**

When SIGTERM arrives on the deprecated `serve` path (with `StartIngestWorker: true`), the select unblocks on `<-ctx.Done()`, calls `shutdown()`, and returns. The two deferred calls then run in LIFO order: `stop()` (no-op — context is already done), then `runtimeDeps.pool.Close()`. The ingest goroutine may still be executing a database query at that point — the context is cancelled so pgx will abort the query, but there is no `doneCh` synchronization to confirm the goroutine has exited before the pool is torn down. By contrast, `worker_ingest.go` uses `<-doneCh` to guarantee the goroutine has finished before the pool and shutdown context are released. The inconsistency can produce spurious "pool closed" errors logged at process exit and a non-zero exit status visible to systemd/container orchestrators.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["cr fix"](https://github.com/open-sspm/open-sspm/commit/191d88b2e1498ef346c268ea823cf5f60c05fbb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31435004)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->