### PR TITLE
refactor: Improve Okta push-triggered sync freshness

### DIFF
--- a/docs/config/connectors/okta.md
+++ b/docs/config/connectors/okta.md
@@ -9,19 +9,20 @@ The Okta connector syncs users, groups, applications, and assignments from your 
 - Applications
 - App assignments
 - Discovery evidence from SSO, OAuth consent, and app-assignment events
+- State refresh triggers from user, group, application, and membership change events
 
 ## Ingest Modes
 
-Open-SSPM supports polling and push for Okta discovery. Polling remains the completeness and backfill path because Okta push delivery is at-least-once and Log Streaming has no replay.
+Open-SSPM supports polling and push for Okta discovery and state freshness. Polling remains the completeness and backfill path because Okta push delivery is at-least-once and Log Streaming has no replay.
 
 | Mode | Requires | Best for | Notes |
 |------|----------|----------|-------|
 | Polling | Okta API token | Any deployment | Pulls the System Log API on a schedule. |
-| Event Hook | Public HTTPS `/ingest/okta/events` endpoint and shared secret | Non-AWS deployments that can expose inbound HTTPS | Queues only discovery-relevant eligible events. |
+| Event Hook | Public HTTPS `/ingest/okta/events` endpoint and shared secret | Non-AWS deployments that can expose inbound HTTPS | Queues discovery evidence and selected state-change signals. |
 | EventBridge | AWS EventBridge relay to `/ingest/okta/eventbridge` and shared secret | AWS customers who want full System Log push | Carries full System Log events, including `app.oauth2.signon`. |
 | Hybrid | API token plus one push channel | Recommended production setup | Push improves latency; polling covers history and gaps. |
 
-Open-SSPM does not store Okta push data as a long-term log archive. Push payloads are kept in a short-retention Postgres inbox for processing and dead-letter triage; non-discovery events are dropped before storage. Use a SIEM or object storage if you need full raw log retention.
+Open-SSPM does not store Okta push data as a long-term log archive. Push payloads are kept in a short-retention Postgres inbox for processing and dead-letter triage; events that are neither discovery evidence nor state-refresh signals are dropped before storage. Use a SIEM or object storage if you need full raw log retention.
 
 ## Prerequisites
 
@@ -70,7 +71,7 @@ Use the same secret value in Okta and in **Event Hook secret**. Open-SSPM compar
 
 Treat the Event Hook secret as a bearer credential: anyone who learns it can submit events until the secret is rotated. Open-SSPM does not verify a separate vendor HMAC signature for Event Hooks, so expose the endpoint only over HTTPS and consider a reverse proxy, WAF rule, or IP allowlist when your deployment model supports it. Replayed delivery IDs are deduplicated by Okta event ID, but replay protection does not stop fabricated events from a caller with the secret.
 
-Open-SSPM accepts and stores these discovery-relevant Event Hook events:
+Open-SSPM accepts and stores these discovery-relevant Event Hook events and selected state-change signals:
 
 - `user.authentication.sso`
 - `app.oauth2.as.consent.grant`
@@ -84,6 +85,10 @@ Open-SSPM accepts and stores these discovery-relevant Event Hook events:
 - `application.user_membership.add`
 - `application.user_membership.remove`
 - `application.user_membership.update`
+- `group.user_membership.add`, `group.user_membership.remove`, and `group.user_membership.update`
+- `user.lifecycle.*` and `user.account.*`
+- `group.lifecycle.*`
+- `application.lifecycle.*` and `app.lifecycle.*`
 
 Other valid Okta System Log events are acknowledged and dropped before storage.
 Event Hooks do not deliver every Okta System Log event; for example, `app.oauth2.signon` is handled by the poller or EventBridge.
@@ -124,7 +129,7 @@ SYNC_OKTA_INTERVAL=15m
 SYNC_OKTA_WORKERS=3
 ```
 
-Push delivery is received by the `api` process and queued in Postgres. Push processing runs in the `worker-ingest` process. The inbox processor polls queued rows every five seconds, reclaims stuck `processing` rows after five minutes, retries transient failures with exponential backoff (up to 10 attempts), then deletes processed and ignored rows after 30 days and dead-letter rows after 90 days.
+Push delivery is received by the `api` process and queued in Postgres. Push processing runs in the `worker-ingest` process. The inbox processor polls queued rows every five seconds, writes discovery evidence when present, and queues a scoped Okta full sync for user, group, application, or membership change events. It reclaims stuck `processing` rows after five minutes, retries transient failures with exponential backoff (up to 10 attempts), then deletes processed and ignored rows after 30 days and dead-letter rows after 90 days.
 
 After enabling a push channel, run an Okta discovery sync from **Settings → Connector Health**. That backfills recent history through the System Log API and keeps the source from looking healthy on push delivery alone.
 

--- a/internal/connectors/okta/discovery_normalization_test.go
+++ b/internal/connectors/okta/discovery_normalization_test.go
@@ -336,3 +336,47 @@ func TestNormalizeOktaDiscoverySignalKinds(t *testing.T) {
 		t.Fatalf("no-app signal = %q, want absent", got["no-app"])
 	}
 }
+
+func TestOktaStateRefreshSignalKinds(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		eventType string
+		wantKind  string
+		wantOK    bool
+	}{
+		{name: "app membership add", eventType: "application.user_membership.add", wantKind: "app_assignment", wantOK: true},
+		{name: "app membership remove", eventType: "application.user_membership.remove", wantKind: "app_assignment", wantOK: true},
+		{name: "group membership add", eventType: "group.user_membership.add", wantKind: "group_membership", wantOK: true},
+		{name: "user lifecycle", eventType: "user.lifecycle.deactivate", wantKind: "user", wantOK: true},
+		{name: "user account", eventType: "user.account.update_profile", wantKind: "user", wantOK: true},
+		{name: "group lifecycle", eventType: "group.lifecycle.update", wantKind: "group", wantOK: true},
+		{name: "application lifecycle", eventType: "application.lifecycle.update", wantKind: "app", wantOK: true},
+		{name: "policy lifecycle ignored", eventType: "policy.lifecycle.update", wantOK: false},
+		{name: "sso ignored for state refresh", eventType: "user.authentication.sso", wantOK: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotKind, gotOK := StateRefreshSignalKind(SystemLogEvent{EventType: tc.eventType})
+			if gotOK != tc.wantOK || gotKind != tc.wantKind {
+				t.Fatalf("StateRefreshSignalKind(%q) = %q/%v, want %q/%v", tc.eventType, gotKind, gotOK, tc.wantKind, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestShouldIngestOktaPushEventIncludesStateRefreshOnlyEvents(t *testing.T) {
+	t.Parallel()
+
+	if !ShouldIngestPushEvent(SystemLogEvent{EventType: "user.authentication.sso", AppID: "0oa1"}) {
+		t.Fatalf("SSO event with app target should be ingested")
+	}
+	if !ShouldIngestPushEvent(SystemLogEvent{EventType: "user.lifecycle.deactivate"}) {
+		t.Fatalf("state-refresh event should be ingested")
+	}
+	if ShouldIngestPushEvent(SystemLogEvent{EventType: "policy.lifecycle.update", AppID: "0oa1"}) {
+		t.Fatalf("policy lifecycle event should not be ingested")
+	}
+}

--- a/internal/connectors/okta/integration.go
+++ b/internal/connectors/okta/integration.go
@@ -884,38 +884,38 @@ func NormalizeDiscoveryEvents(events []SystemLogEvent, sourceName string, now ti
 // intentionally dropped — the prior catch-all-to-IDPSSO behavior produced too
 // much incidental signal once Okta push ingestion broadened the input stream.
 func DiscoverySignalKind(event SystemLogEvent) (string, bool) {
-	eventType := strings.ToLower(strings.TrimSpace(event.EventType))
+	normalizedEventType := strings.ToLower(strings.TrimSpace(event.EventType))
 	hasApp := strings.TrimSpace(event.AppID) != "" || strings.TrimSpace(event.AppName) != ""
 	if !hasApp {
 		return "", false
 	}
-	if isApplicationMembershipEvent(eventType) {
+	if isApplicationMembershipEvent(normalizedEventType) {
 		return discovery.SignalKindAssignment, true
 	}
-	switch eventType {
+	switch normalizedEventType {
 	case "user.authentication.sso", "app.oauth2.signon":
 		return discovery.SignalKindIDPSSO, true
 	}
-	if strings.Contains(eventType, "oauth") ||
-		strings.Contains(eventType, "grant") ||
-		strings.Contains(eventType, "consent") {
+	if strings.Contains(normalizedEventType, "oauth") ||
+		strings.Contains(normalizedEventType, "grant") ||
+		strings.Contains(normalizedEventType, "consent") {
 		return discovery.SignalKindOAuth, true
 	}
 	return "", false
 }
 
 func StateRefreshSignalKind(event SystemLogEvent) (string, bool) {
-	eventType := strings.ToLower(strings.TrimSpace(event.EventType))
+	normalizedEventType := strings.ToLower(strings.TrimSpace(event.EventType))
 	switch {
-	case isApplicationMembershipEvent(eventType):
+	case isApplicationMembershipEvent(normalizedEventType):
 		return "app_assignment", true
-	case isGroupMembershipEvent(eventType):
+	case isGroupMembershipEvent(normalizedEventType):
 		return "group_membership", true
-	case strings.HasPrefix(eventType, "user.lifecycle.") || strings.HasPrefix(eventType, "user.account."):
+	case strings.HasPrefix(normalizedEventType, "user.lifecycle.") || strings.HasPrefix(normalizedEventType, "user.account."):
 		return "user", true
-	case strings.HasPrefix(eventType, "group.lifecycle."):
+	case strings.HasPrefix(normalizedEventType, "group.lifecycle."):
 		return "group", true
-	case strings.HasPrefix(eventType, "application.lifecycle.") || strings.HasPrefix(eventType, "app.lifecycle."):
+	case strings.HasPrefix(normalizedEventType, "application.lifecycle.") || strings.HasPrefix(normalizedEventType, "app.lifecycle."):
 		return "app", true
 	default:
 		return "", false
@@ -931,7 +931,7 @@ func ShouldIngestPushEvent(event SystemLogEvent) bool {
 }
 
 func isApplicationMembershipEvent(eventType string) bool {
-	switch strings.ToLower(strings.TrimSpace(eventType)) {
+	switch eventType {
 	case "application.user_membership.add", "application.user_membership.remove", "application.user_membership.update":
 		return true
 	default:
@@ -940,7 +940,7 @@ func isApplicationMembershipEvent(eventType string) bool {
 }
 
 func isGroupMembershipEvent(eventType string) bool {
-	switch strings.ToLower(strings.TrimSpace(eventType)) {
+	switch eventType {
 	case "group.user_membership.add", "group.user_membership.remove", "group.user_membership.update":
 		return true
 	default:

--- a/internal/connectors/okta/integration.go
+++ b/internal/connectors/okta/integration.go
@@ -889,13 +889,8 @@ func DiscoverySignalKind(event SystemLogEvent) (string, bool) {
 	if !hasApp {
 		return "", false
 	}
-	if strings.HasPrefix(eventType, "application.user_membership.") {
-		switch eventType {
-		case "application.user_membership.add", "application.user_membership.remove", "application.user_membership.update":
-			return discovery.SignalKindAssignment, true
-		default:
-			return "", false
-		}
+	if isApplicationMembershipEvent(eventType) {
+		return discovery.SignalKindAssignment, true
 	}
 	switch eventType {
 	case "user.authentication.sso", "app.oauth2.signon":
@@ -907,6 +902,50 @@ func DiscoverySignalKind(event SystemLogEvent) (string, bool) {
 		return discovery.SignalKindOAuth, true
 	}
 	return "", false
+}
+
+func StateRefreshSignalKind(event SystemLogEvent) (string, bool) {
+	eventType := strings.ToLower(strings.TrimSpace(event.EventType))
+	switch {
+	case isApplicationMembershipEvent(eventType):
+		return "app_assignment", true
+	case isGroupMembershipEvent(eventType):
+		return "group_membership", true
+	case strings.HasPrefix(eventType, "user.lifecycle.") || strings.HasPrefix(eventType, "user.account."):
+		return "user", true
+	case strings.HasPrefix(eventType, "group.lifecycle."):
+		return "group", true
+	case strings.HasPrefix(eventType, "application.lifecycle.") || strings.HasPrefix(eventType, "app.lifecycle."):
+		return "app", true
+	default:
+		return "", false
+	}
+}
+
+func ShouldIngestPushEvent(event SystemLogEvent) bool {
+	if _, ok := DiscoverySignalKind(event); ok {
+		return true
+	}
+	_, ok := StateRefreshSignalKind(event)
+	return ok
+}
+
+func isApplicationMembershipEvent(eventType string) bool {
+	switch strings.ToLower(strings.TrimSpace(eventType)) {
+	case "application.user_membership.add", "application.user_membership.remove", "application.user_membership.update":
+		return true
+	default:
+		return false
+	}
+}
+
+func isGroupMembershipEvent(eventType string) bool {
+	switch strings.ToLower(strings.TrimSpace(eventType)) {
+	case "group.user_membership.add", "group.user_membership.remove", "group.user_membership.update":
+		return true
+	default:
+		return false
+	}
 }
 
 func (i *OktaIntegration) writeDiscoveryRows(ctx context.Context, q *gen.Queries, report func(registry.Event), runID int64, sources []discovery.SourceRow, events []discovery.EventRow) error {

--- a/internal/connectors/registry/helpers.go
+++ b/internal/connectors/registry/helpers.go
@@ -440,6 +440,10 @@ func FinalizeAppRun(ctx context.Context, q *gen.Queries, pool *pgxpool.Pool, run
 }
 
 func FinalizeDiscoveryRun(ctx context.Context, q *gen.Queries, pool *pgxpool.Pool, runID int64, sourceKind, sourceName string, duration time.Duration) error {
+	return FinalizeDiscoveryRunWithCounts(ctx, q, pool, runID, sourceKind, sourceName, duration, nil)
+}
+
+func FinalizeDiscoveryRunWithCounts(ctx context.Context, q *gen.Queries, pool *pgxpool.Pool, runID int64, sourceKind, sourceName string, duration time.Duration, extraCounts map[string]int64) error {
 	tx, err := pool.Begin(ctx)
 	if err != nil {
 		return err
@@ -488,6 +492,10 @@ func FinalizeDiscoveryRun(ctx context.Context, q *gen.Queries, pool *pgxpool.Poo
 		return err
 	}
 	counts["saas_app_events_expired"] = expired
+
+	for key, count := range extraCounts {
+		counts[key] += count
+	}
 
 	if err := finalizeRunCountsInTx(ctx, qtx, runID, counts, duration, sourceKind, sourceName); err != nil {
 		return err

--- a/internal/http/handlers/okta_push_ingest.go
+++ b/internal/http/handlers/okta_push_ingest.go
@@ -281,7 +281,7 @@ func oktaPushInboxParamsFromRawEvents(sourceName, channel, deliveryExternalID st
 		if err != nil {
 			return gen.UpsertOktaPushInboxEventsBulkParams{}, 0, echo.NewHTTPError(http.StatusBadRequest, "invalid Okta System Log event")
 		}
-		if _, ok := oktaconnector.DiscoverySignalKind(event); !ok {
+		if !oktaconnector.ShouldIngestPushEvent(event) {
 			ignored++
 			continue
 		}

--- a/internal/http/handlers/okta_push_ingest_test.go
+++ b/internal/http/handlers/okta_push_ingest_test.go
@@ -125,6 +125,35 @@ func TestHandleOktaEventHookPostDropsNonDiscoveryEventsBeforeStorage(t *testing.
 	})
 }
 
+func TestHandleOktaEventHookPostQueuesStateRefreshEvents(t *testing.T) {
+	withCommandSearchTestDatabase(t, func(ctx context.Context, pool *pgxpool.Pool, _ *gen.Queries, h *Handlers) {
+		upsertOktaPushIngestConfig(t, ctx, pool)
+
+		body := `{
+			"eventId": "delivery-user-refresh",
+			"data": {
+				"events": [{
+					"uuid": "evt-user-refresh-1",
+					"eventType": "user.lifecycle.deactivate",
+					"published": "2026-01-01T12:00:00Z",
+					"actor": {"id": "00u1", "alternateId": "alice@example.com", "displayName": "Alice"}
+				}]
+			}
+		}`
+		c, rec := newOktaIngestContext(http.MethodPost, "http://example.com/ingest/okta/events", body)
+		c.Request().Header.Set(echo.HeaderAuthorization, "hook-secret")
+
+		if err := h.HandleOktaEventHookPost(c); err != nil {
+			t.Fatalf("HandleOktaEventHookPost(): %v", err)
+		}
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusNoContent, rec.Body.String())
+		}
+
+		assertOktaPushInboxRow(t, ctx, pool, "acme.okta.com", "event_hook", "delivery-user-refresh", "evt-user-refresh-1", "user.lifecycle.deactivate")
+	})
+}
+
 func TestHandleOktaEventHookPostRejectsDisabledIngestConfigurations(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/ingest/okta/processor.go
+++ b/internal/ingest/okta/processor.go
@@ -278,21 +278,28 @@ func startOktaPushSyncRun(ctx context.Context, q *gen.Queries, sourceName string
 }
 
 func finalizeOktaPushRun(ctx context.Context, q *gen.Queries, pool *pgxpool.Pool, runID int64, sourceName string, duration time.Duration, hasDiscoveryRows bool, refreshCounts map[string]int64) error {
+	counts := oktaStateRefreshRunCounts(refreshCounts)
 	if hasDiscoveryRows {
-		return registry.FinalizeDiscoveryRun(ctx, q, pool, runID, "okta", sourceName, duration)
+		return registry.FinalizeDiscoveryRunWithCounts(ctx, q, pool, runID, "okta", sourceName, duration, counts)
 	}
+	stats := registry.MarshalJSON(map[string]any{
+		"counts":      counts,
+		"duration_ms": duration.Milliseconds(),
+	})
+	return q.MarkSyncRunSuccess(ctx, gen.MarkSyncRunSuccessParams{ID: runID, Stats: stats})
+}
+
+func oktaStateRefreshRunCounts(refreshCounts map[string]int64) map[string]int64 {
 	counts := map[string]int64{}
 	var total int64
 	for kind, count := range refreshCounts {
 		counts["state_refresh_"+kind] = count
 		total += count
 	}
-	counts["state_refresh_events"] = total
-	stats := registry.MarshalJSON(map[string]any{
-		"counts":      counts,
-		"duration_ms": duration.Milliseconds(),
-	})
-	return q.MarkSyncRunSuccess(ctx, gen.MarkSyncRunSuccessParams{ID: runID, Stats: stats})
+	if total > 0 {
+		counts["state_refresh_events"] = total
+	}
+	return counts
 }
 
 func enqueueOktaFullSync(ctx context.Context, pool *pgxpool.Pool, sourceName string) error {

--- a/internal/ingest/okta/processor.go
+++ b/internal/ingest/okta/processor.go
@@ -11,11 +11,13 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/open-sspm/open-sspm/internal/connectors/configstore"
 	oktaconnector "github.com/open-sspm/open-sspm/internal/connectors/okta"
 	"github.com/open-sspm/open-sspm/internal/connectors/registry"
 	"github.com/open-sspm/open-sspm/internal/db/gen"
 	"github.com/open-sspm/open-sspm/internal/discovery"
 	"github.com/open-sspm/open-sspm/internal/metrics"
+	osspmsync "github.com/open-sspm/open-sspm/internal/sync"
 )
 
 const (
@@ -163,7 +165,7 @@ func processSourceRows(ctx context.Context, q *gen.Queries, pool *pgxpool.Pool, 
 			deadLetterIDs = append(deadLetterIDs, row.ID)
 			continue
 		}
-		if _, ok := oktaconnector.DiscoverySignalKind(event); !ok {
+		if !oktaconnector.ShouldIngestPushEvent(event) {
 			ignoredIDs = append(ignoredIDs, row.ID)
 			continue
 		}
@@ -176,25 +178,33 @@ func processSourceRows(ctx context.Context, q *gen.Queries, pool *pgxpool.Pool, 
 	if err := flushDeadLetter(ctx, q, sourceName, rows, deadLetterIDs, "invalid Okta System Log event JSON", "mark okta push inbox dead-letter", &result); err != nil {
 		return result, err
 	}
-	if err := flushIgnored(ctx, q, sourceName, rows, ignoredIDs, "event is not discovery evidence", &result); err != nil {
+	if err := flushIgnored(ctx, q, sourceName, rows, ignoredIDs, "event is not discovery or state-refresh evidence", &result); err != nil {
 		return result, err
 	}
 	if len(parsed) == 0 {
 		return result, nil
 	}
 
-	events := make([]oktaconnector.SystemLogEvent, 0, len(parsed))
+	discoveryEvents := make([]oktaconnector.SystemLogEvent, 0, len(parsed))
 	processedIDs := make([]int64, 0, len(parsed))
+	refreshCounts := make(map[string]int64)
 	for _, item := range parsed {
-		events = append(events, item.event)
+		if _, ok := oktaconnector.DiscoverySignalKind(item.event); ok {
+			discoveryEvents = append(discoveryEvents, item.event)
+		}
+		if kind, ok := oktaconnector.StateRefreshSignalKind(item.event); ok {
+			refreshCounts[kind]++
+		}
 		processedIDs = append(processedIDs, item.row.ID)
 	}
 
-	sources, normalizedEvents := oktaconnector.NormalizeDiscoveryEvents(events, sourceName, time.Now().UTC())
-	if len(sources) == 0 && len(normalizedEvents) == 0 {
+	sources, normalizedEvents := oktaconnector.NormalizeDiscoveryEvents(discoveryEvents, sourceName, time.Now().UTC())
+	hasDiscoveryRows := len(sources) > 0 || len(normalizedEvents) > 0
+	hasStateRefresh := len(refreshCounts) > 0
+	if !hasDiscoveryRows && !hasStateRefresh {
 		if _, err := q.MarkOktaPushInboxIgnored(ctx, gen.MarkOktaPushInboxIgnoredParams{
 			ProcessedRunID: pgtype.Int8{},
-			ErrorMessage:   "event did not normalize to discovery evidence",
+			ErrorMessage:   "event did not normalize to discovery or state-refresh evidence",
 			Ids:            processedIDs,
 		}); err != nil {
 			return result, fmt.Errorf("mark okta push inbox ignored: %w", err)
@@ -211,18 +221,29 @@ func processSourceRows(ctx context.Context, q *gen.Queries, pool *pgxpool.Pool, 
 		return result, err
 	}
 
-	if err := discovery.WriteRows(ctx, q, discovery.WriteRowsParams{
-		SourceKind: "okta",
-		SourceName: sourceName,
-		RunID:      runID,
-		Sources:    sources,
-		Events:     normalizedEvents,
-	}); err != nil {
-		_ = registry.FailSyncRun(ctx, q, runID, err, registry.SyncErrorKindDB)
-		_ = retryOrDeadLetterRows(ctx, q, sourceName, inboxRowsFromParsed(parsed), err, cfg)
-		return result, err
+	if hasDiscoveryRows {
+		if err := discovery.WriteRows(ctx, q, discovery.WriteRowsParams{
+			SourceKind: "okta",
+			SourceName: sourceName,
+			RunID:      runID,
+			Sources:    sources,
+			Events:     normalizedEvents,
+		}); err != nil {
+			_ = registry.FailSyncRun(ctx, q, runID, err, registry.SyncErrorKindDB)
+			_ = retryOrDeadLetterRows(ctx, q, sourceName, inboxRowsFromParsed(parsed), err, cfg)
+			return result, err
+		}
 	}
-	if err := registry.FinalizeDiscoveryRun(ctx, q, pool, runID, "okta", sourceName, time.Since(runStarted)); err != nil {
+
+	if hasStateRefresh {
+		if err := enqueueOktaFullSync(ctx, pool, sourceName); err != nil {
+			_ = registry.FailSyncRun(ctx, q, runID, err, registry.SyncErrorKindDB)
+			_ = retryOrDeadLetterRows(ctx, q, sourceName, inboxRowsFromParsed(parsed), err, cfg)
+			return result, err
+		}
+	}
+
+	if err := finalizeOktaPushRun(ctx, q, pool, runID, sourceName, time.Since(runStarted), hasDiscoveryRows, refreshCounts); err != nil {
 		_ = registry.FailSyncRun(ctx, q, runID, err, registry.SyncErrorKindDB)
 		_ = retryOrDeadLetterRows(ctx, q, sourceName, inboxRowsFromParsed(parsed), err, cfg)
 		return result, err
@@ -254,6 +275,41 @@ func startOktaPushSyncRun(ctx context.Context, q *gen.Queries, sourceName string
 		return 0, fmt.Errorf("create sync run for %s/%s: %w", SourceKindOktaPush, sourceName, err)
 	}
 	return runID, nil
+}
+
+func finalizeOktaPushRun(ctx context.Context, q *gen.Queries, pool *pgxpool.Pool, runID int64, sourceName string, duration time.Duration, hasDiscoveryRows bool, refreshCounts map[string]int64) error {
+	if hasDiscoveryRows {
+		return registry.FinalizeDiscoveryRun(ctx, q, pool, runID, "okta", sourceName, duration)
+	}
+	counts := map[string]int64{}
+	var total int64
+	for kind, count := range refreshCounts {
+		counts["state_refresh_"+kind] = count
+		total += count
+	}
+	counts["state_refresh_events"] = total
+	stats := registry.MarshalJSON(map[string]any{
+		"counts":      counts,
+		"duration_ms": duration.Milliseconds(),
+	})
+	return q.MarkSyncRunSuccess(ctx, gen.MarkSyncRunSuccessParams{ID: runID, Stats: stats})
+}
+
+func enqueueOktaFullSync(ctx context.Context, pool *pgxpool.Pool, sourceName string) error {
+	if pool == nil {
+		return fmt.Errorf("queue okta full sync: pool is nil")
+	}
+	store := osspmsync.NewSyncJobStore(pool)
+	runner := osspmsync.NewResyncQueueRunnerWithPlanner(store, nil, registry.RunModeFull)
+	err := runner.RunOnce(osspmsync.WithConnectorScope(ctx, configstore.KindOkta, sourceName))
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, osspmsync.ErrSyncQueued), errors.Is(err, osspmsync.ErrSyncAlreadyRunning):
+		return nil
+	default:
+		return fmt.Errorf("queue okta full sync for %s: %w", sourceName, err)
+	}
 }
 
 func flushDeadLetter(ctx context.Context, q *gen.Queries, sourceName string, rows []gen.OktaPushInbox, ids []int64, errMsg, wrapPrefix string, result *ProcessResult) error {

--- a/internal/ingest/okta/processor_integration_test.go
+++ b/internal/ingest/okta/processor_integration_test.go
@@ -55,6 +55,78 @@ func TestProcessQueuedWritesDiscoveryRows(t *testing.T) {
 	})
 }
 
+func TestProcessQueuedQueuesOktaFullSyncForAssignmentChanges(t *testing.T) {
+	withOktaIngestTestDatabase(t, func(ctx context.Context, pool *pgxpool.Pool, q *gen.Queries) {
+		queueOktaPushEvent(t, ctx, q, "acme.okta.com", "evt-assignment-refresh", `{
+			"uuid": "evt-assignment-refresh",
+			"eventType": "application.user_membership.add",
+			"published": "2026-01-01T12:00:00Z",
+			"actor": {"id": "00u1", "alternateId": "alice@example.com", "displayName": "Alice"},
+			"target": [{"id": "0oa1", "type": "AppInstance", "alternateId": "https://app.example.com", "displayName": "Example App"}]
+		}`)
+
+		result, err := ProcessQueued(ctx, q, pool, 100)
+		if err != nil {
+			t.Fatalf("ProcessQueued(): %v", err)
+		}
+		if result.Processed != 1 {
+			t.Fatalf("processed = %d, want 1", result.Processed)
+		}
+
+		assertQueuedOktaFullSync(t, ctx, pool, "acme.okta.com")
+	})
+}
+
+func TestProcessQueuedQueuesOktaFullSyncForStateRefreshOnlyEvents(t *testing.T) {
+	withOktaIngestTestDatabase(t, func(ctx context.Context, pool *pgxpool.Pool, q *gen.Queries) {
+		queueOktaPushEvent(t, ctx, q, "acme.okta.com", "evt-user-refresh", `{
+			"uuid": "evt-user-refresh",
+			"eventType": "user.lifecycle.deactivate",
+			"published": "2026-01-01T12:00:00Z",
+			"actor": {"id": "00u1", "alternateId": "alice@example.com", "displayName": "Alice"}
+		}`)
+
+		result, err := ProcessQueued(ctx, q, pool, 100)
+		if err != nil {
+			t.Fatalf("ProcessQueued(): %v", err)
+		}
+		if result.Processed != 1 || result.Ignored != 0 {
+			t.Fatalf("result = %+v, want processed=1 ignored=0", result)
+		}
+
+		var status, runStatus, sourceKind string
+		var processedRunID pgtype.Int8
+		if err := pool.QueryRow(ctx, `
+			SELECT i.status, i.processed_run_id, sr.source_kind, sr.status
+			FROM okta_push_inbox i
+			JOIN sync_runs sr ON sr.id = i.processed_run_id
+			WHERE i.event_external_id = 'evt-user-refresh'
+		`).Scan(&status, &processedRunID, &sourceKind, &runStatus); err != nil {
+			t.Fatalf("select processed state-refresh event: %v", err)
+		}
+		if status != "processed" || !processedRunID.Valid {
+			t.Fatalf("inbox status/run = %q/%+v, want processed with run", status, processedRunID)
+		}
+		if sourceKind != SourceKindOktaPush || runStatus != "success" {
+			t.Fatalf("run = %s/%s, want %s/success", sourceKind, runStatus, SourceKindOktaPush)
+		}
+
+		var discoveryEvents int
+		if err := pool.QueryRow(ctx, `
+			SELECT count(*)
+			FROM saas_app_events
+			WHERE event_external_id = 'evt-user-refresh'
+		`).Scan(&discoveryEvents); err != nil {
+			t.Fatalf("count discovery events: %v", err)
+		}
+		if discoveryEvents != 0 {
+			t.Fatalf("discovery events = %d, want 0", discoveryEvents)
+		}
+
+		assertQueuedOktaFullSync(t, ctx, pool, "acme.okta.com")
+	})
+}
+
 func TestProcessQueuedUsesOktaPushRunWithoutReclaimingExistingRuns(t *testing.T) {
 	withOktaIngestTestDatabase(t, func(ctx context.Context, pool *pgxpool.Pool, q *gen.Queries) {
 		var discoveryRunID int64
@@ -426,5 +498,25 @@ func queueOktaPushEvent(t *testing.T, ctx context.Context, q *gen.Queries, sourc
 		RawJsons:            [][]byte{[]byte(raw)},
 	}); err != nil {
 		t.Fatalf("queue okta push event: %v", err)
+	}
+}
+
+func assertQueuedOktaFullSync(t *testing.T, ctx context.Context, pool *pgxpool.Pool, sourceName string) {
+	t.Helper()
+
+	var count int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*)
+		FROM sync_jobs
+		WHERE lane = 'full'
+		  AND connector_kind = 'okta'
+		  AND source_name = $1
+		  AND trigger_kind = 'manual'
+		  AND status = 'pending'
+	`, sourceName).Scan(&count); err != nil {
+		t.Fatalf("count queued okta full sync jobs: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("queued okta full sync jobs = %d, want 1", count)
 	}
 }

--- a/internal/ingest/okta/processor_integration_test.go
+++ b/internal/ingest/okta/processor_integration_test.go
@@ -2,6 +2,7 @@ package oktaingest
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -121,6 +122,59 @@ func TestProcessQueuedQueuesOktaFullSyncForStateRefreshOnlyEvents(t *testing.T) 
 		}
 		if discoveryEvents != 0 {
 			t.Fatalf("discovery events = %d, want 0", discoveryEvents)
+		}
+
+		assertQueuedOktaFullSync(t, ctx, pool, "acme.okta.com")
+	})
+}
+
+func TestProcessQueuedRecordsStateRefreshStatsForMixedBatch(t *testing.T) {
+	withOktaIngestTestDatabase(t, func(ctx context.Context, pool *pgxpool.Pool, q *gen.Queries) {
+		queueOktaPushEvent(t, ctx, q, "acme.okta.com", "evt-sso-1", `{
+			"uuid": "evt-sso-1",
+			"eventType": "user.authentication.sso",
+			"published": "2026-01-01T12:00:00Z",
+			"actor": {"id": "00u1", "alternateId": "alice@example.com", "displayName": "Alice"},
+			"target": [{"id": "0oa1", "type": "AppInstance", "alternateId": "https://app.example.com", "displayName": "Example App"}]
+		}`)
+		queueOktaPushEvent(t, ctx, q, "acme.okta.com", "evt-user-refresh", `{
+			"uuid": "evt-user-refresh",
+			"eventType": "user.lifecycle.deactivate",
+			"published": "2026-01-01T12:00:00Z",
+			"actor": {"id": "00u1", "alternateId": "alice@example.com", "displayName": "Alice"}
+		}`)
+
+		result, err := ProcessQueued(ctx, q, pool, 100)
+		if err != nil {
+			t.Fatalf("ProcessQueued(): %v", err)
+		}
+		if result.Processed != 2 {
+			t.Fatalf("processed = %d, want 2", result.Processed)
+		}
+
+		var rawStats []byte
+		if err := pool.QueryRow(ctx, `
+			SELECT stats
+			FROM sync_runs
+			WHERE source_kind = 'okta_push'
+			  AND source_name = 'acme.okta.com'
+			  AND status = 'success'
+			ORDER BY id DESC
+			LIMIT 1
+		`).Scan(&rawStats); err != nil {
+			t.Fatalf("select okta_push stats: %v", err)
+		}
+		var stats struct {
+			Counts map[string]int64 `json:"counts"`
+		}
+		if err := json.Unmarshal(rawStats, &stats); err != nil {
+			t.Fatalf("unmarshal okta_push stats: %v", err)
+		}
+		if stats.Counts["state_refresh_user"] != 1 || stats.Counts["state_refresh_events"] != 1 {
+			t.Fatalf("state refresh counts = %+v, want user=1 events=1", stats.Counts)
+		}
+		if stats.Counts["saas_app_events_observed"] != 1 {
+			t.Fatalf("saas_app_events_observed = %d, want 1", stats.Counts["saas_app_events_observed"])
 		}
 
 		assertQueuedOktaFullSync(t, ctx, pool, "acme.okta.com")


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends Okta push-triggered sync so that state-change events (user lifecycle, group lifecycle, application lifecycle, and group/application membership changes) are now ingested and used to enqueue a scoped Okta full sync, improving data freshness without waiting for the next polling cycle.

- **New `StateRefreshSignalKind` and `ShouldIngestPushEvent` functions** classify events as discovery evidence, state-refresh signals, or both, replacing the previous `DiscoverySignalKind`-only gate at both the HTTP ingest layer and the inbox processor.
- **`processSourceRows` is refactored** to split each parsed event into discovery evidence and/or a state-refresh counter, write discovery rows conditionally, enqueue a full Okta sync when refresh signals are present, and record per-kind refresh counts in the run stats via the new `FinalizeDiscoveryRunWithCounts` helper.
- **`FinalizeDiscoveryRunWithCounts`** is introduced as a thin wrapper around `FinalizeDiscoveryRun` that merges caller-supplied extra counts (e.g., `state_refresh_user=1`) into the finalized run stats in the same transaction.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change correctly bifurcates the existing push-ingest pipeline into discovery and state-refresh paths with proper idempotency, no transaction gaps, and thorough integration test coverage across all new event categories.

The dual-signal split in processSourceRows is logically sound: each parsed event is independently classified for discovery evidence and for state-refresh, the enqueue path is idempotent (ErrSyncQueued/ErrSyncAlreadyRunning are treated as success), and the FinalizeDiscoveryRunWithCounts extra-counts merge uses a prefixed key convention that prevents any collision with the built-in promote/expire counts. Error handling on the new enqueueOktaFullSync call mirrors the existing discovery.WriteRows failure path. The nil-planner path in ResyncQueueRunner is explicitly guarded before the Prepare call.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/ingest/okta/processor.go | Core logic refactored to split discovery and state-refresh signal paths; new enqueueOktaFullSync and finalizeOktaPushRun helpers added with proper idempotency and error handling. |
| internal/connectors/okta/integration.go | Adds StateRefreshSignalKind, ShouldIngestPushEvent, isApplicationMembershipEvent, isGroupMembershipEvent; DiscoverySignalKind refactored to use isApplicationMembershipEvent with equivalent semantics. |
| internal/connectors/registry/helpers.go | FinalizeDiscoveryRunWithCounts introduced as a superset of FinalizeDiscoveryRun; extra counts are merged additively after the built-in promote/expire counts with no key collision risk given the state_refresh_* prefix convention. |
| internal/http/handlers/okta_push_ingest.go | Single-line change to replace DiscoverySignalKind gate with ShouldIngestPushEvent, correctly broadening accepted event set at the HTTP layer. |
| internal/http/handlers/okta_push_ingest_test.go | Adds integration test verifying that a user.lifecycle.deactivate event is queued and stored, complementing the unit-level signal-kind tests. |
| internal/ingest/okta/processor_integration_test.go | Three new integration tests covering assignment-change sync enqueue, state-refresh-only event processing, and mixed-batch stats recording; assertQueuedOktaFullSync helper added. |
| internal/connectors/okta/discovery_normalization_test.go | New unit tests for StateRefreshSignalKind and ShouldIngestPushEvent covering all major event prefixes and a few negative cases. |
| docs/config/connectors/okta.md | Documentation updated to reflect the new state-refresh ingestion behaviour, expanded event list, and the revised processing pipeline description. |

</details>

<sub>Reviews (2): Last reviewed commit: ["cr fixes"](https://github.com/open-sspm/open-sspm/commit/9890b491afc5bb47996aed5bc81caeed192f2770) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31442157)</sub>

<!-- /greptile_comment -->