### PR TITLE
feat: promote identities

### DIFF
--- a/db/queries/identities.sql
+++ b/db/queries/identities.sql
@@ -213,6 +213,10 @@ WHERE
   AND (
     sqlc.arg(activity_state)::text = ''
     OR b.activity_state = sqlc.arg(activity_state)::text
+  )
+  AND (
+    sqlc.arg(row_state)::text = ''
+    OR b.row_state = sqlc.arg(row_state)::text
   );
 
 -- name: ListIdentitiesInventoryPageByFilters :many
@@ -434,6 +438,10 @@ WHERE
   AND (
     sqlc.arg(activity_state)::text = ''
     OR b.activity_state = sqlc.arg(activity_state)::text
+  )
+  AND (
+    sqlc.arg(row_state)::text = ''
+    OR b.row_state = sqlc.arg(row_state)::text
   )
 ORDER BY
   CASE
@@ -717,6 +725,11 @@ SELECT
   COUNT(*) FILTER (WHERE row_state = 'action_required')::bigint             AS action_required_count,
   COUNT(*) FILTER (WHERE row_state = 'review')::bigint                      AS review_count,
   COUNT(*) FILTER (WHERE privileged_roles > 0)::bigint                      AS privileged_count,
+  COUNT(*) FILTER (WHERE privileged_roles > 0 AND NOT managed)::bigint       AS privileged_unmanaged_count,
+  COUNT(*) FILTER (
+    WHERE privileged_roles > 0
+      AND activity_state = 'stale'
+  )::bigint                                                                 AS stale_privileged_count,
   COUNT(*) FILTER (WHERE NOT managed)::bigint                               AS unmanaged_count,
   COUNT(*) FILTER (WHERE status = 'suspended')::bigint                      AS suspended_count,
   COUNT(*) FILTER (WHERE activity_state = 'stale')::bigint                   AS stale_count

--- a/internal/db/gen/identities.sql.go
+++ b/internal/db/gen/identities.sql.go
@@ -16,8 +16,8 @@ WITH configured_sources AS (
   SELECT
     k.kind AS source_kind,
     n.name AS source_name
-  FROM unnest($5::text[]) WITH ORDINALITY AS k(kind, ord)
-  JOIN unnest($6::text[]) WITH ORDINALITY AS n(name, ord) USING (ord)
+  FROM unnest($6::text[]) WITH ORDINALITY AS k(kind, ord)
+  JOIN unnest($7::text[]) WITH ORDINALITY AS n(name, ord) USING (ord)
 ),
 all_active_accounts AS (
   SELECT
@@ -41,12 +41,12 @@ filtered_source_accounts AS (
   SELECT identity_id, account_id, source_kind, source_name, external_id, created_at, last_observed_at, normalized_status
   FROM all_active_accounts aa
   WHERE (
-      $7::text = ''
-      OR aa.source_kind = $7::text
+      $8::text = ''
+      OR aa.source_kind = $8::text
     )
     AND (
-      $8::text = ''
-      OR aa.source_name = $8::text
+      $9::text = ''
+      OR aa.source_name = $9::text
     )
 ),
 filtered_identities AS (
@@ -55,19 +55,19 @@ filtered_identities AS (
   FROM identities i
   WHERE
     (
-      $9::text = ''
-      OR i.primary_email ILIKE ('%' || $9::text || '%')
-      OR i.display_name ILIKE ('%' || $9::text || '%')
+      $10::text = ''
+      OR i.primary_email ILIKE ('%' || $10::text || '%')
+      OR i.display_name ILIKE ('%' || $10::text || '%')
       OR EXISTS (
         SELECT 1
         FROM all_active_accounts aa
         WHERE aa.identity_id = i.id
-          AND aa.external_id ILIKE ('%' || $9::text || '%')
+          AND aa.external_id ILIKE ('%' || $10::text || '%')
       )
     )
     AND (
-      $10::text = ''
-      OR i.kind = $10::text
+      $11::text = ''
+      OR i.kind = $11::text
     )
 ),
 candidate_identities AS (
@@ -190,6 +190,10 @@ WHERE
     $4::text = ''
     OR b.activity_state = $4::text
   )
+  AND (
+    $5::text = ''
+    OR b.row_state = $5::text
+  )
 `
 
 type CountIdentitiesInventoryByFiltersParams struct {
@@ -197,6 +201,7 @@ type CountIdentitiesInventoryByFiltersParams struct {
 	PrivilegedOnly        bool     `json:"privileged_only"`
 	Status                string   `json:"status"`
 	ActivityState         string   `json:"activity_state"`
+	RowState              string   `json:"row_state"`
 	ConfiguredSourceKinds []string `json:"configured_source_kinds"`
 	ConfiguredSourceNames []string `json:"configured_source_names"`
 	SourceKind            string   `json:"source_kind"`
@@ -211,6 +216,7 @@ func (q *Queries) CountIdentitiesInventoryByFilters(ctx context.Context, arg Cou
 		arg.PrivilegedOnly,
 		arg.Status,
 		arg.ActivityState,
+		arg.RowState,
 		arg.ConfiguredSourceKinds,
 		arg.ConfiguredSourceNames,
 		arg.SourceKind,
@@ -342,8 +348,8 @@ WITH configured_sources AS (
   SELECT
     k.kind AS source_kind,
     n.name AS source_name
-  FROM unnest($9::text[]) WITH ORDINALITY AS k(kind, ord)
-  JOIN unnest($10::text[]) WITH ORDINALITY AS n(name, ord) USING (ord)
+  FROM unnest($10::text[]) WITH ORDINALITY AS k(kind, ord)
+  JOIN unnest($11::text[]) WITH ORDINALITY AS n(name, ord) USING (ord)
 ),
 all_active_accounts AS (
   SELECT
@@ -367,12 +373,12 @@ filtered_source_accounts AS (
   SELECT identity_id, account_id, source_kind, source_name, external_id, created_at, last_observed_at, normalized_status
   FROM all_active_accounts aa
   WHERE (
-      $11::text = ''
-      OR aa.source_kind = $11::text
+      $12::text = ''
+      OR aa.source_kind = $12::text
     )
     AND (
-      $12::text = ''
-      OR aa.source_name = $12::text
+      $13::text = ''
+      OR aa.source_name = $13::text
     )
 ),
 filtered_identities AS (
@@ -385,19 +391,19 @@ filtered_identities AS (
   FROM identities i
   WHERE
     (
-      $13::text = ''
-      OR i.primary_email ILIKE ('%' || $13::text || '%')
-      OR i.display_name ILIKE ('%' || $13::text || '%')
+      $14::text = ''
+      OR i.primary_email ILIKE ('%' || $14::text || '%')
+      OR i.display_name ILIKE ('%' || $14::text || '%')
       OR EXISTS (
         SELECT 1
         FROM all_active_accounts aa
         WHERE aa.identity_id = i.id
-          AND aa.external_id ILIKE ('%' || $13::text || '%')
+          AND aa.external_id ILIKE ('%' || $14::text || '%')
       )
     )
     AND (
-      $14::text = ''
-      OR i.kind = $14::text
+      $15::text = ''
+      OR i.kind = $15::text
     )
 ),
 candidate_identities AS (
@@ -557,88 +563,92 @@ WHERE
     $4::text = ''
     OR b.activity_state = $4::text
   )
+  AND (
+    $5::text = ''
+    OR b.row_state = $5::text
+  )
 ORDER BY
   CASE
-    WHEN $5::text = '' THEN
+    WHEN $6::text = '' THEN
       CASE b.row_state
         WHEN 'action_required' THEN 0
         WHEN 'review' THEN 1
         ELSE 2
       END
   END ASC,
-  CASE WHEN $5::text = '' THEN b.privileged_roles END DESC,
-  CASE WHEN $5::text = '' THEN b.last_seen_at END ASC NULLS FIRST,
-  CASE WHEN $5::text = '' THEN b.id END DESC,
+  CASE WHEN $6::text = '' THEN b.privileged_roles END DESC,
+  CASE WHEN $6::text = '' THEN b.last_seen_at END ASC NULLS FIRST,
+  CASE WHEN $6::text = '' THEN b.id END DESC,
 
   CASE
-    WHEN $5::text = 'identity'
-      AND $6::text = 'asc'
+    WHEN $6::text = 'identity'
+      AND $7::text = 'asc'
     THEN lower(COALESCE(NULLIF(trim(b.display_name), ''), NULLIF(trim(b.primary_email), ''), 'identity ' || b.id::text))
   END ASC,
   CASE
-    WHEN $5::text = 'identity'
-      AND $6::text = 'desc'
+    WHEN $6::text = 'identity'
+      AND $7::text = 'desc'
     THEN lower(COALESCE(NULLIF(trim(b.display_name), ''), NULLIF(trim(b.primary_email), ''), 'identity ' || b.id::text))
   END DESC,
 
   CASE
-    WHEN $5::text = 'identity_type'
-      AND $6::text = 'asc'
+    WHEN $6::text = 'identity_type'
+      AND $7::text = 'asc'
     THEN lower(b.identity_type)
   END ASC,
   CASE
-    WHEN $5::text = 'identity_type'
-      AND $6::text = 'desc'
+    WHEN $6::text = 'identity_type'
+      AND $7::text = 'desc'
     THEN lower(b.identity_type)
   END DESC,
 
   CASE
-    WHEN $5::text = 'managed'
-      AND $6::text = 'asc'
+    WHEN $6::text = 'managed'
+      AND $7::text = 'asc'
     THEN CASE WHEN b.managed THEN 1 ELSE 0 END
   END ASC,
   CASE
-    WHEN $5::text = 'managed'
-      AND $6::text = 'desc'
+    WHEN $6::text = 'managed'
+      AND $7::text = 'desc'
     THEN CASE WHEN b.managed THEN 1 ELSE 0 END
   END DESC,
 
   CASE
-    WHEN $5::text = 'source_type'
-      AND $6::text = 'asc'
+    WHEN $6::text = 'source_type'
+      AND $7::text = 'asc'
     THEN NULLIF(lower(trim(b.source_kind)), '')
   END ASC NULLS LAST,
   CASE
-    WHEN $5::text = 'source_type'
-      AND $6::text = 'desc'
+    WHEN $6::text = 'source_type'
+      AND $7::text = 'desc'
     THEN NULLIF(lower(trim(b.source_kind)), '')
   END DESC NULLS LAST,
 
   CASE
-    WHEN $5::text = 'linked_sources'
-      AND $6::text = 'asc'
+    WHEN $6::text = 'linked_sources'
+      AND $7::text = 'asc'
     THEN b.integration_count
   END ASC,
   CASE
-    WHEN $5::text = 'linked_sources'
-      AND $6::text = 'desc'
+    WHEN $6::text = 'linked_sources'
+      AND $7::text = 'desc'
     THEN b.integration_count
   END DESC,
 
   CASE
-    WHEN $5::text = 'privileged_roles'
-      AND $6::text = 'asc'
+    WHEN $6::text = 'privileged_roles'
+      AND $7::text = 'asc'
     THEN b.privileged_roles
   END ASC,
   CASE
-    WHEN $5::text = 'privileged_roles'
-      AND $6::text = 'desc'
+    WHEN $6::text = 'privileged_roles'
+      AND $7::text = 'desc'
     THEN b.privileged_roles
   END DESC,
 
   CASE
-    WHEN $5::text = 'status'
-      AND $6::text = 'asc'
+    WHEN $6::text = 'status'
+      AND $7::text = 'asc'
     THEN
       CASE b.status
         WHEN 'active' THEN 0
@@ -649,8 +659,8 @@ ORDER BY
       END
   END ASC,
   CASE
-    WHEN $5::text = 'status'
-      AND $6::text = 'desc'
+    WHEN $6::text = 'status'
+      AND $7::text = 'desc'
     THEN
       CASE b.status
         WHEN 'active' THEN 0
@@ -662,18 +672,18 @@ ORDER BY
   END DESC,
 
   CASE
-    WHEN $5::text = 'last_seen'
-      AND $6::text = 'asc'
+    WHEN $6::text = 'last_seen'
+      AND $7::text = 'asc'
     THEN b.last_seen_at
   END ASC NULLS FIRST,
   CASE
-    WHEN $5::text = 'last_seen'
-      AND $6::text = 'desc'
+    WHEN $6::text = 'last_seen'
+      AND $7::text = 'desc'
     THEN b.last_seen_at
   END DESC NULLS LAST,
   b.id DESC
-LIMIT $8::int
-OFFSET $7::int
+LIMIT $9::int
+OFFSET $8::int
 `
 
 type ListIdentitiesInventoryPageByFiltersParams struct {
@@ -681,6 +691,7 @@ type ListIdentitiesInventoryPageByFiltersParams struct {
 	PrivilegedOnly        bool     `json:"privileged_only"`
 	Status                string   `json:"status"`
 	ActivityState         string   `json:"activity_state"`
+	RowState              string   `json:"row_state"`
 	SortBy                string   `json:"sort_by"`
 	SortDir               string   `json:"sort_dir"`
 	PageOffset            int32    `json:"page_offset"`
@@ -717,6 +728,7 @@ func (q *Queries) ListIdentitiesInventoryPageByFilters(ctx context.Context, arg 
 		arg.PrivilegedOnly,
 		arg.Status,
 		arg.ActivityState,
+		arg.RowState,
 		arg.SortBy,
 		arg.SortDir,
 		arg.PageOffset,
@@ -918,6 +930,11 @@ SELECT
   COUNT(*) FILTER (WHERE row_state = 'action_required')::bigint             AS action_required_count,
   COUNT(*) FILTER (WHERE row_state = 'review')::bigint                      AS review_count,
   COUNT(*) FILTER (WHERE privileged_roles > 0)::bigint                      AS privileged_count,
+  COUNT(*) FILTER (WHERE privileged_roles > 0 AND NOT managed)::bigint       AS privileged_unmanaged_count,
+  COUNT(*) FILTER (
+    WHERE privileged_roles > 0
+      AND activity_state = 'stale'
+  )::bigint                                                                 AS stale_privileged_count,
   COUNT(*) FILTER (WHERE NOT managed)::bigint                               AS unmanaged_count,
   COUNT(*) FILTER (WHERE status = 'suspended')::bigint                      AS suspended_count,
   COUNT(*) FILTER (WHERE activity_state = 'stale')::bigint                   AS stale_count
@@ -934,13 +951,15 @@ type SummarizeIdentitiesInventoryByFiltersParams struct {
 }
 
 type SummarizeIdentitiesInventoryByFiltersRow struct {
-	TotalCount          int64 `json:"total_count"`
-	ActionRequiredCount int64 `json:"action_required_count"`
-	ReviewCount         int64 `json:"review_count"`
-	PrivilegedCount     int64 `json:"privileged_count"`
-	UnmanagedCount      int64 `json:"unmanaged_count"`
-	SuspendedCount      int64 `json:"suspended_count"`
-	StaleCount          int64 `json:"stale_count"`
+	TotalCount               int64 `json:"total_count"`
+	ActionRequiredCount      int64 `json:"action_required_count"`
+	ReviewCount              int64 `json:"review_count"`
+	PrivilegedCount          int64 `json:"privileged_count"`
+	PrivilegedUnmanagedCount int64 `json:"privileged_unmanaged_count"`
+	StalePrivilegedCount     int64 `json:"stale_privileged_count"`
+	UnmanagedCount           int64 `json:"unmanaged_count"`
+	SuspendedCount           int64 `json:"suspended_count"`
+	StaleCount               int64 `json:"stale_count"`
 }
 
 // Returns bucketed counts for the identity inventory, scoped to the
@@ -966,6 +985,8 @@ func (q *Queries) SummarizeIdentitiesInventoryByFilters(ctx context.Context, arg
 		&i.ActionRequiredCount,
 		&i.ReviewCount,
 		&i.PrivilegedCount,
+		&i.PrivilegedUnmanagedCount,
+		&i.StalePrivilegedCount,
 		&i.UnmanagedCount,
 		&i.SuspendedCount,
 		&i.StaleCount,

--- a/internal/http/handlers/apps.go
+++ b/internal/http/handlers/apps.go
@@ -76,7 +76,7 @@ func (h *Handlers) HandleApps(c *echo.Context) error {
 	addVary(c, "HX-Request", "HX-Target")
 
 	ctx := c.Request().Context()
-	layout, _, err := h.LayoutData(ctx, c, "Assigned Apps")
+	layout, _, err := h.LayoutData(ctx, c, "Okta Assigned Apps")
 	if err != nil {
 		return h.RenderError(c, err)
 	}

--- a/internal/http/handlers/command.go
+++ b/internal/http/handlers/command.go
@@ -144,14 +144,14 @@ func (h *Handlers) HandleCommandSearch(c *echo.Context) error {
 	if len(discoveryRows) > 0 {
 		data.Sections = append(data.Sections, viewmodels.CommandSectionView{
 			Key:   "discovery-apps",
-			Title: "Discovery Apps",
+			Title: "Apps & Discovery",
 			Items: commandDiscoveryAppItems(discoveryRows),
 		})
 	}
 	if len(oktaAppRows) > 0 {
 		data.Sections = append(data.Sections, viewmodels.CommandSectionView{
 			Key:   "okta-apps",
-			Title: "Assigned Apps",
+			Title: "Okta Assigned Apps",
 			Items: commandOktaAppItems(oktaAppRows),
 		})
 	}
@@ -329,21 +329,21 @@ func commandActionSection(stateView connectorStateView, query string) viewmodels
 	if commandHasNonHumanAccessSurface(stateView) {
 		items = append(items, commandActionItem(
 			"cmd-action-non-human-access",
-			fmt.Sprintf("Search Non-Human Access for “%s”", query),
+			fmt.Sprintf("Search Non-Human Principals for “%s”", query),
 			commandQueryURL("/non-human-access", query),
 		))
 	}
 	if commandHasDiscoverySurface(stateView) {
 		items = append(items, commandActionItem(
 			"cmd-action-discovery-apps",
-			fmt.Sprintf("Search Discovery Apps for “%s”", query),
+			fmt.Sprintf("Search Apps & Discovery for “%s”", query),
 			commandQueryURL("/discovery/apps", query),
 		))
 	}
 	if commandOktaAppsAvailable(stateView) {
 		items = append(items, commandActionItem(
 			"cmd-action-okta-apps",
-			fmt.Sprintf("Search Assigned Apps for “%s”", query),
+			fmt.Sprintf("Search Okta Assigned Apps for “%s”", query),
 			commandQueryURL("/assigned-apps", query),
 		))
 	}

--- a/internal/http/handlers/command_integration_test.go
+++ b/internal/http/handlers/command_integration_test.go
@@ -336,8 +336,8 @@ func TestHandleCommandSearchUsesLiveDiscoveryPostureBadges(t *testing.T) {
 		)
 
 		body := renderCommandSearch(t, h, "http://example.com/command/search?q=orphaned")
-		if !strings.Contains(body, `role="heading">Discovery Apps`) {
-			t.Fatalf("orphaned body missing discovery apps section: %s", body)
+		if !strings.Contains(body, `role="heading">Apps &amp; Discovery`) {
+			t.Fatalf("orphaned body missing apps and discovery section: %s", body)
 		}
 		if !strings.Contains(body, "Orphaned Portal") {
 			t.Fatalf("orphaned body missing discovery app row: %s", body)

--- a/internal/http/handlers/dashboard.go
+++ b/internal/http/handlers/dashboard.go
@@ -14,7 +14,7 @@ import (
 // HandleDashboard renders the dashboard page.
 func (h *Handlers) HandleDashboard(c *echo.Context) error {
 	ctx := c.Request().Context()
-	layout, stateView, err := h.LayoutData(ctx, c, "Dashboard")
+	layout, stateView, err := h.LayoutData(ctx, c, "Posture")
 	if err != nil {
 		return h.RenderError(c, err)
 	}

--- a/internal/http/handlers/discovery.go
+++ b/internal/http/handlers/discovery.go
@@ -61,7 +61,7 @@ func (h *Handlers) HandleDiscoveryApps(c *echo.Context) error {
 	addVary(c, "HX-Request", "HX-Target")
 
 	ctx := c.Request().Context()
-	layout, stateView, err := h.LayoutData(ctx, c, "SaaS Discovery")
+	layout, stateView, err := h.LayoutData(ctx, c, "Apps & Discovery")
 	if err != nil {
 		return h.RenderError(c, err)
 	}

--- a/internal/http/handlers/global_view.go
+++ b/internal/http/handlers/global_view.go
@@ -11,7 +11,7 @@ import (
 
 func (h *Handlers) HandleGlobalView(c *echo.Context) error {
 	ctx := c.Request().Context()
-	layout, _, err := h.LayoutData(ctx, c, "Global View")
+	layout, _, err := h.LayoutData(ctx, c, "Sources")
 	if err != nil {
 		return h.RenderError(c, err)
 	}

--- a/internal/http/handlers/identities.go
+++ b/internal/http/handlers/identities.go
@@ -71,13 +71,15 @@ func (h *Handlers) HandleIdentities(c *echo.Context) error {
 		return h.RenderError(c, err)
 	}
 	data.Summary = viewmodels.IdentitiesSummary{
-		Total:          summaryRow.TotalCount,
-		ActionRequired: summaryRow.ActionRequiredCount,
-		Review:         summaryRow.ReviewCount,
-		Privileged:     summaryRow.PrivilegedCount,
-		Unmanaged:      summaryRow.UnmanagedCount,
-		Suspended:      summaryRow.SuspendedCount,
-		Stale:          summaryRow.StaleCount,
+		Total:               summaryRow.TotalCount,
+		ActionRequired:      summaryRow.ActionRequiredCount,
+		Review:              summaryRow.ReviewCount,
+		Privileged:          summaryRow.PrivilegedCount,
+		PrivilegedUnmanaged: summaryRow.PrivilegedUnmanagedCount,
+		StalePrivileged:     summaryRow.StalePrivilegedCount,
+		Unmanaged:           summaryRow.UnmanagedCount,
+		Suspended:           summaryRow.SuspendedCount,
+		Stale:               summaryRow.StaleCount,
 	}
 
 	listParams := func(offset int32) gen.ListIdentitiesInventoryPageByFiltersParams {
@@ -86,6 +88,7 @@ func (h *Handlers) HandleIdentities(c *echo.Context) error {
 			PrivilegedOnly:        queryState.PrivilegedOnly,
 			Status:                queryState.Status,
 			ActivityState:         queryState.ActivityState,
+			RowState:              queryState.RowState,
 			SortBy:                queryState.SortBy,
 			SortDir:               queryState.SortDir,
 			PageOffset:            offset,
@@ -103,6 +106,7 @@ func (h *Handlers) HandleIdentities(c *echo.Context) error {
 		PrivilegedOnly:        queryState.PrivilegedOnly,
 		Status:                queryState.Status,
 		ActivityState:         queryState.ActivityState,
+		RowState:              queryState.RowState,
 		ConfiguredSourceKinds: configuredSourceKinds,
 		ConfiguredSourceNames: configuredSourceNames,
 		Query:                 queryState.Q,

--- a/internal/http/handlers/non_human_access.go
+++ b/internal/http/handlers/non_human_access.go
@@ -72,7 +72,7 @@ func (h *Handlers) HandleNonHumanAccess(c *echo.Context) error {
 	addVary(c, "HX-Request", "HX-Target")
 
 	ctx := c.Request().Context()
-	layout, stateView, err := h.LayoutData(ctx, c, "Non-Human Access")
+	layout, stateView, err := h.LayoutData(ctx, c, "Non-Human Principals")
 	if err != nil {
 		return h.RenderError(c, err)
 	}
@@ -153,7 +153,7 @@ func isNonHumanAccessResultsTarget(c *echo.Context) bool {
 
 func (h *Handlers) HandleNonHumanAccessShow(c *echo.Context) error {
 	ctx := c.Request().Context()
-	layout, _, err := h.LayoutData(ctx, c, "Non-Human Access")
+	layout, _, err := h.LayoutData(ctx, c, "Non-Human Principal")
 	if err != nil {
 		return h.RenderError(c, err)
 	}

--- a/internal/http/handlers/non_human_access_integration_test.go
+++ b/internal/http/handlers/non_human_access_integration_test.go
@@ -82,7 +82,7 @@ func TestHandleNonHumanAccessRendersUnifiedInventory(t *testing.T) {
 		}
 
 		body := rec.Body.String()
-		assertContains(t, body, "Non-Human Access")
+		assertContains(t, body, "Non-Human Principals")
 		assertContains(t, body, `id="non-human-access-results"`)
 		assertContains(t, body, `id="non-human-access-filters"`)
 		assertContains(t, body, `id="non-human-access-inventory"`)

--- a/internal/http/querystate/identities.go
+++ b/internal/http/querystate/identities.go
@@ -13,6 +13,7 @@ type IdentitiesQuery struct {
 	PrivilegedOnly bool
 	Status         string
 	ActivityState  string
+	RowState       string
 	SortBy         string
 	SortDir        string
 	Page           int
@@ -29,6 +30,7 @@ func ParseIdentitiesQuery(values url.Values, sources []SourceSelection) Identiti
 		PrivilegedOnly: parseBool(values.Get("privileged")),
 		Status:         normalizeIdentityStatus(values.Get("status")),
 		ActivityState:  normalizeIdentityActivityState(values.Get("activity_state")),
+		RowState:       normalizeIdentityRowState(values.Get("row_state")),
 		SortBy:         sortBy,
 		SortDir:        normalizeIdentitySortDir(values.Get("sort_dir"), sortBy),
 		Page:           parsePage(values.Get("page")),
@@ -45,6 +47,7 @@ func (q IdentitiesQuery) Values() url.Values {
 	setIfTrue(values, "privileged", q.PrivilegedOnly)
 	setIfNotEmpty(values, "status", q.Status)
 	setIfNotEmpty(values, "activity_state", q.ActivityState)
+	setIfNotEmpty(values, "row_state", q.RowState)
 	setIfNotEmpty(values, "sort_by", q.SortBy)
 	if q.SortBy != "" {
 		setIfNotEmpty(values, "sort_dir", q.SortDir)
@@ -89,22 +92,46 @@ func (q IdentitiesQuery) WithManagedState(state string) IdentitiesQuery {
 	return q
 }
 
-// ClearSegments resets the segment-style filters (activity, status, managed,
-// privileged) while preserving source, search, type, and sort. It powers the
-// "All" chip on the identities list.
+func (q IdentitiesQuery) WithRowState(state string) IdentitiesQuery {
+	q.RowState = normalizeIdentityRowState(state)
+	q.Page = 1
+	return q
+}
+
+// ClearSegments resets the segment-style filters while preserving source,
+// search, type, and sort. It powers the "All" chip on the identities list.
 func (q IdentitiesQuery) ClearSegments() IdentitiesQuery {
 	q.ActivityState = ""
 	q.Status = ""
 	q.ManagedState = ""
 	q.PrivilegedOnly = false
+	q.RowState = ""
 	q.Page = 1
 	return q
 }
 
-// SegmentPrivileged returns a query that selects the privileged-only segment
-// without leaking any other segment filter into the URL.
-func (q IdentitiesQuery) SegmentPrivileged() IdentitiesQuery {
+func (q IdentitiesQuery) SegmentNeedsAction() IdentitiesQuery {
 	q = q.ClearSegments()
+	q.RowState = "action_required"
+	return q
+}
+
+func (q IdentitiesQuery) SegmentReview() IdentitiesQuery {
+	q = q.ClearSegments()
+	q.RowState = "review"
+	return q
+}
+
+func (q IdentitiesQuery) SegmentPrivilegedUnmanaged() IdentitiesQuery {
+	q = q.ClearSegments()
+	q.PrivilegedOnly = true
+	q.ManagedState = "unmanaged"
+	return q
+}
+
+func (q IdentitiesQuery) SegmentStalePrivileged() IdentitiesQuery {
+	q = q.ClearSegments()
+	q.ActivityState = "stale"
 	q.PrivilegedOnly = true
 	return q
 }
@@ -112,7 +139,7 @@ func (q IdentitiesQuery) SegmentPrivileged() IdentitiesQuery {
 // HasSegment reports whether any segment-style filter is currently active.
 // Used to highlight the "All" chip when no segment is selected.
 func (q IdentitiesQuery) HasSegment() bool {
-	return q.ActivityState != "" || q.Status != "" || q.ManagedState != "" || q.PrivilegedOnly
+	return q.ActivityState != "" || q.Status != "" || q.ManagedState != "" || q.PrivilegedOnly || q.RowState != ""
 }
 
 func (q IdentitiesQuery) TogglePrivilegedOnly() IdentitiesQuery {
@@ -134,6 +161,7 @@ func (q IdentitiesQuery) ClearFilters() IdentitiesQuery {
 	q.PrivilegedOnly = false
 	q.Status = ""
 	q.ActivityState = ""
+	q.RowState = ""
 	q.SortBy = ""
 	q.SortDir = ""
 	q.Page = 1
@@ -147,6 +175,7 @@ func (q IdentitiesQuery) HasFilters() bool {
 		q.PrivilegedOnly ||
 		q.Status != "" ||
 		q.ActivityState != "" ||
+		q.RowState != "" ||
 		q.Source.Kind != "" ||
 		q.Source.Name != ""
 }
@@ -154,6 +183,9 @@ func (q IdentitiesQuery) HasFilters() bool {
 func (q IdentitiesQuery) FilterCount() int {
 	count := 0
 	if q.ActivityState != "" {
+		count++
+	}
+	if q.RowState != "" {
 		count++
 	}
 	if q.PrivilegedOnly {
@@ -318,6 +350,19 @@ func normalizeIdentityActivityState(raw string) string {
 		return "stale"
 	case "never_seen":
 		return "never_seen"
+	default:
+		return ""
+	}
+}
+
+func normalizeIdentityRowState(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "action_required":
+		return "action_required"
+	case "review":
+		return "review"
+	case "healthy":
+		return "healthy"
 	default:
 		return ""
 	}

--- a/internal/http/querystate/querystate_test.go
+++ b/internal/http/querystate/querystate_test.go
@@ -44,10 +44,11 @@ func TestParseIdentitiesQuery(t *testing.T) {
 		query := ParseIdentitiesQuery(url.Values{
 			"q":          []string{" alice "},
 			"privileged": []string{"true"},
+			"row_state":  []string{"action_required"},
 			"sort_by":    []string{"identity"},
 			"page":       []string{"0"},
 		}, sources)
-		if query.Q != "alice" || !query.PrivilegedOnly {
+		if query.Q != "alice" || !query.PrivilegedOnly || query.RowState != "action_required" {
 			t.Fatalf("query = %#v", query)
 		}
 		if query.SortDir != "desc" || query.Page != 1 {
@@ -82,6 +83,15 @@ func TestIdentitiesQueryMutations(t *testing.T) {
 	}
 	if got := query.WithActivityState("recent"); got.ActivityState != "recent" || got.Page != 1 {
 		t.Fatalf("WithActivityState() = %#v", got)
+	}
+	if got := query.SegmentNeedsAction(); got.RowState != "action_required" || got.ActivityState != "" || got.Page != 1 {
+		t.Fatalf("SegmentNeedsAction() = %#v", got)
+	}
+	if got := query.SegmentPrivilegedUnmanaged(); !got.PrivilegedOnly || got.ManagedState != "unmanaged" || got.ActivityState != "" || got.RowState != "" || got.Page != 1 {
+		t.Fatalf("SegmentPrivilegedUnmanaged() = %#v", got)
+	}
+	if got := query.SegmentStalePrivileged(); !got.PrivilegedOnly || got.ActivityState != "stale" || got.ManagedState != "" || got.RowState != "" || got.Page != 1 {
+		t.Fatalf("SegmentStalePrivileged() = %#v", got)
 	}
 	if got := query.TogglePrivilegedOnly(); got.PrivilegedOnly || got.Page != 1 {
 		t.Fatalf("TogglePrivilegedOnly() = %#v", got)

--- a/internal/http/viewmodels/identities.go
+++ b/internal/http/viewmodels/identities.go
@@ -29,13 +29,15 @@ type IdentityListItem struct {
 // stat strip and segment chips can show the shape of the population a user is
 // actually looking at, independent of which segment they have clicked.
 type IdentitiesSummary struct {
-	Total          int64
-	ActionRequired int64
-	Review         int64
-	Privileged     int64
-	Unmanaged      int64
-	Suspended      int64
-	Stale          int64
+	Total               int64
+	ActionRequired      int64
+	Review              int64
+	Privileged          int64
+	PrivilegedUnmanaged int64
+	StalePrivileged     int64
+	Unmanaged           int64
+	Suspended           int64
+	Stale               int64
 }
 
 type IdentitiesViewData struct {

--- a/internal/http/views/global_view.templ
+++ b/internal/http/views/global_view.templ
@@ -5,12 +5,12 @@ import "github.com/open-sspm/open-sspm/internal/http/viewmodels"
 templ GlobalViewPage(data viewmodels.GlobalViewData) {
 	@Layout(data.Layout) {
 		<section class="space-y-1">
-			<h2 class="text-lg font-semibold tracking-tight">Connector coverage</h2>
+			<h2 class="text-lg font-semibold tracking-tight">Sources</h2>
 			<p class="text-sm text-muted-foreground">Identity and application sources configured in this workspace, with current coverage and state.</p>
 		</section>
 
 		if len(data.Cards) == 0 {
-			@EmptyState("No connectors yet", "Configure a connector to start tracking identity coverage and connector health from one place.") {
+			@EmptyState("No sources yet", "Configure a connector to start tracking identity coverage and source health from one place.") {
 				if data.Layout.IsAdmin {
 					<a class="btn-sm-outline" href="/settings/connectors">Manage connectors</a>
 				}
@@ -30,7 +30,7 @@ templ GlobalViewPage(data viewmodels.GlobalViewData) {
 
 templ GlobalViewSummary(cards []viewmodels.GlobalViewAppCard) {
 	<section aria-label="Summary" class="grid grid-cols-2 gap-x-8 gap-y-5 border-y border-border py-5 sm:grid-cols-4">
-		@globalViewStat("Connectors", FormatInt(len(cards)))
+		@globalViewStat("Sources", FormatInt(len(cards)))
 		@globalViewStat("Active", FormatInt(GlobalViewEnabledCount(cards)))
 		@globalViewStat("Needs setup", FormatInt(GlobalViewAttentionCount(cards)))
 		<div class="space-y-2">
@@ -40,7 +40,7 @@ templ GlobalViewSummary(cards []viewmodels.GlobalViewAppCard) {
 				<div
 					class="global-view-bar"
 					role="progressbar"
-					aria-label="Average connector score"
+					aria-label="Average source score"
 					aria-valuemin="0"
 					aria-valuemax="100"
 					aria-valuenow={ FormatInt(GlobalViewAverageScore(cards)) }
@@ -52,7 +52,7 @@ templ GlobalViewSummary(cards []viewmodels.GlobalViewAppCard) {
 				</div>
 			} else {
 				<p class="text-2xl font-semibold tabular-nums tracking-tight text-muted-foreground">—</p>
-				<p class="text-xs text-muted-foreground">No active connectors yet</p>
+				<p class="text-xs text-muted-foreground">No active sources yet</p>
 			}
 		</div>
 	</section>

--- a/internal/http/views/global_view_templ.go
+++ b/internal/http/views/global_view_templ.go
@@ -43,7 +43,7 @@ func GlobalViewPage(data viewmodels.GlobalViewData) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<section class=\"space-y-1\"><h2 class=\"text-lg font-semibold tracking-tight\">Connector coverage</h2><p class=\"text-sm text-muted-foreground\">Identity and application sources configured in this workspace, with current coverage and state.</p></section>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<section class=\"space-y-1\"><h2 class=\"text-lg font-semibold tracking-tight\">Sources</h2><p class=\"text-sm text-muted-foreground\">Identity and application sources configured in this workspace, with current coverage and state.</p></section>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -68,7 +68,7 @@ func GlobalViewPage(data viewmodels.GlobalViewData) templ.Component {
 					}
 					return nil
 				})
-				templ_7745c5c3_Err = EmptyState("No connectors yet", "Configure a connector to start tracking identity coverage and connector health from one place.").Render(templ.WithChildren(ctx, templ_7745c5c3_Var3), templ_7745c5c3_Buffer)
+				templ_7745c5c3_Err = EmptyState("No sources yet", "Configure a connector to start tracking identity coverage and source health from one place.").Render(templ.WithChildren(ctx, templ_7745c5c3_Var3), templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -139,7 +139,7 @@ func GlobalViewSummary(cards []viewmodels.GlobalViewAppCard) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = globalViewStat("Connectors", FormatInt(len(cards))).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = globalViewStat("Sources", FormatInt(len(cards))).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -163,20 +163,20 @@ func GlobalViewSummary(cards []viewmodels.GlobalViewAppCard) templ.Component {
 			var templ_7745c5c3_Var5 string
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt(GlobalViewAverageScore(cards)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 39, Col: 108}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 39, Col: 108}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "%</p><div class=\"global-view-bar\" role=\"progressbar\" aria-label=\"Average connector score\" aria-valuemin=\"0\" aria-valuemax=\"100\" aria-valuenow=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "%</p><div class=\"global-view-bar\" role=\"progressbar\" aria-label=\"Average source score\" aria-valuemin=\"0\" aria-valuemax=\"100\" aria-valuenow=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt(GlobalViewAverageScore(cards)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 46, Col: 61}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 46, Col: 61}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
@@ -198,7 +198,7 @@ func GlobalViewSummary(cards []viewmodels.GlobalViewAppCard) templ.Component {
 			var templ_7745c5c3_Var8 string
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var7).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 1, Col: 0}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
@@ -211,7 +211,7 @@ func GlobalViewSummary(cards []viewmodels.GlobalViewAppCard) templ.Component {
 			var templ_7745c5c3_Var9 string
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues("width: " + FormatInt(GlobalViewAverageScore(cards)) + "%")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 50, Col: 72}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 50, Col: 72}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {
@@ -222,7 +222,7 @@ func GlobalViewSummary(cards []viewmodels.GlobalViewAppCard) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<p class=\"text-2xl font-semibold tabular-nums tracking-tight text-muted-foreground\">—</p><p class=\"text-xs text-muted-foreground\">No active connectors yet</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<p class=\"text-2xl font-semibold tabular-nums tracking-tight text-muted-foreground\">—</p><p class=\"text-xs text-muted-foreground\">No active sources yet</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -263,7 +263,7 @@ func globalViewStat(label, value string) templ.Component {
 		var templ_7745c5c3_Var11 string
 		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 63, Col: 50}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 63, Col: 50}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 		if templ_7745c5c3_Err != nil {
@@ -276,7 +276,7 @@ func globalViewStat(label, value string) templ.Component {
 		var templ_7745c5c3_Var12 string
 		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 64, Col: 71}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 64, Col: 71}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 		if templ_7745c5c3_Err != nil {
@@ -319,7 +319,7 @@ func GlobalViewGroup(title, hint string, cards []viewmodels.GlobalViewAppCard, a
 			var templ_7745c5c3_Var14 string
 			templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 70, Col: 29}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 70, Col: 29}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 			if templ_7745c5c3_Err != nil {
@@ -332,7 +332,7 @@ func GlobalViewGroup(title, hint string, cards []viewmodels.GlobalViewAppCard, a
 			var templ_7745c5c3_Var15 string
 			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 73, Col: 61}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 73, Col: 61}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 			if templ_7745c5c3_Err != nil {
@@ -345,7 +345,7 @@ func GlobalViewGroup(title, hint string, cards []viewmodels.GlobalViewAppCard, a
 			var templ_7745c5c3_Var16 string
 			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt(len(cards)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 74, Col: 72}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 74, Col: 72}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 			if templ_7745c5c3_Err != nil {
@@ -358,7 +358,7 @@ func GlobalViewGroup(title, hint string, cards []viewmodels.GlobalViewAppCard, a
 			var templ_7745c5c3_Var17 string
 			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(hint)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 76, Col: 51}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 76, Col: 51}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 			if templ_7745c5c3_Err != nil {
@@ -419,7 +419,7 @@ func GlobalViewRow(card viewmodels.GlobalViewAppCard, active bool) templ.Compone
 		var templ_7745c5c3_Var20 string
 		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var19).String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 1, Col: 0}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 1, Col: 0}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 		if templ_7745c5c3_Err != nil {
@@ -440,7 +440,7 @@ func GlobalViewRow(card viewmodels.GlobalViewAppCard, active bool) templ.Compone
 		var templ_7745c5c3_Var21 string
 		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(card.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 98, Col: 81}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 98, Col: 81}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 		if templ_7745c5c3_Err != nil {
@@ -458,7 +458,7 @@ func GlobalViewRow(card viewmodels.GlobalViewAppCard, active bool) templ.Compone
 			var templ_7745c5c3_Var22 string
 			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(card.CategoryLabel)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 100, Col: 70}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 100, Col: 70}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 			if templ_7745c5c3_Err != nil {
@@ -481,7 +481,7 @@ func GlobalViewRow(card viewmodels.GlobalViewAppCard, active bool) templ.Compone
 			var templ_7745c5c3_Var23 string
 			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(card.Subtitle)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 104, Col: 76}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 104, Col: 76}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 			if templ_7745c5c3_Err != nil {
@@ -494,7 +494,7 @@ func GlobalViewRow(card viewmodels.GlobalViewAppCard, active bool) templ.Compone
 			var templ_7745c5c3_Var24 string
 			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(card.Subtitle)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 104, Col: 94}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 104, Col: 94}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 			if templ_7745c5c3_Err != nil {
@@ -517,7 +517,7 @@ func GlobalViewRow(card viewmodels.GlobalViewAppCard, active bool) templ.Compone
 			var templ_7745c5c3_Var25 string
 			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(metric.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 109, Col: 63}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 109, Col: 63}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {
@@ -530,7 +530,7 @@ func GlobalViewRow(card viewmodels.GlobalViewAppCard, active bool) templ.Compone
 			var templ_7745c5c3_Var26 string
 			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(metric.Value)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 110, Col: 82}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 110, Col: 82}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 			if templ_7745c5c3_Err != nil {
@@ -553,7 +553,7 @@ func GlobalViewRow(card viewmodels.GlobalViewAppCard, active bool) templ.Compone
 			var templ_7745c5c3_Var27 string
 			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(card.ScoreLabel)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 120, Col: 66}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 120, Col: 66}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 			if templ_7745c5c3_Err != nil {
@@ -566,7 +566,7 @@ func GlobalViewRow(card viewmodels.GlobalViewAppCard, active bool) templ.Compone
 			var templ_7745c5c3_Var28 string
 			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt(card.ScoreValue))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 121, Col: 82}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 121, Col: 82}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 			if templ_7745c5c3_Err != nil {
@@ -579,7 +579,7 @@ func GlobalViewRow(card viewmodels.GlobalViewAppCard, active bool) templ.Compone
 			var templ_7745c5c3_Var29 string
 			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(card.Name + " " + card.ScoreLabel)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 126, Col: 51}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 126, Col: 51}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 			if templ_7745c5c3_Err != nil {
@@ -592,7 +592,7 @@ func GlobalViewRow(card viewmodels.GlobalViewAppCard, active bool) templ.Compone
 			var templ_7745c5c3_Var30 string
 			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt(card.ScoreValue))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 129, Col: 47}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 129, Col: 47}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 			if templ_7745c5c3_Err != nil {
@@ -614,7 +614,7 @@ func GlobalViewRow(card viewmodels.GlobalViewAppCard, active bool) templ.Compone
 			var templ_7745c5c3_Var32 string
 			templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var31).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 1, Col: 0}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
 			if templ_7745c5c3_Err != nil {
@@ -627,7 +627,7 @@ func GlobalViewRow(card viewmodels.GlobalViewAppCard, active bool) templ.Compone
 			var templ_7745c5c3_Var33 string
 			templ_7745c5c3_Var33, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues("width: " + FormatInt(card.ScoreValue) + "%")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 133, Col: 58}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 133, Col: 58}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 			if templ_7745c5c3_Err != nil {
@@ -654,7 +654,7 @@ func GlobalViewRow(card viewmodels.GlobalViewAppCard, active bool) templ.Compone
 			var templ_7745c5c3_Var35 string
 			templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var34).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 1, Col: 0}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
 			if templ_7745c5c3_Err != nil {
@@ -667,7 +667,7 @@ func GlobalViewRow(card viewmodels.GlobalViewAppCard, active bool) templ.Compone
 			var templ_7745c5c3_Var36 string
 			templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(card.StatusLabel)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 139, Col: 55}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 139, Col: 55}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 			if templ_7745c5c3_Err != nil {
@@ -695,7 +695,7 @@ func GlobalViewRow(card viewmodels.GlobalViewAppCard, active bool) templ.Compone
 			var templ_7745c5c3_Var37 templ.SafeURL
 			templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(card.PrimaryHref))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 147, Col: 66}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 147, Col: 66}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 			if templ_7745c5c3_Err != nil {
@@ -708,7 +708,7 @@ func GlobalViewRow(card viewmodels.GlobalViewAppCard, active bool) templ.Compone
 			var templ_7745c5c3_Var38 string
 			templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(card.PrimaryLabel)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 147, Col: 88}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 147, Col: 88}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 			if templ_7745c5c3_Err != nil {
@@ -727,7 +727,7 @@ func GlobalViewRow(card viewmodels.GlobalViewAppCard, active bool) templ.Compone
 			var templ_7745c5c3_Var39 templ.SafeURL
 			templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(card.SecondaryHref))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 150, Col: 68}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 150, Col: 68}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 			if templ_7745c5c3_Err != nil {
@@ -740,7 +740,7 @@ func GlobalViewRow(card viewmodels.GlobalViewAppCard, active bool) templ.Compone
 			var templ_7745c5c3_Var40 string
 			templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(card.SecondaryLabel)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/global_view.templ`, Line: 150, Col: 92}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `global_view.templ`, Line: 150, Col: 92}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 			if templ_7745c5c3_Err != nil {

--- a/internal/http/views/helpers.go
+++ b/internal/http/views/helpers.go
@@ -910,7 +910,7 @@ func HumanizeIdentityStatus(status string) string {
 func HumanizeIdentityRowState(state string) string {
 	switch strings.ToLower(strings.TrimSpace(state)) {
 	case "action_required":
-		return "Action required"
+		return "Needs action"
 	case "review":
 		return "Review"
 	case "healthy":
@@ -1051,6 +1051,8 @@ func segmentChipClass(active bool, tone string) string {
 	base := "osspm-segment-chip"
 	if active {
 		switch tone {
+		case "danger":
+			return base + " osspm-segment-chip-active osspm-segment-chip-danger"
 		case "warn":
 			return base + " osspm-segment-chip-active osspm-segment-chip-warn"
 		default:
@@ -1239,6 +1241,13 @@ func AriaCurrent(activePath, target string) string {
 
 func AriaCurrentNonHumanAccessSurface(activePath string) string {
 	if IsActivePath(activePath, "/non-human-access") || IsActivePath(activePath, "/app-assets") || IsActivePath(activePath, "/credentials") {
+		return "page"
+	}
+	return ""
+}
+
+func AriaCurrentAppsSurface(activePath string) string {
+	if IsActivePath(activePath, "/discovery") || IsActivePath(activePath, "/assigned-apps") || IsActivePath(activePath, "/oauth-apps") {
 		return "page"
 	}
 	return ""

--- a/internal/http/views/identities.templ
+++ b/internal/http/views/identities.templ
@@ -142,23 +142,24 @@ templ identityStat(value, label, tone string) {
 templ identitiesSegmentChips(q querystate.IdentitiesQuery, s viewmodels.IdentitiesSummary) {
 	<nav class="osspm-segment-chips" aria-label="Identity segments">
 		@segmentChip(q.ClearSegments().Href(), "All", FormatInt64(s.Total), !q.HasSegment(), "")
-		@segmentChip(q.SegmentPrivileged().Href(), "Privileged", FormatInt64(s.Privileged), q.PrivilegedOnly, "warn")
-		@segmentChip(q.ClearSegments().WithManagedState("unmanaged").Href(), "Unmanaged", FormatInt64(s.Unmanaged), q.ManagedState == "unmanaged", "")
+		@segmentChip(q.SegmentNeedsAction().Href(), "Needs action", FormatInt64(s.ActionRequired), q.RowState == "action_required", "danger")
+		@segmentChip(q.SegmentPrivilegedUnmanaged().Href(), "Privileged unmanaged", FormatInt64(s.PrivilegedUnmanaged), q.PrivilegedOnly && q.ManagedState == "unmanaged" && q.RowState == "", "warn")
+		@segmentChip(q.SegmentStalePrivileged().Href(), "Stale privileged", FormatInt64(s.StalePrivileged), q.PrivilegedOnly && q.ActivityState == "stale" && q.RowState == "", "warn")
 		@segmentChip(q.ClearSegments().WithStatus("suspended").Href(), "Suspended", FormatInt64(s.Suspended), q.Status == "suspended", "")
-		@segmentChip(q.ClearSegments().WithActivityState("stale").Href(), "Stale 90d+", FormatInt64(s.Stale), q.ActivityState == "stale", "")
+		@segmentChip(q.SegmentReview().Href(), "Review", FormatInt64(s.Review), q.RowState == "review", "warn")
 	</nav>
 }
 
 templ segmentChip(href, label, count string, active bool, tone string) {
-		<a
-			href={ templ.SafeURL(href) }
-			hx-get={ href }
-			hx-target="#identities-results"
-			hx-swap="outerHTML"
-			hx-push-url="true"
-			class={ segmentChipClass(active, tone) }
-			aria-current={ AriaCurrentBool(active) }
-		>
+	<a
+		href={ templ.SafeURL(href) }
+		hx-get={ href }
+		hx-target="#identities-results"
+		hx-swap="outerHTML"
+		hx-push-url="true"
+		class={ segmentChipClass(active, tone) }
+		aria-current={ AriaCurrentBool(active) }
+	>
 		<span>{ label }</span>
 		<span class="osspm-segment-chip-count">{ count }</span>
 	</a>

--- a/internal/http/views/identities.templ
+++ b/internal/http/views/identities.templ
@@ -143,8 +143,8 @@ templ identitiesSegmentChips(q querystate.IdentitiesQuery, s viewmodels.Identiti
 	<nav class="osspm-segment-chips" aria-label="Identity segments">
 		@segmentChip(q.ClearSegments().Href(), "All", FormatInt64(s.Total), !q.HasSegment(), "")
 		@segmentChip(q.SegmentNeedsAction().Href(), "Needs action", FormatInt64(s.ActionRequired), q.RowState == "action_required", "danger")
-		@segmentChip(q.SegmentPrivilegedUnmanaged().Href(), "Privileged unmanaged", FormatInt64(s.PrivilegedUnmanaged), q.PrivilegedOnly && q.ManagedState == "unmanaged" && q.RowState == "", "warn")
-		@segmentChip(q.SegmentStalePrivileged().Href(), "Stale privileged", FormatInt64(s.StalePrivileged), q.PrivilegedOnly && q.ActivityState == "stale" && q.RowState == "", "warn")
+		@segmentChip(q.SegmentPrivilegedUnmanaged().Href(), "Privileged unmanaged", FormatInt64(s.PrivilegedUnmanaged), q.PrivilegedOnly && q.ManagedState == "unmanaged" && q.ActivityState == "" && q.Status == "" && q.RowState == "", "warn")
+		@segmentChip(q.SegmentStalePrivileged().Href(), "Stale privileged", FormatInt64(s.StalePrivileged), q.PrivilegedOnly && q.ActivityState == "stale" && q.ManagedState == "" && q.Status == "" && q.RowState == "", "warn")
 		@segmentChip(q.ClearSegments().WithStatus("suspended").Href(), "Suspended", FormatInt64(s.Suspended), q.Status == "suspended", "")
 		@segmentChip(q.SegmentReview().Href(), "Review", FormatInt64(s.Review), q.RowState == "review", "warn")
 	</nav>

--- a/internal/http/views/identities_templ.go
+++ b/internal/http/views/identities_templ.go
@@ -115,7 +115,7 @@ func IdentitiesPageResults(data viewmodels.IdentitiesViewData) templ.Component {
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs("Showing ")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 38, Col: 18}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 38, Col: 18}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -124,7 +124,7 @@ func IdentitiesPageResults(data viewmodels.IdentitiesViewData) templ.Component {
 			var templ_7745c5c3_Var5 string
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt(data.ShowingFrom))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 38, Col: 49}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 38, Col: 49}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {
@@ -133,7 +133,7 @@ func IdentitiesPageResults(data viewmodels.IdentitiesViewData) templ.Component {
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs("-")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 38, Col: 56}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 38, Col: 56}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
@@ -142,7 +142,7 @@ func IdentitiesPageResults(data viewmodels.IdentitiesViewData) templ.Component {
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt(data.ShowingTo))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 38, Col: 85}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 38, Col: 85}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -151,7 +151,7 @@ func IdentitiesPageResults(data viewmodels.IdentitiesViewData) templ.Component {
 			var templ_7745c5c3_Var8 string
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(" of ")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 38, Col: 95}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 38, Col: 95}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
@@ -160,7 +160,7 @@ func IdentitiesPageResults(data viewmodels.IdentitiesViewData) templ.Component {
 			var templ_7745c5c3_Var9 string
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt64(data.TotalCount))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 38, Col: 127}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 38, Col: 127}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {
@@ -260,7 +260,7 @@ func IdentitiesPageResults(data viewmodels.IdentitiesViewData) templ.Component {
 			var templ_7745c5c3_Var11 string
 			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs("Page ")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 98, Col: 57}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 98, Col: 57}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
@@ -269,7 +269,7 @@ func IdentitiesPageResults(data viewmodels.IdentitiesViewData) templ.Component {
 			var templ_7745c5c3_Var12 string
 			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt(data.Page))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 98, Col: 81}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 98, Col: 81}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
@@ -278,7 +278,7 @@ func IdentitiesPageResults(data viewmodels.IdentitiesViewData) templ.Component {
 			var templ_7745c5c3_Var13 string
 			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(" of ")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 98, Col: 91}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 98, Col: 91}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 			if templ_7745c5c3_Err != nil {
@@ -287,7 +287,7 @@ func IdentitiesPageResults(data viewmodels.IdentitiesViewData) templ.Component {
 			var templ_7745c5c3_Var14 string
 			templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt(data.TotalPages))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 98, Col: 121}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 98, Col: 121}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 			if templ_7745c5c3_Err != nil {
@@ -305,7 +305,7 @@ func IdentitiesPageResults(data viewmodels.IdentitiesViewData) templ.Component {
 				var templ_7745c5c3_Var15 templ.SafeURL
 				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinURLErrs(data.Query.WithPage(data.Page - 1).Href())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 101, Col: 79}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 101, Col: 79}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 				if templ_7745c5c3_Err != nil {
@@ -318,7 +318,7 @@ func IdentitiesPageResults(data viewmodels.IdentitiesViewData) templ.Component {
 				var templ_7745c5c3_Var16 string
 				templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(data.Query.WithPage(data.Page - 1).Href())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 101, Col: 130}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 101, Col: 130}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 				if templ_7745c5c3_Err != nil {
@@ -342,7 +342,7 @@ func IdentitiesPageResults(data viewmodels.IdentitiesViewData) templ.Component {
 				var templ_7745c5c3_Var17 templ.SafeURL
 				templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinURLErrs(data.Query.WithPage(data.Page + 1).Href())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 106, Col: 79}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 106, Col: 79}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 				if templ_7745c5c3_Err != nil {
@@ -355,7 +355,7 @@ func IdentitiesPageResults(data viewmodels.IdentitiesViewData) templ.Component {
 				var templ_7745c5c3_Var18 string
 				templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(data.Query.WithPage(data.Page + 1).Href())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 106, Col: 130}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 106, Col: 130}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 				if templ_7745c5c3_Err != nil {
@@ -485,7 +485,7 @@ func identityStat(value, label, tone string) templ.Component {
 		var templ_7745c5c3_Var22 string
 		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var21).String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 1, Col: 0}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 1, Col: 0}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 		if templ_7745c5c3_Err != nil {
@@ -498,7 +498,7 @@ func identityStat(value, label, tone string) templ.Component {
 		var templ_7745c5c3_Var23 string
 		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 133, Col: 51}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 133, Col: 51}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 		if templ_7745c5c3_Err != nil {
@@ -511,7 +511,7 @@ func identityStat(value, label, tone string) templ.Component {
 		var templ_7745c5c3_Var24 string
 		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 134, Col: 39}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 134, Col: 39}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 		if templ_7745c5c3_Err != nil {
@@ -558,11 +558,15 @@ func identitiesSegmentChips(q querystate.IdentitiesQuery, s viewmodels.Identitie
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = segmentChip(q.SegmentPrivileged().Href(), "Privileged", FormatInt64(s.Privileged), q.PrivilegedOnly, "warn").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = segmentChip(q.SegmentNeedsAction().Href(), "Needs action", FormatInt64(s.ActionRequired), q.RowState == "action_required", "danger").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = segmentChip(q.ClearSegments().WithManagedState("unmanaged").Href(), "Unmanaged", FormatInt64(s.Unmanaged), q.ManagedState == "unmanaged", "").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = segmentChip(q.SegmentPrivilegedUnmanaged().Href(), "Privileged unmanaged", FormatInt64(s.PrivilegedUnmanaged), q.PrivilegedOnly && q.ManagedState == "unmanaged" && q.RowState == "", "warn").Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = segmentChip(q.SegmentStalePrivileged().Href(), "Stale privileged", FormatInt64(s.StalePrivileged), q.PrivilegedOnly && q.ActivityState == "stale" && q.RowState == "", "warn").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -570,7 +574,7 @@ func identitiesSegmentChips(q querystate.IdentitiesQuery, s viewmodels.Identitie
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = segmentChip(q.ClearSegments().WithActivityState("stale").Href(), "Stale 90d+", FormatInt64(s.Stale), q.ActivityState == "stale", "").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = segmentChip(q.SegmentReview().Href(), "Review", FormatInt64(s.Review), q.RowState == "review", "warn").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -615,7 +619,7 @@ func segmentChip(href, label, count string, active bool, tone string) templ.Comp
 		var templ_7745c5c3_Var28 templ.SafeURL
 		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(href))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 154, Col: 29}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 155, Col: 28}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 		if templ_7745c5c3_Err != nil {
@@ -628,7 +632,7 @@ func segmentChip(href, label, count string, active bool, tone string) templ.Comp
 		var templ_7745c5c3_Var29 string
 		templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(href)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 155, Col: 16}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 156, Col: 15}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 		if templ_7745c5c3_Err != nil {
@@ -641,7 +645,7 @@ func segmentChip(href, label, count string, active bool, tone string) templ.Comp
 		var templ_7745c5c3_Var30 string
 		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var27).String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 1, Col: 0}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 1, Col: 0}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 		if templ_7745c5c3_Err != nil {
@@ -654,7 +658,7 @@ func segmentChip(href, label, count string, active bool, tone string) templ.Comp
 		var templ_7745c5c3_Var31 string
 		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrentBool(active))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 160, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 161, Col: 40}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 		if templ_7745c5c3_Err != nil {
@@ -667,7 +671,7 @@ func segmentChip(href, label, count string, active bool, tone string) templ.Comp
 		var templ_7745c5c3_Var32 string
 		templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 162, Col: 15}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 163, Col: 15}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
 		if templ_7745c5c3_Err != nil {
@@ -680,7 +684,7 @@ func segmentChip(href, label, count string, active bool, tone string) templ.Comp
 		var templ_7745c5c3_Var33 string
 		templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(count)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 163, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 164, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 		if templ_7745c5c3_Err != nil {
@@ -722,7 +726,7 @@ func identityCardMobile(item viewmodels.IdentityListItem) templ.Component {
 		var templ_7745c5c3_Var35 templ.SafeURL
 		templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(fmt.Sprintf("/identities/%d", item.ID)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 169, Col: 62}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 170, Col: 62}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
 		if templ_7745c5c3_Err != nil {
@@ -735,7 +739,7 @@ func identityCardMobile(item viewmodels.IdentityListItem) templ.Component {
 		var templ_7745c5c3_Var36 string
 		templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(item.NamePrimary)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 174, Col: 56}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 175, Col: 56}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 		if templ_7745c5c3_Err != nil {
@@ -753,7 +757,7 @@ func identityCardMobile(item viewmodels.IdentityListItem) templ.Component {
 			var templ_7745c5c3_Var37 string
 			templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(item.NameSecondary)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 176, Col: 77}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 177, Col: 77}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 			if templ_7745c5c3_Err != nil {
@@ -771,7 +775,7 @@ func identityCardMobile(item viewmodels.IdentityListItem) templ.Component {
 		var templ_7745c5c3_Var38 string
 		templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeIdentityType(item.IdentityType))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 179, Col: 46}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 180, Col: 46}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 		if templ_7745c5c3_Err != nil {
@@ -785,7 +789,7 @@ func identityCardMobile(item viewmodels.IdentityListItem) templ.Component {
 			var templ_7745c5c3_Var39 string
 			templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(" · ")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 181, Col: 14}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 182, Col: 14}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 			if templ_7745c5c3_Err != nil {
@@ -794,7 +798,7 @@ func identityCardMobile(item viewmodels.IdentityListItem) templ.Component {
 			var templ_7745c5c3_Var40 string
 			templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeIdentityStatus(item.Status))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 181, Col: 53}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 182, Col: 53}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 			if templ_7745c5c3_Err != nil {
@@ -817,7 +821,7 @@ func identityCardMobile(item viewmodels.IdentityListItem) templ.Component {
 		var templ_7745c5c3_Var42 string
 		templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var41).String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 1, Col: 0}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 1, Col: 0}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
 		if templ_7745c5c3_Err != nil {
@@ -830,7 +834,7 @@ func identityCardMobile(item viewmodels.IdentityListItem) templ.Component {
 		var templ_7745c5c3_Var43 string
 		templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeIdentityRowState(item.RowState))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 185, Col: 102}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 186, Col: 102}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 		if templ_7745c5c3_Err != nil {
@@ -844,7 +848,7 @@ func identityCardMobile(item viewmodels.IdentityListItem) templ.Component {
 			var templ_7745c5c3_Var44 string
 			templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeProgrammaticKind(item.SourceKind))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 192, Col: 49}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 193, Col: 49}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 			if templ_7745c5c3_Err != nil {
@@ -872,7 +876,7 @@ func identityCardMobile(item viewmodels.IdentityListItem) templ.Component {
 		var templ_7745c5c3_Var46 string
 		templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var45).String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 1, Col: 0}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 1, Col: 0}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 		if templ_7745c5c3_Err != nil {
@@ -885,7 +889,7 @@ func identityCardMobile(item viewmodels.IdentityListItem) templ.Component {
 		var templ_7745c5c3_Var47 string
 		templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt64(item.PrivilegedRoles))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 200, Col: 121}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 201, Col: 121}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
 		if templ_7745c5c3_Err != nil {
@@ -899,7 +903,7 @@ func identityCardMobile(item viewmodels.IdentityListItem) templ.Component {
 			var templ_7745c5c3_Var48 string
 			templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(item.LastSeen.Relative)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 206, Col: 30}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 207, Col: 30}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
 			if templ_7745c5c3_Err != nil {
@@ -909,7 +913,7 @@ func identityCardMobile(item viewmodels.IdentityListItem) templ.Component {
 			var templ_7745c5c3_Var49 string
 			templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(item.LastSeen.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 208, Col: 27}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 209, Col: 27}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
 			if templ_7745c5c3_Err != nil {
@@ -957,7 +961,7 @@ func identityRowDesktop(item viewmodels.IdentityListItem) templ.Component {
 		var templ_7745c5c3_Var52 string
 		templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("/identities/%d", item.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 217, Col: 59}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 218, Col: 59}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
 		if templ_7745c5c3_Err != nil {
@@ -970,7 +974,7 @@ func identityRowDesktop(item viewmodels.IdentityListItem) templ.Component {
 		var templ_7745c5c3_Var53 string
 		templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var51).String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 1, Col: 0}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 1, Col: 0}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var53))
 		if templ_7745c5c3_Err != nil {
@@ -983,7 +987,7 @@ func identityRowDesktop(item viewmodels.IdentityListItem) templ.Component {
 		var templ_7745c5c3_Var54 templ.SafeURL
 		templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(fmt.Sprintf("/identities/%d", item.ID)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 219, Col: 94}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 220, Col: 94}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
 		if templ_7745c5c3_Err != nil {
@@ -996,7 +1000,7 @@ func identityRowDesktop(item viewmodels.IdentityListItem) templ.Component {
 		var templ_7745c5c3_Var55 string
 		templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(item.NamePrimary)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 220, Col: 69}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 221, Col: 69}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
 		if templ_7745c5c3_Err != nil {
@@ -1009,7 +1013,7 @@ func identityRowDesktop(item viewmodels.IdentityListItem) templ.Component {
 		var templ_7745c5c3_Var56 string
 		templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(item.NamePrimary)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 220, Col: 125}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 221, Col: 125}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
 		if templ_7745c5c3_Err != nil {
@@ -1027,7 +1031,7 @@ func identityRowDesktop(item viewmodels.IdentityListItem) templ.Component {
 			var templ_7745c5c3_Var57 string
 			templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinStringErrs(item.NameSecondary)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 223, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 224, Col: 74}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var57))
 			if templ_7745c5c3_Err != nil {
@@ -1040,7 +1044,7 @@ func identityRowDesktop(item viewmodels.IdentityListItem) templ.Component {
 			var templ_7745c5c3_Var58 string
 			templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinStringErrs(item.NameSecondary)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 223, Col: 132}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 224, Col: 132}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var58))
 			if templ_7745c5c3_Err != nil {
@@ -1059,7 +1063,7 @@ func identityRowDesktop(item viewmodels.IdentityListItem) templ.Component {
 			var templ_7745c5c3_Var59 string
 			templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeIdentityStatus(item.Status))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 226, Col: 79}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 227, Col: 79}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var59))
 			if templ_7745c5c3_Err != nil {
@@ -1077,7 +1081,7 @@ func identityRowDesktop(item viewmodels.IdentityListItem) templ.Component {
 		var templ_7745c5c3_Var60 string
 		templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeIdentityType(item.IdentityType))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 231, Col: 85}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 232, Col: 85}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var60))
 		if templ_7745c5c3_Err != nil {
@@ -1095,7 +1099,7 @@ func identityRowDesktop(item viewmodels.IdentityListItem) templ.Component {
 			var templ_7745c5c3_Var61 string
 			templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeProgrammaticKind(item.SourceKind))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 234, Col: 92}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 235, Col: 92}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var61))
 			if templ_7745c5c3_Err != nil {
@@ -1113,7 +1117,7 @@ func identityRowDesktop(item viewmodels.IdentityListItem) templ.Component {
 				var templ_7745c5c3_Var62 string
 				templ_7745c5c3_Var62, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt64(item.IntegrationsCount))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 236, Col: 77}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 237, Col: 77}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var62))
 				if templ_7745c5c3_Err != nil {
@@ -1122,7 +1126,7 @@ func identityRowDesktop(item viewmodels.IdentityListItem) templ.Component {
 				var templ_7745c5c3_Var63 string
 				templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.JoinStringErrs(" sources")
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 236, Col: 91}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 237, Col: 91}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var63))
 				if templ_7745c5c3_Err != nil {
@@ -1140,7 +1144,7 @@ func identityRowDesktop(item viewmodels.IdentityListItem) templ.Component {
 				var templ_7745c5c3_Var64 string
 				templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.JoinStringErrs(item.SourceName)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 238, Col: 72}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 239, Col: 72}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var64))
 				if templ_7745c5c3_Err != nil {
@@ -1153,7 +1157,7 @@ func identityRowDesktop(item viewmodels.IdentityListItem) templ.Component {
 				var templ_7745c5c3_Var65 string
 				templ_7745c5c3_Var65, templ_7745c5c3_Err = templ.JoinStringErrs(item.SourceName)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 238, Col: 92}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 239, Col: 92}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var65))
 				if templ_7745c5c3_Err != nil {
@@ -1186,7 +1190,7 @@ func identityRowDesktop(item viewmodels.IdentityListItem) templ.Component {
 		var templ_7745c5c3_Var67 string
 		templ_7745c5c3_Var67, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var66).String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 1, Col: 0}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 1, Col: 0}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var67))
 		if templ_7745c5c3_Err != nil {
@@ -1199,7 +1203,7 @@ func identityRowDesktop(item viewmodels.IdentityListItem) templ.Component {
 		var templ_7745c5c3_Var68 string
 		templ_7745c5c3_Var68, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt64(item.PrivilegedRoles))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 244, Col: 116}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 245, Col: 116}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var68))
 		if templ_7745c5c3_Err != nil {
@@ -1236,7 +1240,7 @@ func identityRowDesktop(item viewmodels.IdentityListItem) templ.Component {
 		var templ_7745c5c3_Var70 string
 		templ_7745c5c3_Var70, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var69).String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 1, Col: 0}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 1, Col: 0}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var70))
 		if templ_7745c5c3_Err != nil {
@@ -1249,7 +1253,7 @@ func identityRowDesktop(item viewmodels.IdentityListItem) templ.Component {
 		var templ_7745c5c3_Var71 string
 		templ_7745c5c3_Var71, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeIdentityRowState(item.RowState))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 252, Col: 105}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 253, Col: 105}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var71))
 		if templ_7745c5c3_Err != nil {
@@ -1267,7 +1271,7 @@ func identityRowDesktop(item viewmodels.IdentityListItem) templ.Component {
 			var templ_7745c5c3_Var72 string
 			templ_7745c5c3_Var72, templ_7745c5c3_Err = templ.JoinStringErrs(item.LastSeen.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 255, Col: 64}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 256, Col: 64}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var72))
 			if templ_7745c5c3_Err != nil {
@@ -1280,7 +1284,7 @@ func identityRowDesktop(item viewmodels.IdentityListItem) templ.Component {
 			var templ_7745c5c3_Var73 string
 			templ_7745c5c3_Var73, templ_7745c5c3_Err = templ.JoinStringErrs(item.LastSeen.Relative)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 255, Col: 91}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 256, Col: 91}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var73))
 			if templ_7745c5c3_Err != nil {
@@ -1298,7 +1302,7 @@ func identityRowDesktop(item viewmodels.IdentityListItem) templ.Component {
 			var templ_7745c5c3_Var74 string
 			templ_7745c5c3_Var74, templ_7745c5c3_Err = templ.JoinStringErrs(item.LastSeen.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/identities.templ`, Line: 257, Col: 58}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `identities.templ`, Line: 258, Col: 58}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var74))
 			if templ_7745c5c3_Err != nil {

--- a/internal/http/views/identities_templ.go
+++ b/internal/http/views/identities_templ.go
@@ -562,11 +562,11 @@ func identitiesSegmentChips(q querystate.IdentitiesQuery, s viewmodels.Identitie
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = segmentChip(q.SegmentPrivilegedUnmanaged().Href(), "Privileged unmanaged", FormatInt64(s.PrivilegedUnmanaged), q.PrivilegedOnly && q.ManagedState == "unmanaged" && q.RowState == "", "warn").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = segmentChip(q.SegmentPrivilegedUnmanaged().Href(), "Privileged unmanaged", FormatInt64(s.PrivilegedUnmanaged), q.PrivilegedOnly && q.ManagedState == "unmanaged" && q.ActivityState == "" && q.Status == "" && q.RowState == "", "warn").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = segmentChip(q.SegmentStalePrivileged().Href(), "Stale privileged", FormatInt64(s.StalePrivileged), q.PrivilegedOnly && q.ActivityState == "stale" && q.RowState == "", "warn").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = segmentChip(q.SegmentStalePrivileged().Href(), "Stale privileged", FormatInt64(s.StalePrivileged), q.PrivilegedOnly && q.ActivityState == "stale" && q.ManagedState == "" && q.Status == "" && q.RowState == "", "warn").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/http/views/non_human_access_show.templ
+++ b/internal/http/views/non_human_access_show.templ
@@ -18,7 +18,7 @@ templ NonHumanAccessShowPage(data viewmodels.NonHumanAccessShowViewData) {
 templ nonHumanAccessShowHeader(p viewmodels.NonHumanAccessSummaryView) {
 	<header class="space-y-4 border-b border-border/60 pb-6">
 		<div>
-			<a class="text-xs text-muted-foreground hover:text-foreground" href="/non-human-access">← Non-Human Access</a>
+			<a class="text-xs text-muted-foreground hover:text-foreground" href="/non-human-access">← Non-Human Principals</a>
 		</div>
 		<div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
 			<div class="min-w-0 space-y-2">

--- a/internal/http/views/non_human_access_show_templ.go
+++ b/internal/http/views/non_human_access_show_templ.go
@@ -106,14 +106,14 @@ func nonHumanAccessShowHeader(p viewmodels.NonHumanAccessSummaryView) templ.Comp
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<header class=\"space-y-4 border-b border-border/60 pb-6\"><div><a class=\"text-xs text-muted-foreground hover:text-foreground\" href=\"/non-human-access\">← Non-Human Access</a></div><div class=\"flex flex-col gap-4 md:flex-row md:items-start md:justify-between\"><div class=\"min-w-0 space-y-2\"><p class=\"text-xs uppercase tracking-wide text-muted-foreground\"><span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<header class=\"space-y-4 border-b border-border/60 pb-6\"><div><a class=\"text-xs text-muted-foreground hover:text-foreground\" href=\"/non-human-access\">← Non-Human Principals</a></div><div class=\"flex flex-col gap-4 md:flex-row md:items-start md:justify-between\"><div class=\"min-w-0 space-y-2\"><p class=\"text-xs uppercase tracking-wide text-muted-foreground\"><span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeNonHumanPrincipalType(p.PrincipalType))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 26, Col: 59}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 26, Col: 59}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -126,7 +126,7 @@ func nonHumanAccessShowHeader(p viewmodels.NonHumanAccessSummaryView) templ.Comp
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeConnectorKind(p.SourceKind))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 28, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 28, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
@@ -144,7 +144,7 @@ func nonHumanAccessShowHeader(p viewmodels.NonHumanAccessSummaryView) templ.Comp
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(" (")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 30, Col: 51}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 30, Col: 51}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
@@ -153,7 +153,7 @@ func nonHumanAccessShowHeader(p viewmodels.NonHumanAccessSummaryView) templ.Comp
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(p.SourceName)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 30, Col: 67}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 30, Col: 67}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -162,7 +162,7 @@ func nonHumanAccessShowHeader(p viewmodels.NonHumanAccessSummaryView) templ.Comp
 			var templ_7745c5c3_Var8 string
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(")")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 30, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 30, Col: 74}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
@@ -180,7 +180,7 @@ func nonHumanAccessShowHeader(p viewmodels.NonHumanAccessSummaryView) templ.Comp
 		var templ_7745c5c3_Var9 string
 		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(p.DisplayName)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 33, Col: 107}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 33, Col: 107}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 		if templ_7745c5c3_Err != nil {
@@ -198,7 +198,7 @@ func nonHumanAccessShowHeader(p viewmodels.NonHumanAccessSummaryView) templ.Comp
 			var templ_7745c5c3_Var10 string
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(p.SecondaryName)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 35, Col: 73}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 35, Col: 73}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
@@ -216,7 +216,7 @@ func nonHumanAccessShowHeader(p viewmodels.NonHumanAccessSummaryView) templ.Comp
 		var templ_7745c5c3_Var11 string
 		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(p.PrincipalRef)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 38, Col: 82}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 38, Col: 82}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 		if templ_7745c5c3_Err != nil {
@@ -246,7 +246,7 @@ func nonHumanAccessShowHeader(p viewmodels.NonHumanAccessSummaryView) templ.Comp
 		var templ_7745c5c3_Var13 string
 		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var12).String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 1, Col: 0}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 1, Col: 0}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 		if templ_7745c5c3_Err != nil {
@@ -259,7 +259,7 @@ func nonHumanAccessShowHeader(p viewmodels.NonHumanAccessSummaryView) templ.Comp
 		var templ_7745c5c3_Var14 string
 		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeCredentialRisk(p.RiskLevel))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 43, Col: 95}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 43, Col: 95}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 		if templ_7745c5c3_Err != nil {
@@ -268,7 +268,7 @@ func nonHumanAccessShowHeader(p viewmodels.NonHumanAccessSummaryView) templ.Comp
 		var templ_7745c5c3_Var15 string
 		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(" risk")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 43, Col: 106}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 43, Col: 106}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 		if templ_7745c5c3_Err != nil {
@@ -290,7 +290,7 @@ func nonHumanAccessShowHeader(p viewmodels.NonHumanAccessSummaryView) templ.Comp
 		var templ_7745c5c3_Var17 string
 		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var16).String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 1, Col: 0}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 1, Col: 0}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
@@ -303,7 +303,7 @@ func nonHumanAccessShowHeader(p viewmodels.NonHumanAccessSummaryView) templ.Comp
 		var templ_7745c5c3_Var18 string
 		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeAppAssetGovernanceState(p.GovernanceState))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 44, Col: 125}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 44, Col: 125}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 		if templ_7745c5c3_Err != nil {
@@ -321,7 +321,7 @@ func nonHumanAccessShowHeader(p viewmodels.NonHumanAccessSummaryView) templ.Comp
 			var templ_7745c5c3_Var19 templ.SafeURL
 			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinURLErrs(p.IdentityHref)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 46, Col: 52}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 46, Col: 52}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 			if templ_7745c5c3_Err != nil {
@@ -440,7 +440,7 @@ func nonHumanAccessShowOwnerField(p viewmodels.NonHumanAccessSummaryView) templ.
 			var templ_7745c5c3_Var22 templ.SafeURL
 			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinURLErrs(p.AccountableOwnerHref)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 74, Col: 112}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 74, Col: 112}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 			if templ_7745c5c3_Err != nil {
@@ -453,7 +453,7 @@ func nonHumanAccessShowOwnerField(p viewmodels.NonHumanAccessSummaryView) templ.
 			var templ_7745c5c3_Var23 string
 			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(p.AccountableOwner)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 74, Col: 135}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 74, Col: 135}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 			if templ_7745c5c3_Err != nil {
@@ -476,7 +476,7 @@ func nonHumanAccessShowOwnerField(p viewmodels.NonHumanAccessSummaryView) templ.
 			var templ_7745c5c3_Var25 string
 			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var24).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 1, Col: 0}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {
@@ -494,7 +494,7 @@ func nonHumanAccessShowOwnerField(p viewmodels.NonHumanAccessSummaryView) templ.
 			var templ_7745c5c3_Var26 string
 			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(p.AccountableOwner)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 78, Col: 67}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 78, Col: 67}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 			if templ_7745c5c3_Err != nil {
@@ -541,7 +541,7 @@ func nonHumanAccessShowDateField(label string, value viewmodels.TimeDisplay) tem
 		var templ_7745c5c3_Var28 string
 		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 85, Col: 91}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 85, Col: 91}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 		if templ_7745c5c3_Err != nil {
@@ -564,7 +564,7 @@ func nonHumanAccessShowDateField(label string, value viewmodels.TimeDisplay) tem
 			var templ_7745c5c3_Var29 string
 			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(value.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 89, Col: 61}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 89, Col: 61}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 			if templ_7745c5c3_Err != nil {
@@ -582,7 +582,7 @@ func nonHumanAccessShowDateField(label string, value viewmodels.TimeDisplay) tem
 				var templ_7745c5c3_Var30 string
 				templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(value.Relative)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 91, Col: 62}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 91, Col: 62}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 				if templ_7745c5c3_Err != nil {
@@ -639,7 +639,7 @@ func nonHumanAccessShowFreshnessField(p viewmodels.NonHumanAccessSummaryView) te
 		var templ_7745c5c3_Var33 string
 		templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var32).String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 1, Col: 0}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 1, Col: 0}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 		if templ_7745c5c3_Err != nil {
@@ -652,7 +652,7 @@ func nonHumanAccessShowFreshnessField(p viewmodels.NonHumanAccessSummaryView) te
 		var templ_7745c5c3_Var34 string
 		templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeNonHumanFreshnessState(p.FreshnessState))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 100, Col: 139}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 100, Col: 139}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 		if templ_7745c5c3_Err != nil {
@@ -704,7 +704,7 @@ func nonHumanAccessShowActivityField(p viewmodels.NonHumanAccessSummaryView) tem
 		var templ_7745c5c3_Var36 string
 		templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeNonHumanActivityState(p.ActivityState))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 110, Col: 82}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 110, Col: 82}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 		if templ_7745c5c3_Err != nil {
@@ -751,7 +751,7 @@ func nonHumanAccessShowIdentityField(p viewmodels.NonHumanAccessSummaryView) tem
 			var templ_7745c5c3_Var38 templ.SafeURL
 			templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinURLErrs(p.IdentityHref)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 118, Col: 92}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 118, Col: 92}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 			if templ_7745c5c3_Err != nil {
@@ -764,7 +764,7 @@ func nonHumanAccessShowIdentityField(p viewmodels.NonHumanAccessSummaryView) tem
 			var templ_7745c5c3_Var39 string
 			templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs("Identity #")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 118, Col: 109}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 118, Col: 109}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 			if templ_7745c5c3_Err != nil {
@@ -773,7 +773,7 @@ func nonHumanAccessShowIdentityField(p viewmodels.NonHumanAccessSummaryView) tem
 			var templ_7745c5c3_Var40 string
 			templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt64(p.IdentityID))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 118, Col: 138}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 118, Col: 138}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 			if templ_7745c5c3_Err != nil {
@@ -825,7 +825,7 @@ func nonHumanAccessShowAssetCountField(p viewmodels.NonHumanAccessSummaryView) t
 		var templ_7745c5c3_Var42 string
 		templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt64(p.LinkedAssetsCount))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 128, Col: 81}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 128, Col: 81}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
 		if templ_7745c5c3_Err != nil {
@@ -867,7 +867,7 @@ func nonHumanAccessShowCredentialCountField(p viewmodels.NonHumanAccessSummaryVi
 		var templ_7745c5c3_Var44 string
 		templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt64(p.LinkedCredentialsCount))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 135, Col: 86}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 135, Col: 86}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 		if templ_7745c5c3_Err != nil {
@@ -914,7 +914,7 @@ func nonHumanAccessShowAttributionField(p viewmodels.NonHumanAccessSummaryView) 
 			var templ_7745c5c3_Var46 templ.SafeURL
 			templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinURLErrs(p.BestAvailableAttributionHref)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 143, Col: 120}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 143, Col: 120}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 			if templ_7745c5c3_Err != nil {
@@ -927,7 +927,7 @@ func nonHumanAccessShowAttributionField(p viewmodels.NonHumanAccessSummaryView) 
 			var templ_7745c5c3_Var47 string
 			templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(p.BestAvailableAttribution)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 143, Col: 151}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 143, Col: 151}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
 			if templ_7745c5c3_Err != nil {
@@ -945,7 +945,7 @@ func nonHumanAccessShowAttributionField(p viewmodels.NonHumanAccessSummaryView) 
 			var templ_7745c5c3_Var48 string
 			templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(p.BestAvailableAttribution)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 145, Col: 75}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 145, Col: 75}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
 			if templ_7745c5c3_Err != nil {
@@ -997,7 +997,7 @@ func nonHumanAccessShowSignals(data viewmodels.NonHumanAccessShowViewData) templ
 			var templ_7745c5c3_Var50 string
 			templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt(len(data.RiskSignals)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 156, Col: 82}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 156, Col: 82}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
 			if templ_7745c5c3_Err != nil {
@@ -1006,7 +1006,7 @@ func nonHumanAccessShowSignals(data viewmodels.NonHumanAccessShowViewData) templ
 			var templ_7745c5c3_Var51 string
 			templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(pluralizeSuffix(len(data.RiskSignals), " signal", " signals"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 156, Col: 147}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 156, Col: 147}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
 			if templ_7745c5c3_Err != nil {
@@ -1043,7 +1043,7 @@ func nonHumanAccessShowSignals(data viewmodels.NonHumanAccessShowViewData) templ
 				var templ_7745c5c3_Var53 string
 				templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var52).String())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 1, Col: 0}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 1, Col: 0}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var53))
 				if templ_7745c5c3_Err != nil {
@@ -1065,7 +1065,7 @@ func nonHumanAccessShowSignals(data viewmodels.NonHumanAccessShowViewData) templ
 				var templ_7745c5c3_Var55 string
 				templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var54).String())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 1, Col: 0}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 1, Col: 0}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
 				if templ_7745c5c3_Err != nil {
@@ -1078,7 +1078,7 @@ func nonHumanAccessShowSignals(data viewmodels.NonHumanAccessShowViewData) templ
 				var templ_7745c5c3_Var56 string
 				templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeRiskSeverity(signal.Severity))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 165, Col: 126}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 165, Col: 126}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
 				if templ_7745c5c3_Err != nil {
@@ -1091,7 +1091,7 @@ func nonHumanAccessShowSignals(data viewmodels.NonHumanAccessShowViewData) templ
 				var templ_7745c5c3_Var57 string
 				templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinStringErrs(signal.Title)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 168, Col: 52}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 168, Col: 52}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var57))
 				if templ_7745c5c3_Err != nil {
@@ -1109,7 +1109,7 @@ func nonHumanAccessShowSignals(data viewmodels.NonHumanAccessShowViewData) templ
 					var templ_7745c5c3_Var58 string
 					templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinStringErrs(signal.Evidence)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 170, Col: 66}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 170, Col: 66}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var58))
 					if templ_7745c5c3_Err != nil {
@@ -1176,7 +1176,7 @@ func nonHumanAccessShowRelatedAssets(data viewmodels.NonHumanAccessShowViewData)
 			var templ_7745c5c3_Var60 string
 			templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt(len(data.RelatedAssets)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 187, Col: 84}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 187, Col: 84}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var60))
 			if templ_7745c5c3_Err != nil {
@@ -1185,7 +1185,7 @@ func nonHumanAccessShowRelatedAssets(data viewmodels.NonHumanAccessShowViewData)
 			var templ_7745c5c3_Var61 string
 			templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.JoinStringErrs(pluralizeSuffix(len(data.RelatedAssets), " asset", " assets"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 187, Col: 149}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 187, Col: 149}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var61))
 			if templ_7745c5c3_Err != nil {
@@ -1213,7 +1213,7 @@ func nonHumanAccessShowRelatedAssets(data viewmodels.NonHumanAccessShowViewData)
 				var templ_7745c5c3_Var62 templ.SafeURL
 				templ_7745c5c3_Var62, templ_7745c5c3_Err = templ.JoinURLErrs(item.Href)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 207, Col: 77}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 207, Col: 77}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var62))
 				if templ_7745c5c3_Err != nil {
@@ -1226,7 +1226,7 @@ func nonHumanAccessShowRelatedAssets(data viewmodels.NonHumanAccessShowViewData)
 				var templ_7745c5c3_Var63 string
 				templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.JoinStringErrs(item.DisplayName)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 207, Col: 98}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 207, Col: 98}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var63))
 				if templ_7745c5c3_Err != nil {
@@ -1239,7 +1239,7 @@ func nonHumanAccessShowRelatedAssets(data viewmodels.NonHumanAccessShowViewData)
 				var templ_7745c5c3_Var64 string
 				templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeProgrammaticKind(item.AssetKind))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 208, Col: 94}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 208, Col: 94}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var64))
 				if templ_7745c5c3_Err != nil {
@@ -1248,7 +1248,7 @@ func nonHumanAccessShowRelatedAssets(data viewmodels.NonHumanAccessShowViewData)
 				var templ_7745c5c3_Var65 string
 				templ_7745c5c3_Var65, templ_7745c5c3_Err = templ.JoinStringErrs(" · ")
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 208, Col: 104}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 208, Col: 104}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var65))
 				if templ_7745c5c3_Err != nil {
@@ -1257,7 +1257,7 @@ func nonHumanAccessShowRelatedAssets(data viewmodels.NonHumanAccessShowViewData)
 				var templ_7745c5c3_Var66 string
 				templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeConnectorKind(item.SourceKind))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 208, Col: 146}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 208, Col: 146}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var66))
 				if templ_7745c5c3_Err != nil {
@@ -1275,7 +1275,7 @@ func nonHumanAccessShowRelatedAssets(data viewmodels.NonHumanAccessShowViewData)
 					var templ_7745c5c3_Var67 string
 					templ_7745c5c3_Var67, templ_7745c5c3_Err = templ.JoinStringErrs(item.ExternalID)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 210, Col: 94}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 210, Col: 94}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var67))
 					if templ_7745c5c3_Err != nil {
@@ -1302,7 +1302,7 @@ func nonHumanAccessShowRelatedAssets(data viewmodels.NonHumanAccessShowViewData)
 				var templ_7745c5c3_Var69 string
 				templ_7745c5c3_Var69, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var68).String())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 1, Col: 0}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 1, Col: 0}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var69))
 				if templ_7745c5c3_Err != nil {
@@ -1315,7 +1315,7 @@ func nonHumanAccessShowRelatedAssets(data viewmodels.NonHumanAccessShowViewData)
 				var templ_7745c5c3_Var70 string
 				templ_7745c5c3_Var70, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeAppAssetGovernanceState(item.GovernanceState))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 214, Col: 157}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 214, Col: 157}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var70))
 				if templ_7745c5c3_Err != nil {
@@ -1328,7 +1328,7 @@ func nonHumanAccessShowRelatedAssets(data viewmodels.NonHumanAccessShowViewData)
 				var templ_7745c5c3_Var71 string
 				templ_7745c5c3_Var71, templ_7745c5c3_Err = templ.JoinStringErrs(fallbackHumanized(item.Status))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 215, Col: 84}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 215, Col: 84}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var71))
 				if templ_7745c5c3_Err != nil {
@@ -1346,7 +1346,7 @@ func nonHumanAccessShowRelatedAssets(data viewmodels.NonHumanAccessShowViewData)
 					var templ_7745c5c3_Var72 templ.SafeURL
 					templ_7745c5c3_Var72, templ_7745c5c3_Err = templ.JoinURLErrs(item.GovernanceOwnerHref)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 219, Col: 69}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 219, Col: 69}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var72))
 					if templ_7745c5c3_Err != nil {
@@ -1359,7 +1359,7 @@ func nonHumanAccessShowRelatedAssets(data viewmodels.NonHumanAccessShowViewData)
 					var templ_7745c5c3_Var73 string
 					templ_7745c5c3_Var73, templ_7745c5c3_Err = templ.JoinStringErrs(item.GovernanceOwner)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 219, Col: 94}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 219, Col: 94}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var73))
 					if templ_7745c5c3_Err != nil {
@@ -1377,7 +1377,7 @@ func nonHumanAccessShowRelatedAssets(data viewmodels.NonHumanAccessShowViewData)
 					var templ_7745c5c3_Var74 string
 					templ_7745c5c3_Var74, templ_7745c5c3_Err = templ.JoinStringErrs(item.GovernanceOwner)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 221, Col: 54}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 221, Col: 54}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var74))
 					if templ_7745c5c3_Err != nil {
@@ -1395,7 +1395,7 @@ func nonHumanAccessShowRelatedAssets(data viewmodels.NonHumanAccessShowViewData)
 				var templ_7745c5c3_Var75 string
 				templ_7745c5c3_Var75, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt64(item.LinkedCredentials))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 224, Col: 80}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 224, Col: 80}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var75))
 				if templ_7745c5c3_Err != nil {
@@ -1417,7 +1417,7 @@ func nonHumanAccessShowRelatedAssets(data viewmodels.NonHumanAccessShowViewData)
 				var templ_7745c5c3_Var77 string
 				templ_7745c5c3_Var77, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var76).String())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 1, Col: 0}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 1, Col: 0}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var77))
 				if templ_7745c5c3_Err != nil {
@@ -1430,7 +1430,7 @@ func nonHumanAccessShowRelatedAssets(data viewmodels.NonHumanAccessShowViewData)
 				var templ_7745c5c3_Var78 string
 				templ_7745c5c3_Var78, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeAppAssetEvidenceFreshness(item.EvidenceFreshness))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 227, Col: 145}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 227, Col: 145}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var78))
 				if templ_7745c5c3_Err != nil {
@@ -1443,7 +1443,7 @@ func nonHumanAccessShowRelatedAssets(data viewmodels.NonHumanAccessShowViewData)
 				var templ_7745c5c3_Var79 string
 				templ_7745c5c3_Var79, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeAppAssetEvidenceConfidence(item.EvidenceConfidence))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 228, Col: 115}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 228, Col: 115}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var79))
 				if templ_7745c5c3_Err != nil {
@@ -1456,7 +1456,7 @@ func nonHumanAccessShowRelatedAssets(data viewmodels.NonHumanAccessShowViewData)
 				var templ_7745c5c3_Var80 string
 				templ_7745c5c3_Var80, templ_7745c5c3_Err = templ.JoinStringErrs(item.EvidenceSeen.Label)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 231, Col: 90}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 231, Col: 90}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var80))
 				if templ_7745c5c3_Err != nil {
@@ -1531,7 +1531,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 			var templ_7745c5c3_Var83 string
 			templ_7745c5c3_Var83, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var82).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 1, Col: 0}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var83))
 			if templ_7745c5c3_Err != nil {
@@ -1554,7 +1554,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 			var templ_7745c5c3_Var85 string
 			templ_7745c5c3_Var85, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var84).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 1, Col: 0}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var85))
 			if templ_7745c5c3_Err != nil {
@@ -1583,7 +1583,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 			var templ_7745c5c3_Var86 string
 			templ_7745c5c3_Var86, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt(len(data.Credentials)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 260, Col: 82}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 260, Col: 82}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var86))
 			if templ_7745c5c3_Err != nil {
@@ -1592,7 +1592,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 			var templ_7745c5c3_Var87 string
 			templ_7745c5c3_Var87, templ_7745c5c3_Err = templ.JoinStringErrs(pluralizeSuffix(len(data.Credentials), " credential", " credentials"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 260, Col: 155}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 260, Col: 155}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var87))
 			if templ_7745c5c3_Err != nil {
@@ -1620,7 +1620,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 				var templ_7745c5c3_Var88 templ.SafeURL
 				templ_7745c5c3_Var88, templ_7745c5c3_Err = templ.JoinURLErrs(item.Href)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 281, Col: 77}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 281, Col: 77}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var88))
 				if templ_7745c5c3_Err != nil {
@@ -1633,7 +1633,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 				var templ_7745c5c3_Var89 string
 				templ_7745c5c3_Var89, templ_7745c5c3_Err = templ.JoinStringErrs(item.DisplayName)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 281, Col: 98}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 281, Col: 98}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var89))
 				if templ_7745c5c3_Err != nil {
@@ -1646,7 +1646,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 				var templ_7745c5c3_Var90 string
 				templ_7745c5c3_Var90, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeCredentialKind(item.CredentialKind))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 283, Col: 55}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 283, Col: 55}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var90))
 				if templ_7745c5c3_Err != nil {
@@ -1655,7 +1655,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 				var templ_7745c5c3_Var91 string
 				templ_7745c5c3_Var91, templ_7745c5c3_Err = templ.JoinStringErrs(" · ")
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 283, Col: 65}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 283, Col: 65}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var91))
 				if templ_7745c5c3_Err != nil {
@@ -1664,7 +1664,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 				var templ_7745c5c3_Var92 string
 				templ_7745c5c3_Var92, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeConnectorKind(item.SourceKind))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 283, Col: 107}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 283, Col: 107}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var92))
 				if templ_7745c5c3_Err != nil {
@@ -1678,7 +1678,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 					var templ_7745c5c3_Var93 string
 					templ_7745c5c3_Var93, templ_7745c5c3_Err = templ.JoinStringErrs(" · ")
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 285, Col: 19}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 285, Col: 19}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var93))
 					if templ_7745c5c3_Err != nil {
@@ -1687,7 +1687,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 					var templ_7745c5c3_Var94 string
 					templ_7745c5c3_Var94, templ_7745c5c3_Err = templ.JoinStringErrs(fallbackHumanized(item.Status))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 285, Col: 53}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 285, Col: 53}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var94))
 					if templ_7745c5c3_Err != nil {
@@ -1706,7 +1706,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 					var templ_7745c5c3_Var95 string
 					templ_7745c5c3_Var95, templ_7745c5c3_Err = templ.JoinStringErrs(item.ExternalID)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 289, Col: 94}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 289, Col: 94}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var95))
 					if templ_7745c5c3_Err != nil {
@@ -1733,7 +1733,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 				var templ_7745c5c3_Var97 string
 				templ_7745c5c3_Var97, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var96).String())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 1, Col: 0}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 1, Col: 0}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var97))
 				if templ_7745c5c3_Err != nil {
@@ -1746,7 +1746,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 				var templ_7745c5c3_Var98 string
 				templ_7745c5c3_Var98, templ_7745c5c3_Err = templ.JoinStringErrs(HumanizeCredentialRisk(item.RiskLevel))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 293, Col: 106}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 293, Col: 106}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var98))
 				if templ_7745c5c3_Err != nil {
@@ -1759,7 +1759,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 				var templ_7745c5c3_Var99 string
 				templ_7745c5c3_Var99, templ_7745c5c3_Err = templ.JoinStringErrs(item.ExpiresAt.Label)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 295, Col: 65}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 295, Col: 65}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var99))
 				if templ_7745c5c3_Err != nil {
@@ -1772,7 +1772,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 				var templ_7745c5c3_Var100 string
 				templ_7745c5c3_Var100, templ_7745c5c3_Err = templ.JoinStringErrs(item.LastUsedAt.Label)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 296, Col: 66}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 296, Col: 66}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var100))
 				if templ_7745c5c3_Err != nil {
@@ -1790,7 +1790,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 					var templ_7745c5c3_Var101 templ.SafeURL
 					templ_7745c5c3_Var101, templ_7745c5c3_Err = templ.JoinURLErrs(item.CreatedByHref)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 299, Col: 75}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 299, Col: 75}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var101))
 					if templ_7745c5c3_Err != nil {
@@ -1803,7 +1803,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 					var templ_7745c5c3_Var102 string
 					templ_7745c5c3_Var102, templ_7745c5c3_Err = templ.JoinStringErrs(item.CreatedBy)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 299, Col: 94}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 299, Col: 94}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var102))
 					if templ_7745c5c3_Err != nil {
@@ -1821,7 +1821,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 					var templ_7745c5c3_Var103 string
 					templ_7745c5c3_Var103, templ_7745c5c3_Err = templ.JoinStringErrs(item.CreatedBy)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 301, Col: 52}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 301, Col: 52}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var103))
 					if templ_7745c5c3_Err != nil {
@@ -1844,7 +1844,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 					var templ_7745c5c3_Var104 templ.SafeURL
 					templ_7745c5c3_Var104, templ_7745c5c3_Err = templ.JoinURLErrs(item.ApprovedByHref)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 306, Col: 76}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 306, Col: 76}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var104))
 					if templ_7745c5c3_Err != nil {
@@ -1857,7 +1857,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 					var templ_7745c5c3_Var105 string
 					templ_7745c5c3_Var105, templ_7745c5c3_Err = templ.JoinStringErrs(item.ApprovedBy)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 306, Col: 96}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 306, Col: 96}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var105))
 					if templ_7745c5c3_Err != nil {
@@ -1875,7 +1875,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 					var templ_7745c5c3_Var106 string
 					templ_7745c5c3_Var106, templ_7745c5c3_Err = templ.JoinStringErrs(item.ApprovedBy)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 308, Col: 53}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 308, Col: 53}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var106))
 					if templ_7745c5c3_Err != nil {
@@ -1898,7 +1898,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 					var templ_7745c5c3_Var107 templ.SafeURL
 					templ_7745c5c3_Var107, templ_7745c5c3_Err = templ.JoinURLErrs(item.AppAssetHref)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 313, Col: 74}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 313, Col: 74}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var107))
 					if templ_7745c5c3_Err != nil {
@@ -1911,7 +1911,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 					var templ_7745c5c3_Var108 string
 					templ_7745c5c3_Var108, templ_7745c5c3_Err = templ.JoinStringErrs(item.AppAssetDisplay)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 313, Col: 99}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 313, Col: 99}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var108))
 					if templ_7745c5c3_Err != nil {
@@ -1929,7 +1929,7 @@ func nonHumanAccessShowCredentials(data viewmodels.NonHumanAccessShowViewData) t
 					var templ_7745c5c3_Var109 string
 					templ_7745c5c3_Var109, templ_7745c5c3_Err = templ.JoinStringErrs(item.AppAssetDisplay)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/non_human_access_show.templ`, Line: 315, Col: 58}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `non_human_access_show.templ`, Line: 315, Col: 58}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var109))
 					if templ_7745c5c3_Err != nil {

--- a/internal/http/views/overview_map.templ
+++ b/internal/http/views/overview_map.templ
@@ -10,7 +10,7 @@ templ OverviewMap(graph viewmodels.OverviewMapGraph) {
 					<h2>Relationship map</h2>
 					<p>Configured identity sources, managed account coverage, and highest-risk privileged buckets.</p>
 				</div>
-				<a class="btn-sm-ghost" href="/global-view">Connector coverage <span aria-hidden="true">→</span></a>
+				<a class="btn-sm-ghost" href="/global-view">Sources <span aria-hidden="true">→</span></a>
 			</header>
 
 			<div class="overview-map-surface hidden lg:block" data-overview-map-surface>

--- a/internal/http/views/overview_map_templ.go
+++ b/internal/http/views/overview_map_templ.go
@@ -32,7 +32,7 @@ func OverviewMap(graph viewmodels.OverviewMapGraph) templ.Component {
 		}
 		ctx = templ.ClearChildren(ctx)
 		if len(graph.Sources) > 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<section class=\"overview-map\" aria-label=\"Relationship map\" data-testid=\"overview-map\"><header class=\"overview-map-header\"><div><h2>Relationship map</h2><p>Configured identity sources, managed account coverage, and highest-risk privileged buckets.</p></div><a class=\"btn-sm-ghost\" href=\"/global-view\">Connector coverage <span aria-hidden=\"true\">→</span></a></header><div class=\"overview-map-surface hidden lg:block\" data-overview-map-surface><svg class=\"overview-map-lines\" viewBox=\"0 0 100 100\" preserveAspectRatio=\"none\" aria-hidden=\"true\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<section class=\"overview-map\" aria-label=\"Relationship map\" data-testid=\"overview-map\"><header class=\"overview-map-header\"><div><h2>Relationship map</h2><p>Configured identity sources, managed account coverage, and highest-risk privileged buckets.</p></div><a class=\"btn-sm-ghost\" href=\"/global-view\">Sources <span aria-hidden=\"true\">→</span></a></header><div class=\"overview-map-surface hidden lg:block\" data-overview-map-surface><svg class=\"overview-map-lines\" viewBox=\"0 0 100 100\" preserveAspectRatio=\"none\" aria-hidden=\"true\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -44,7 +44,7 @@ func OverviewMap(graph viewmodels.OverviewMapGraph) templ.Component {
 				var templ_7745c5c3_Var2 string
 				templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(OverviewMapEdgePath(graph.CenterX, graph.CenterY, source.X, source.Y))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 19, Col: 111}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 19, Col: 111}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 				if templ_7745c5c3_Err != nil {
@@ -57,7 +57,7 @@ func OverviewMap(graph viewmodels.OverviewMapGraph) templ.Component {
 				var templ_7745c5c3_Var3 string
 				templ_7745c5c3_Var3, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues("--overview-map-index: " + FormatInt(idx) + ";")
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 19, Col: 169}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 19, Col: 169}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 				if templ_7745c5c3_Err != nil {
@@ -70,7 +70,7 @@ func OverviewMap(graph viewmodels.OverviewMapGraph) templ.Component {
 				var templ_7745c5c3_Var4 string
 				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt(idx))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 19, Col: 211}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 19, Col: 211}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 				if templ_7745c5c3_Err != nil {
@@ -88,7 +88,7 @@ func OverviewMap(graph viewmodels.OverviewMapGraph) templ.Component {
 			var templ_7745c5c3_Var5 string
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(OverviewMapNodeStyle(graph.CenterX, graph.CenterY))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 22, Col: 113}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 22, Col: 113}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {
@@ -109,7 +109,7 @@ func OverviewMap(graph viewmodels.OverviewMapGraph) templ.Component {
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt64(graph.IdentityCount))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 27, Col: 79}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 27, Col: 79}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
@@ -122,7 +122,7 @@ func OverviewMap(graph viewmodels.OverviewMapGraph) templ.Component {
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt64(graph.AccountCount))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 28, Col: 44}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 28, Col: 44}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -191,7 +191,7 @@ func overviewMapSourceNode(source viewmodels.OverviewMapSourceNode, index int) t
 			var templ_7745c5c3_Var10 string
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var9).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 1, Col: 0}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
@@ -204,7 +204,7 @@ func overviewMapSourceNode(source viewmodels.OverviewMapSourceNode, index int) t
 			var templ_7745c5c3_Var11 string
 			templ_7745c5c3_Var11, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(OverviewMapNodeStyle(source.X, source.Y) + " --overview-map-index: " + FormatInt(index) + ";")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 46, Col: 152}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 46, Col: 152}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
@@ -217,7 +217,7 @@ func overviewMapSourceNode(source viewmodels.OverviewMapSourceNode, index int) t
 			var templ_7745c5c3_Var12 templ.SafeURL
 			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(source.Href))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 46, Col: 188}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 46, Col: 188}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
@@ -230,7 +230,7 @@ func overviewMapSourceNode(source viewmodels.OverviewMapSourceNode, index int) t
 			var templ_7745c5c3_Var13 string
 			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt(index))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 46, Col: 232}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 46, Col: 232}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 			if templ_7745c5c3_Err != nil {
@@ -261,7 +261,7 @@ func overviewMapSourceNode(source viewmodels.OverviewMapSourceNode, index int) t
 			var templ_7745c5c3_Var15 string
 			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var14).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 1, Col: 0}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 			if templ_7745c5c3_Err != nil {
@@ -274,7 +274,7 @@ func overviewMapSourceNode(source viewmodels.OverviewMapSourceNode, index int) t
 			var templ_7745c5c3_Var16 string
 			templ_7745c5c3_Var16, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(OverviewMapNodeStyle(source.X, source.Y) + " --overview-map-index: " + FormatInt(index) + ";")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 50, Col: 154}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 50, Col: 154}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 			if templ_7745c5c3_Err != nil {
@@ -287,7 +287,7 @@ func overviewMapSourceNode(source viewmodels.OverviewMapSourceNode, index int) t
 			var templ_7745c5c3_Var17 string
 			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt(index))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 50, Col: 198}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 50, Col: 198}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 			if templ_7745c5c3_Err != nil {
@@ -346,7 +346,7 @@ func overviewMapSourceNodeContent(source viewmodels.OverviewMapSourceNode) templ
 		var templ_7745c5c3_Var19 string
 		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(source.Label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 63, Col: 24}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 63, Col: 24}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 		if templ_7745c5c3_Err != nil {
@@ -364,7 +364,7 @@ func overviewMapSourceNodeContent(source viewmodels.OverviewMapSourceNode) templ
 			var templ_7745c5c3_Var20 string
 			templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(source.SourceName)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 66, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 66, Col: 32}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 			if templ_7745c5c3_Err != nil {
@@ -377,7 +377,7 @@ func overviewMapSourceNodeContent(source viewmodels.OverviewMapSourceNode) templ
 			var templ_7745c5c3_Var21 string
 			templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(source.SourceName)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 66, Col: 54}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 66, Col: 54}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 			if templ_7745c5c3_Err != nil {
@@ -395,7 +395,7 @@ func overviewMapSourceNodeContent(source viewmodels.OverviewMapSourceNode) templ
 		var templ_7745c5c3_Var22 string
 		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(source.Label + " managed account coverage")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 70, Col: 107}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 70, Col: 107}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 		if templ_7745c5c3_Err != nil {
@@ -408,7 +408,7 @@ func overviewMapSourceNodeContent(source viewmodels.OverviewMapSourceNode) templ
 		var templ_7745c5c3_Var23 string
 		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt(source.CoveragePercent))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 70, Col: 197}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 70, Col: 197}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 		if templ_7745c5c3_Err != nil {
@@ -421,7 +421,7 @@ func overviewMapSourceNodeContent(source viewmodels.OverviewMapSourceNode) templ
 		var templ_7745c5c3_Var24 string
 		templ_7745c5c3_Var24, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues("width: " + FormatInt(source.CoveragePercent) + "%")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 71, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 71, Col: 66}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 		if templ_7745c5c3_Err != nil {
@@ -434,7 +434,7 @@ func overviewMapSourceNodeContent(source viewmodels.OverviewMapSourceNode) templ
 		var templ_7745c5c3_Var25 string
 		templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt64(source.IdentityCount))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 74, Col: 43}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 74, Col: 43}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 		if templ_7745c5c3_Err != nil {
@@ -447,7 +447,7 @@ func overviewMapSourceNodeContent(source viewmodels.OverviewMapSourceNode) templ
 		var templ_7745c5c3_Var26 string
 		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt64(source.UnmanagedAccountCount))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 75, Col: 51}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 75, Col: 51}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 		if templ_7745c5c3_Err != nil {
@@ -548,7 +548,7 @@ func overviewMapSourceListContent(source viewmodels.OverviewMapSourceNode) templ
 		var templ_7745c5c3_Var30 string
 		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(source.Label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 93, Col: 60}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 93, Col: 60}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 		if templ_7745c5c3_Err != nil {
@@ -561,7 +561,7 @@ func overviewMapSourceListContent(source viewmodels.OverviewMapSourceNode) templ
 		var templ_7745c5c3_Var31 string
 		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt64(source.AccountCount))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 94, Col: 82}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 94, Col: 82}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 		if templ_7745c5c3_Err != nil {
@@ -579,7 +579,7 @@ func overviewMapSourceListContent(source viewmodels.OverviewMapSourceNode) templ
 			var templ_7745c5c3_Var32 string
 			templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(source.SourceName)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 97, Col: 73}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 97, Col: 73}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
 			if templ_7745c5c3_Err != nil {
@@ -597,7 +597,7 @@ func overviewMapSourceListContent(source viewmodels.OverviewMapSourceNode) templ
 		var templ_7745c5c3_Var33 string
 		templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt(source.CoveragePercent))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 102, Col: 65}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 102, Col: 65}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 		if templ_7745c5c3_Err != nil {
@@ -615,7 +615,7 @@ func overviewMapSourceListContent(source viewmodels.OverviewMapSourceNode) templ
 			var templ_7745c5c3_Var34 string
 			templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt64(source.UnmanagedAccountCount))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 104, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 104, Col: 74}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 			if templ_7745c5c3_Err != nil {
@@ -673,7 +673,7 @@ func overviewMapMaybeLink(href, className, style, testID string) templ.Component
 				var templ_7745c5c3_Var37 string
 				templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var36).String())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 1, Col: 0}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 1, Col: 0}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 				if templ_7745c5c3_Err != nil {
@@ -686,7 +686,7 @@ func overviewMapMaybeLink(href, className, style, testID string) templ.Component
 				var templ_7745c5c3_Var38 string
 				templ_7745c5c3_Var38, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(style)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 113, Col: 39}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 113, Col: 39}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 				if templ_7745c5c3_Err != nil {
@@ -699,7 +699,7 @@ func overviewMapMaybeLink(href, className, style, testID string) templ.Component
 				var templ_7745c5c3_Var39 templ.SafeURL
 				templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(href))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 113, Col: 68}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 113, Col: 68}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 				if templ_7745c5c3_Err != nil {
@@ -712,7 +712,7 @@ func overviewMapMaybeLink(href, className, style, testID string) templ.Component
 				var templ_7745c5c3_Var40 string
 				templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(testID)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 113, Col: 91}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 113, Col: 91}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 				if templ_7745c5c3_Err != nil {
@@ -743,7 +743,7 @@ func overviewMapMaybeLink(href, className, style, testID string) templ.Component
 				var templ_7745c5c3_Var42 string
 				templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var41).String())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 1, Col: 0}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 1, Col: 0}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
 				if templ_7745c5c3_Err != nil {
@@ -756,7 +756,7 @@ func overviewMapMaybeLink(href, className, style, testID string) templ.Component
 				var templ_7745c5c3_Var43 templ.SafeURL
 				templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(href))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 117, Col: 52}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 117, Col: 52}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 				if templ_7745c5c3_Err != nil {
@@ -769,7 +769,7 @@ func overviewMapMaybeLink(href, className, style, testID string) templ.Component
 				var templ_7745c5c3_Var44 string
 				templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(testID)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 117, Col: 75}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 117, Col: 75}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 				if templ_7745c5c3_Err != nil {
@@ -802,7 +802,7 @@ func overviewMapMaybeLink(href, className, style, testID string) templ.Component
 				var templ_7745c5c3_Var46 string
 				templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var45).String())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 1, Col: 0}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 1, Col: 0}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 				if templ_7745c5c3_Err != nil {
@@ -815,7 +815,7 @@ func overviewMapMaybeLink(href, className, style, testID string) templ.Component
 				var templ_7745c5c3_Var47 string
 				templ_7745c5c3_Var47, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(style)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 123, Col: 41}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 123, Col: 41}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
 				if templ_7745c5c3_Err != nil {
@@ -828,7 +828,7 @@ func overviewMapMaybeLink(href, className, style, testID string) templ.Component
 				var templ_7745c5c3_Var48 string
 				templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(testID)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 123, Col: 64}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 123, Col: 64}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
 				if templ_7745c5c3_Err != nil {
@@ -859,7 +859,7 @@ func overviewMapMaybeLink(href, className, style, testID string) templ.Component
 				var templ_7745c5c3_Var50 string
 				templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var49).String())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 1, Col: 0}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 1, Col: 0}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
 				if templ_7745c5c3_Err != nil {
@@ -872,7 +872,7 @@ func overviewMapMaybeLink(href, className, style, testID string) templ.Component
 				var templ_7745c5c3_Var51 string
 				templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(testID)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 127, Col: 48}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 127, Col: 48}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
 				if templ_7745c5c3_Err != nil {
@@ -930,7 +930,7 @@ func overviewMapBuckets(buckets []viewmodels.OverviewMapBucket, wrapperClass str
 			var templ_7745c5c3_Var54 string
 			templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var53).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 1, Col: 0}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
 			if templ_7745c5c3_Err != nil {
@@ -988,7 +988,7 @@ func overviewMapBucket(bucket viewmodels.OverviewMapBucket) templ.Component {
 		var templ_7745c5c3_Var57 string
 		templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var56).String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 1, Col: 0}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 1, Col: 0}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var57))
 		if templ_7745c5c3_Err != nil {
@@ -1001,7 +1001,7 @@ func overviewMapBucket(bucket viewmodels.OverviewMapBucket) templ.Component {
 		var templ_7745c5c3_Var58 string
 		templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinStringErrs(bucket.Label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 146, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 146, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var58))
 		if templ_7745c5c3_Err != nil {
@@ -1014,7 +1014,7 @@ func overviewMapBucket(bucket viewmodels.OverviewMapBucket) templ.Component {
 		var templ_7745c5c3_Var59 string
 		templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinStringErrs(FormatInt64(bucket.AffectedCount))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/overview_map.templ`, Line: 147, Col: 78}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `overview_map.templ`, Line: 147, Col: 78}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var59))
 		if templ_7745c5c3_Err != nil {

--- a/internal/http/views/sidebar.templ
+++ b/internal/http/views/sidebar.templ
@@ -7,76 +7,71 @@ templ Sidebar(data viewmodels.LayoutData) {
 	<div role="group">
 		<h3>Explore</h3>
 		<ul>
-				<li>
-					<a href="/" aria-current={ AriaCurrent(data.ActivePath, "/") }>
-						@IconHome("sidebar-icon")
-						<span>Dashboard</span>
-					</a>
-				</li>
-				<li>
-					<a href="/global-view" aria-current={ AriaCurrent(data.ActivePath, "/global-view") }>
-						@IconGlobe("sidebar-icon")
-						<span>Global View</span>
-					</a>
-				</li>
-				<li>
-					<a href="/assigned-apps" aria-current={ AriaCurrent(data.ActivePath, "/assigned-apps") }>
-						@IconLayoutGrid("sidebar-icon")
-						<span>Assigned Apps</span>
-					</a>
-				</li>
-				<li>
-					<details open?={ strings.HasPrefix(data.ActivePath, "/discovery") }>
-						<summary aria-current={ AriaCurrent(data.ActivePath, "/discovery") }>
-							@IconAppWindow("sidebar-icon")
-							<span>SaaS Discovery</span>
-						</summary>
+			<li>
+				<a href="/" aria-current={ AriaCurrent(data.ActivePath, "/") }>
+					@IconHome("sidebar-icon")
+					<span>Posture</span>
+				</a>
+			</li>
+			<li>
+				<details open?={ strings.HasPrefix(data.ActivePath, "/discovery") || strings.HasPrefix(data.ActivePath, "/assigned-apps") || strings.HasPrefix(data.ActivePath, "/oauth-apps") }>
+					<summary aria-current={ AriaCurrentAppsSurface(data.ActivePath) }>
+						@IconAppWindow("sidebar-icon")
+						<span>Apps &amp; Discovery</span>
+					</summary>
 					<ul>
 						<li><a href="/discovery/apps" aria-current={ AriaCurrent(data.ActivePath, "/discovery/apps") }><span>Apps</span></a></li>
 						<li><a href="/discovery/hotspots" aria-current={ AriaCurrent(data.ActivePath, "/discovery/hotspots") }><span>Hotspots</span></a></li>
+						<li><a href="/assigned-apps" aria-current={ AriaCurrent(data.ActivePath, "/assigned-apps") }><span>Okta Assigned Apps</span></a></li>
 					</ul>
 				</details>
 			</li>
-				<li>
-					<a href="/identities" aria-current={ AriaCurrent(data.ActivePath, "/identities") }>
-						@IconUsers("sidebar-icon")
-						<span>Identities</span>
-					</a>
-				</li>
-				<li>
-					<details open?={ strings.HasPrefix(data.ActivePath, "/non-human-access") || strings.HasPrefix(data.ActivePath, "/app-assets") || strings.HasPrefix(data.ActivePath, "/credentials") }>
-						<summary aria-current={ AriaCurrentNonHumanAccessSurface(data.ActivePath) }>
-							@IconBot("sidebar-icon")
-							<span>Non-Human Access</span>
-						</summary>
+			<li>
+				<a href="/identities" aria-current={ AriaCurrent(data.ActivePath, "/identities") }>
+					@IconUsers("sidebar-icon")
+					<span>Identities</span>
+				</a>
+			</li>
+			<li>
+				<details open?={ strings.HasPrefix(data.ActivePath, "/non-human-access") || strings.HasPrefix(data.ActivePath, "/app-assets") || strings.HasPrefix(data.ActivePath, "/credentials") }>
+					<summary aria-current={ AriaCurrentNonHumanAccessSurface(data.ActivePath) }>
+						@IconBot("sidebar-icon")
+						<span>Access Risk</span>
+					</summary>
 					<ul>
-						<li><a href="/non-human-access" aria-current={ AriaCurrent(data.ActivePath, "/non-human-access") }><span>Inventory</span></a></li>
+						<li><a href="/non-human-access" aria-current={ AriaCurrent(data.ActivePath, "/non-human-access") }><span>Principals</span></a></li>
 						<li><a href="/app-assets" aria-current={ AriaCurrent(data.ActivePath, "/app-assets") }><span>App Assets</span></a></li>
 						<li><a href="/credentials" aria-current={ AriaCurrent(data.ActivePath, "/credentials") }><span>Credentials</span></a></li>
 					</ul>
 				</details>
 			</li>
-				<li>
-					<details open?={ strings.HasPrefix(data.ActivePath, "/findings") }>
-						<summary aria-current={ AriaCurrent(data.ActivePath, "/findings") }>
-							@IconFileWarning("sidebar-icon")
-							<span>Findings</span>
-						</summary>
-						<ul>
-							<li><a href="/findings" aria-current={ AriaCurrentExact(data.ActivePath, "/findings") }><span>Overview</span></a></li>
-							for _, ruleset := range data.FindingsRulesets {
-								<li><a href={ ruleset.Href } aria-current={ AriaCurrent(data.ActivePath, ruleset.Href) }><span class="truncate" title={ ruleset.Name }>{ ruleset.Name }</span></a></li>
-							}
-						</ul>
-					</details>
-				</li>
+			<li>
+				<a href="/global-view" aria-current={ AriaCurrent(data.ActivePath, "/global-view") }>
+					@IconGlobe("sidebar-icon")
+					<span>Sources</span>
+				</a>
+			</li>
+			<li>
+				<details open?={ strings.HasPrefix(data.ActivePath, "/findings") }>
+					<summary aria-current={ AriaCurrent(data.ActivePath, "/findings") }>
+						@IconFileWarning("sidebar-icon")
+						<span>Findings</span>
+					</summary>
+					<ul>
+						<li><a href="/findings" aria-current={ AriaCurrentExact(data.ActivePath, "/findings") }><span>Overview</span></a></li>
+						for _, ruleset := range data.FindingsRulesets {
+							<li><a href={ ruleset.Href } aria-current={ AriaCurrent(data.ActivePath, ruleset.Href) }><span class="truncate" title={ ruleset.Name }>{ ruleset.Name }</span></a></li>
+						}
+					</ul>
+				</details>
+			</li>
 			if data.IsAdmin {
-					<li>
-						<details open?={ strings.HasPrefix(data.ActivePath, "/settings") }>
-							<summary aria-current={ AriaCurrent(data.ActivePath, "/settings") }>
-								@IconSettings("sidebar-icon")
-								<span>Settings</span>
-							</summary>
+				<li>
+					<details open?={ strings.HasPrefix(data.ActivePath, "/settings") }>
+						<summary aria-current={ AriaCurrent(data.ActivePath, "/settings") }>
+							@IconSettings("sidebar-icon")
+							<span>Settings</span>
+						</summary>
 						<ul>
 							<li><a href="/settings" aria-current={ AriaCurrentExact(data.ActivePath, "/settings") }><span>Overview</span></a></li>
 							<li><a href="/settings/connectors" aria-current={ AriaCurrent(data.ActivePath, "/settings/connectors") }><span>Connectors</span></a></li>

--- a/internal/http/views/sidebar_templ.go
+++ b/internal/http/views/sidebar_templ.go
@@ -39,7 +39,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 11, Col: 65}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 11, Col: 64}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
@@ -53,37 +53,26 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<span>Dashboard</span></a></li><li><a href=\"/global-view\" aria-current=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<span>Posture</span></a></li><li><details")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if strings.HasPrefix(data.ActivePath, "/discovery") || strings.HasPrefix(data.ActivePath, "/assigned-apps") || strings.HasPrefix(data.ActivePath, "/oauth-apps") {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, " open")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "><summary aria-current=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var3 string
-		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/global-view"))
+		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrentAppsSurface(data.ActivePath))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 17, Col: 87}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 18, Col: 68}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = IconGlobe("sidebar-icon").Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<span>Global View</span></a></li><li><a href=\"/assigned-apps\" aria-current=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var4 string
-		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/assigned-apps"))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 23, Col: 91}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -91,81 +80,63 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = IconLayoutGrid("sidebar-icon").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = IconAppWindow("sidebar-icon").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<span>Assigned Apps</span></a></li><li><details")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<span>Apps &amp; Discovery</span></summary><ul><li><a href=\"/discovery/apps\" aria-current=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if strings.HasPrefix(data.ActivePath, "/discovery") {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, " open")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
+		var templ_7745c5c3_Var4 string
+		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/discovery/apps"))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 23, Col: 98}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "><summary aria-current=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\"><span>Apps</span></a></li><li><a href=\"/discovery/hotspots\" aria-current=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var5 string
-		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/discovery"))
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/discovery/hotspots"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 30, Col: 72}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 24, Col: 106}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = IconAppWindow("sidebar-icon").Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<span>SaaS Discovery</span></summary><ul><li><a href=\"/discovery/apps\" aria-current=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\"><span>Hotspots</span></a></li><li><a href=\"/assigned-apps\" aria-current=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var6 string
-		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/discovery/apps"))
+		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/assigned-apps"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 35, Col: 98}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 25, Col: 96}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\"><span>Apps</span></a></li><li><a href=\"/discovery/hotspots\" aria-current=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\"><span>Okta Assigned Apps</span></a></li></ul></details></li><li><a href=\"/identities\" aria-current=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var7 string
-		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/discovery/hotspots"))
+		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/identities"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 36, Col: 106}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 30, Col: 84}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\"><span>Hotspots</span></a></li></ul></details></li><li><a href=\"/identities\" aria-current=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var8 string
-		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/identities"))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 41, Col: 85}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -173,30 +144,30 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<span>Identities</span></a></li><li><details")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<span>Identities</span></a></li><li><details")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if strings.HasPrefix(data.ActivePath, "/non-human-access") || strings.HasPrefix(data.ActivePath, "/app-assets") || strings.HasPrefix(data.ActivePath, "/credentials") {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, " open")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, " open")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "><summary aria-current=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "><summary aria-current=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var9 string
-		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrentNonHumanAccessSurface(data.ActivePath))
+		var templ_7745c5c3_Var8 string
+		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrentNonHumanAccessSurface(data.ActivePath))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 48, Col: 79}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 37, Col: 78}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -204,69 +175,90 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<span>Non-Human Access</span></summary><ul><li><a href=\"/non-human-access\" aria-current=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<span>Access Risk</span></summary><ul><li><a href=\"/non-human-access\" aria-current=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var9 string
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/non-human-access"))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 42, Col: 102}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\"><span>Principals</span></a></li><li><a href=\"/app-assets\" aria-current=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var10 string
-		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/non-human-access"))
+		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/app-assets"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 53, Col: 102}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 43, Col: 90}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\"><span>Inventory</span></a></li><li><a href=\"/app-assets\" aria-current=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\"><span>App Assets</span></a></li><li><a href=\"/credentials\" aria-current=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var11 string
-		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/app-assets"))
+		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/credentials"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 54, Col: 90}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 44, Col: 92}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "\"><span>App Assets</span></a></li><li><a href=\"/credentials\" aria-current=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\"><span>Credentials</span></a></li></ul></details></li><li><a href=\"/global-view\" aria-current=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var12 string
-		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/credentials"))
+		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/global-view"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 55, Col: 92}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 49, Col: 86}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "\"><span>Credentials</span></a></li></ul></details></li><li><details")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = IconGlobe("sidebar-icon").Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<span>Sources</span></a></li><li><details")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if strings.HasPrefix(data.ActivePath, "/findings") {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, " open")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, " open")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "><summary aria-current=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "><summary aria-current=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var13 string
 		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/findings"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 61, Col: 71}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 56, Col: 70}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -274,110 +266,110 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<span>Findings</span></summary><ul><li><a href=\"/findings\" aria-current=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<span>Findings</span></summary><ul><li><a href=\"/findings\" aria-current=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var14 string
 		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrentExact(data.ActivePath, "/findings"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 66, Col: 92}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 61, Col: 91}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "\"><span>Overview</span></a></li>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\"><span>Overview</span></a></li>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, ruleset := range data.FindingsRulesets {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<li><a href=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<li><a href=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var15 templ.SafeURL
 			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinURLErrs(ruleset.Href)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 68, Col: 34}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 63, Col: 33}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\" aria-current=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\" aria-current=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var16 string
 			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, ruleset.Href))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 68, Col: 94}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 63, Col: 93}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\"><span class=\"truncate\" title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\"><span class=\"truncate\" title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var17 string
 			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(ruleset.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 68, Col: 140}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 63, Col: 139}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var18 string
 			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(ruleset.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 68, Col: 157}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 63, Col: 156}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</span></a></li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</span></a></li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</ul></details></li>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</ul></details></li>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if data.IsAdmin {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<li><details")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "<li><details")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if strings.HasPrefix(data.ActivePath, "/settings") {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, " open")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, " open")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "><summary aria-current=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "><summary aria-current=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var19 string
 			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/settings"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 76, Col: 72}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 71, Col: 71}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -385,64 +377,64 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "<span>Settings</span></summary><ul><li><a href=\"/settings\" aria-current=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "<span>Settings</span></summary><ul><li><a href=\"/settings\" aria-current=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var20 string
 			templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrentExact(data.ActivePath, "/settings"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 81, Col: 92}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 76, Col: 92}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "\"><span>Overview</span></a></li><li><a href=\"/settings/connectors\" aria-current=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "\"><span>Overview</span></a></li><li><a href=\"/settings/connectors\" aria-current=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var21 string
 			templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/settings/connectors"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 82, Col: 109}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 77, Col: 109}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "\"><span>Connectors</span></a></li><li><a href=\"/settings/connector-health\" aria-current=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "\"><span>Connectors</span></a></li><li><a href=\"/settings/connector-health\" aria-current=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var22 string
 			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/settings/connector-health"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 83, Col: 121}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 78, Col: 121}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "\"><span>Connector health</span></a></li><li><a href=\"/settings/users\" aria-current=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "\"><span>Connector health</span></a></li><li><a href=\"/settings/users\" aria-current=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var23 string
 			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(AriaCurrent(data.ActivePath, "/settings/users"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 84, Col: 99}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 79, Col: 99}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\"><span>Team Management</span></a></li></ul></details></li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "\"><span>Team Management</span></a></li></ul></details></li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "</ul></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "</ul></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/http/views/table_query_bar_helpers.go
+++ b/internal/http/views/table_query_bar_helpers.go
@@ -57,6 +57,11 @@ func IdentitiesTableQueryBar(data viewmodels.IdentitiesViewData) viewmodels.Tabl
 	}
 
 	fields := []viewmodels.TableFilterField{
+		tableQueryField("row_state", "Attention", viewmodels.TableFilterFieldKindSingleSelect, []string{"row_state"}, query.RowState, query.RowState == "", []viewmodels.TableFilterOption{
+			tableQueryOption("action_required", "Needs action", tableQueryControl("row_state", "action_required")),
+			tableQueryOption("review", "Review", tableQueryControl("row_state", "review")),
+			tableQueryOption("healthy", "Healthy", tableQueryControl("row_state", "healthy")),
+		}),
 		tableQueryField("activity_state", "Activity", viewmodels.TableFilterFieldKindSingleSelect, []string{"activity_state"}, query.ActivityState, query.ActivityState == "", []viewmodels.TableFilterOption{
 			tableQueryOption("recent", "Seen < 30d", tableQueryControl("activity_state", "recent")),
 			tableQueryOption("aging", "30-89d", tableQueryControl("activity_state", "aging")),
@@ -93,15 +98,17 @@ func IdentitiesTableQueryBar(data viewmodels.IdentitiesViewData) viewmodels.Tabl
 		fields,
 		[]viewmodels.TableActiveChip{
 			maybeChip(fields[0]),
-			maybeBooleanChip(fields[1], query.PrivilegedOnly),
-			maybeChip(fields[2]),
+			maybeChip(fields[1]),
+			maybeBooleanChip(fields[2], query.PrivilegedOnly),
 			maybeChip(fields[3]),
 			maybeChip(fields[4]),
 			maybeChip(fields[5]),
 			maybeChip(fields[6]),
 			maybeChip(fields[7]),
+			maybeChip(fields[8]),
 		},
 		tableQueryControls(
+			controlIfNotEmpty("row_state", query.RowState),
 			controlIfNotEmpty("source_kind", query.Source.Kind),
 			controlIfNotEmpty("source_name", query.Source.Name),
 			controlIfNotEmpty("identity_type", query.IdentityType),

--- a/web/static/src/input.css
+++ b/web/static/src/input.css
@@ -1177,6 +1177,14 @@
     @apply bg-background/20 text-background;
   }
 
+  .osspm-segment-chip-danger.osspm-segment-chip-active {
+    @apply border-rose-700/30 bg-rose-700 text-rose-50 hover:bg-rose-700/90;
+  }
+
+  .osspm-segment-chip-danger.osspm-segment-chip-active .osspm-segment-chip-count {
+    @apply bg-rose-50/20 text-rose-50;
+  }
+
   .osspm-segment-chip-warn.osspm-segment-chip-active {
     @apply border-amber-700/30 bg-amber-700 text-amber-50 hover:bg-amber-700/90;
   }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR promotes identity segments by adding two new query-level segment chips ("Needs action" and "Review" via `row_state`, plus "Privileged unmanaged" and "Stale privileged") with corresponding SQL filter support (`row_state` column added to `CountIdentitiesInventoryByFilters` and `ListIdentitiesInventoryPageByFilters`), and renames several page titles throughout the UI (Dashboard → Posture, Global View → Sources, Non-Human Access → Non-Human Principals, etc.).

- **SQL layer**: `row_state` filter added to both the count and list inventory queries; two new aggregate columns (`privileged_unmanaged_count`, `stale_privileged_count`) added to the summary query so chip badges reflect real subset sizes.
- **Query-state layer**: `SegmentNeedsAction`, `SegmentReview`, `SegmentPrivilegedUnmanaged`, and `SegmentStalePrivileged` helper methods added, all routing through `ClearSegments()` so segment navigation stays clean.
- **UI label renames**: Consistent rename of \"Dashboard\" → \"Posture\", \"SaaS Discovery\" → \"Apps & Discovery\", \"Non-Human Access\" → \"Non-Human Principals\", \"Assigned Apps\" → \"Okta Assigned Apps\", \"Global View\" → \"Sources\" across handlers, sidebar, and generated templ files.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the SQL, Go handler, and query-state layers are internally consistent; the one finding is a cosmetic chip highlight edge-case only reachable via crafted URLs.

The RowState filter is correctly threaded through SQL, generated Go, handler, and view layers. Segment helpers all route through ClearSegments() so normal navigation never produces an inconsistent state. The active-state overlap between the new row_state chips and the existing status chip is only visible when someone manually constructs a URL combining both parameters, and it affects only highlighting rather than data correctness.

The chip active-state logic in `internal/http/views/identities.templ` (lines 145–149) is the one area worth revisiting before the next related chip is added.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/http/views/identities.templ | Adds four new segment chips with active-state guards; "Needs action" and "Review" chips lack mutual-exclusion guards against the "Suspended" chip's Status field. |
| internal/http/querystate/identities.go | Adds RowState field, four new Segment* helpers (all via ClearSegments), and correctly updates HasSegment/HasFilters/FilterCount/ClearFilters. |
| db/queries/identities.sql | Correctly adds row_state filter to count and list queries, and two new aggregate columns to the summary query. |
| internal/db/gen/identities.sql.go | Generated file correctly reflects the new RowState param and updated positional SQL parameter numbering after the RowState insertion. |
| internal/http/handlers/identities.go | Correctly threads RowState and the two new summary fields through to the view model; summary query intentionally omits segment filters. |
| internal/http/viewmodels/identities.go | IdentitiesSummary struct extended with PrivilegedUnmanaged and StalePrivileged fields; straightforward and consistent. |
| internal/http/querystate/querystate_test.go | Tests for the new segment helpers verify correct field values and mutual exclusion of other segment fields. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    URL["URL query params"] --> Parse["ParseIdentitiesQuery()"]
    Parse --> QS["IdentitiesQuery\n(+RowState field)"]

    QS --> Segment["Segment helper\nClearSegments() + set field(s)"]
    Segment --> NeedsAction["SegmentNeedsAction()\nRowState=action_required"]
    Segment --> Review["SegmentReview()\nRowState=review"]
    Segment --> PrivUnmanaged["SegmentPrivilegedUnmanaged()\nPrivilegedOnly=true\nManagedState=unmanaged"]
    Segment --> StalePriv["SegmentStalePrivileged()\nPrivilegedOnly=true\nActivityState=stale"]

    QS --> Handler["HandleIdentities()"]
    Handler --> SumQuery["SummarizeIdentitiesInventoryByFilters\n(no segment filters — shows full pop.)"]
    SumQuery --> Counts["Summary counts\n+privileged_unmanaged_count\n+stale_privileged_count"]

    Handler --> ListQuery["ListIdentitiesInventoryPageByFilters\n(+row_state filter)"]
    Handler --> CountQuery["CountIdentitiesInventoryByFilters\n(+row_state filter)"]

    Counts --> Chips["identitiesSegmentChips()\nactive state evaluated per chip"]
    ListQuery --> Table["Identity table rows"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/http/views/identities.templ:145-149
**Chip active-state mutual exclusion incomplete for row_state vs status**

The "Needs action" check (`q.RowState == "action_required"`) and "Review" check (`q.RowState == "review"`) don't guard against `q.Status` being set, and the "Suspended" check (`q.Status == "suspended"`) doesn't guard against `q.RowState`. A URL like `?row_state=action_required&status=suspended` renders both "Needs action" and "Suspended" as active simultaneously — the same overlap pattern that was just fixed for the privileged-segment chips on lines 146–147. Applying the same guard style (`&& q.Status == ""` on the row_state chips, `&& q.RowState == ""` on the suspended chip) would make the behaviour fully consistent.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["cr fix"](https://github.com/open-sspm/open-sspm/commit/daa9853549e8d9c1047916fa0bb8023c13fbd88a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31486992)</sub>

<!-- /greptile_comment -->