### PR TITLE
fix: flickr after the htmx changes

### DIFF
--- a/internal/http/views/layout.templ
+++ b/internal/http/views/layout.templ
@@ -8,7 +8,7 @@ templ Layout(data viewmodels.LayoutData) {
 		<head>
 			<meta charset="utf-8"/>
 			<meta name="viewport" content="width=device-width, initial-scale=1"/>
-			<meta name="htmx-config" content={ `{"allowEval":false,"allowScriptTags":false,"defaultSwapStyle":"outerHTML","historyCacheSize":10,"historyRestoreAsHxRequest":false,"selfRequestsOnly":true,"globalViewTransitions":true}` }/>
+			<meta name="htmx-config" content={ `{"allowEval":false,"allowScriptTags":false,"defaultSwapStyle":"outerHTML","historyCacheSize":10,"historyRestoreAsHxRequest":false,"selfRequestsOnly":true}` }/>
 			<meta name="csrf-token" content={ data.CSRFToken }/>
 			<title>{ data.Title }{ " · Open-SSPM" }</title>
 			<link rel="icon" href="/static/favicon.ico" type="image/x-icon"/>
@@ -74,7 +74,7 @@ templ Layout(data viewmodels.LayoutData) {
 								<path fill-rule="evenodd" d="M3 5.25A.75.75 0 0 1 3.75 4.5h12.5a.75.75 0 0 1 0 1.5H3.75A.75.75 0 0 1 3 5.25ZM3 10a.75.75 0 0 1 .75-.75h12.5a.75.75 0 0 1 0 1.5H3.75A.75.75 0 0 1 3 10Zm0 4.75a.75.75 0 0 1 .75-.75h12.5a.75.75 0 0 1 0 1.5H3.75a.75.75 0 0 1-.75-.75Z" clip-rule="evenodd"/>
 							</svg>
 						</button>
-						<h1 class="min-w-0 truncate text-sm font-semibold tracking-tight">{ data.Title }</h1>
+						<h1 id="page-title" class="min-w-0 truncate text-sm font-semibold tracking-tight">{ data.Title }</h1>
 						<div class="flex-1"></div>
 						<div class="flex items-center gap-2">
 							@CommandPaletteTrigger()
@@ -101,7 +101,7 @@ templ Layout(data viewmodels.LayoutData) {
 							</button>
 						</div>
 					</header>
-					<main id="main" role="main" tabindex="-1" data-main-content data-busy-region class="flex-1 focus:outline-none">
+					<main id="main" hx-history-elt role="main" tabindex="-1" data-main-content data-busy-region class="flex-1 focus:outline-none">
 						<div class="w-full px-4 py-6 lg:px-10 lg:py-10 2xl:mx-auto 2xl:max-w-[clamp(72rem,94vw,120rem)]">
 							<section class="space-y-6">
 								{ children... }

--- a/internal/http/views/layout_templ.go
+++ b/internal/http/views/layout_templ.go
@@ -36,9 +36,9 @@ func Layout(data viewmodels.LayoutData) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var2 string
-		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.ResolveAttributeValue(`{"allowEval":false,"allowScriptTags":false,"defaultSwapStyle":"outerHTML","historyCacheSize":10,"historyRestoreAsHxRequest":false,"selfRequestsOnly":true,"globalViewTransitions":true}`)
+		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.ResolveAttributeValue(`{"allowEval":false,"allowScriptTags":false,"defaultSwapStyle":"outerHTML","historyCacheSize":10,"historyRestoreAsHxRequest":false,"selfRequestsOnly":true}`)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/layout.templ`, Line: 11, Col: 223}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `layout.templ`, Line: 11, Col: 194}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var2)
 		if templ_7745c5c3_Err != nil {
@@ -51,7 +51,7 @@ func Layout(data viewmodels.LayoutData) templ.Component {
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.ResolveAttributeValue(data.CSRFToken)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/layout.templ`, Line: 12, Col: 51}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `layout.templ`, Line: 12, Col: 51}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var3)
 		if templ_7745c5c3_Err != nil {
@@ -64,7 +64,7 @@ func Layout(data viewmodels.LayoutData) templ.Component {
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(data.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/layout.templ`, Line: 13, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `layout.templ`, Line: 13, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -73,7 +73,7 @@ func Layout(data viewmodels.LayoutData) templ.Component {
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(" · Open-SSPM")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/layout.templ`, Line: 13, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `layout.templ`, Line: 13, Col: 41}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
@@ -99,7 +99,7 @@ func Layout(data viewmodels.LayoutData) templ.Component {
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(data.UserEmail)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/layout.templ`, Line: 47, Col: 75}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `layout.templ`, Line: 47, Col: 75}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
@@ -133,14 +133,14 @@ func Layout(data viewmodels.LayoutData) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</nav></aside><div class=\"flex min-h-screen flex-col\"><header class=\"app-header sticky top-0 z-10 flex h-14 items-center gap-4 bg-background/80 px-4 backdrop-blur-xl lg:px-8\"><button id=\"sidebar-toggle\" type=\"button\" class=\"btn-icon-ghost\" aria-label=\"Open navigation\" aria-controls=\"app-sidebar\" aria-expanded=\"false\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\" fill=\"currentColor\" class=\"h-5 w-5\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M3 5.25A.75.75 0 0 1 3.75 4.5h12.5a.75.75 0 0 1 0 1.5H3.75A.75.75 0 0 1 3 5.25ZM3 10a.75.75 0 0 1 .75-.75h12.5a.75.75 0 0 1 0 1.5H3.75A.75.75 0 0 1 3 10Zm0 4.75a.75.75 0 0 1 .75-.75h12.5a.75.75 0 0 1 0 1.5H3.75a.75.75 0 0 1-.75-.75Z\" clip-rule=\"evenodd\"></path></svg></button><h1 class=\"min-w-0 truncate text-sm font-semibold tracking-tight\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</nav></aside><div class=\"flex min-h-screen flex-col\"><header class=\"app-header sticky top-0 z-10 flex h-14 items-center gap-4 bg-background/80 px-4 backdrop-blur-xl lg:px-8\"><button id=\"sidebar-toggle\" type=\"button\" class=\"btn-icon-ghost\" aria-label=\"Open navigation\" aria-controls=\"app-sidebar\" aria-expanded=\"false\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\" fill=\"currentColor\" class=\"h-5 w-5\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M3 5.25A.75.75 0 0 1 3.75 4.5h12.5a.75.75 0 0 1 0 1.5H3.75A.75.75 0 0 1 3 5.25ZM3 10a.75.75 0 0 1 .75-.75h12.5a.75.75 0 0 1 0 1.5H3.75A.75.75 0 0 1 3 10Zm0 4.75a.75.75 0 0 1 .75-.75h12.5a.75.75 0 0 1 0 1.5H3.75a.75.75 0 0 1-.75-.75Z\" clip-rule=\"evenodd\"></path></svg></button><h1 id=\"page-title\" class=\"min-w-0 truncate text-sm font-semibold tracking-tight\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var7 string
 		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(data.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/layout.templ`, Line: 77, Col: 84}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `layout.templ`, Line: 77, Col: 100}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {
@@ -154,7 +154,7 @@ func Layout(data viewmodels.LayoutData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<div class=\"mx-0.5 h-4 w-px bg-border/50\" role=\"separator\" aria-hidden=\"true\"></div><button type=\"button\" aria-label=\"Toggle dark mode\" data-tooltip=\"Toggle dark mode\" data-side=\"bottom\" data-align=\"end\" data-osspm-theme-toggle class=\"btn-icon-ghost size-8\"><span class=\"hidden dark:block\"><svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"12\" r=\"4\"></circle> <path d=\"M12 2v2\"></path> <path d=\"M12 20v2\"></path> <path d=\"m4.93 4.93 1.41 1.41\"></path> <path d=\"m17.66 17.66 1.41 1.41\"></path> <path d=\"M2 12h2\"></path> <path d=\"M20 12h2\"></path> <path d=\"m6.34 17.66-1.41 1.41\"></path> <path d=\"m19.07 4.93-1.41 1.41\"></path></svg></span> <span class=\"block dark:hidden\"><svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z\"></path></svg></span></button></div></header><main id=\"main\" role=\"main\" tabindex=\"-1\" data-main-content data-busy-region class=\"flex-1 focus:outline-none\"><div class=\"w-full px-4 py-6 lg:px-10 lg:py-10 2xl:mx-auto 2xl:max-w-[clamp(72rem,94vw,120rem)]\"><section class=\"space-y-6\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<div class=\"mx-0.5 h-4 w-px bg-border/50\" role=\"separator\" aria-hidden=\"true\"></div><button type=\"button\" aria-label=\"Toggle dark mode\" data-tooltip=\"Toggle dark mode\" data-side=\"bottom\" data-align=\"end\" data-osspm-theme-toggle class=\"btn-icon-ghost size-8\"><span class=\"hidden dark:block\"><svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"12\" r=\"4\"></circle> <path d=\"M12 2v2\"></path> <path d=\"M12 20v2\"></path> <path d=\"m4.93 4.93 1.41 1.41\"></path> <path d=\"m17.66 17.66 1.41 1.41\"></path> <path d=\"M2 12h2\"></path> <path d=\"M20 12h2\"></path> <path d=\"m6.34 17.66-1.41 1.41\"></path> <path d=\"m19.07 4.93-1.41 1.41\"></path></svg></span> <span class=\"block dark:hidden\"><svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z\"></path></svg></span></button></div></header><main id=\"main\" hx-history-elt role=\"main\" tabindex=\"-1\" data-main-content data-busy-region class=\"flex-1 focus:outline-none\"><div class=\"w-full px-4 py-6 lg:px-10 lg:py-10 2xl:mx-auto 2xl:max-w-[clamp(72rem,94vw,120rem)]\"><section class=\"space-y-6\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -186,7 +186,7 @@ func Layout(data viewmodels.LayoutData) templ.Component {
 			var templ_7745c5c3_Var8 string
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.ResolveAttributeValue(data.Toast.Category)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/layout.templ`, Line: 133, Col: 76}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `layout.templ`, Line: 133, Col: 76}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var8)
 			if templ_7745c5c3_Err != nil {
@@ -199,7 +199,7 @@ func Layout(data viewmodels.LayoutData) templ.Component {
 			var templ_7745c5c3_Var9 string
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.ResolveAttributeValue(data.Toast.Title)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/layout.templ`, Line: 133, Col: 108}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `layout.templ`, Line: 133, Col: 108}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var9)
 			if templ_7745c5c3_Err != nil {
@@ -212,7 +212,7 @@ func Layout(data viewmodels.LayoutData) templ.Component {
 			var templ_7745c5c3_Var10 string
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.ResolveAttributeValue(data.Toast.Description)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/layout.templ`, Line: 133, Col: 152}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `layout.templ`, Line: 133, Col: 152}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var10)
 			if templ_7745c5c3_Err != nil {

--- a/internal/http/views/sidebar.templ
+++ b/internal/http/views/sidebar.templ
@@ -4,17 +4,17 @@ import "strings"
 import "github.com/open-sspm/open-sspm/internal/http/viewmodels"
 
 templ Sidebar(data viewmodels.LayoutData) {
-	<div role="group">
+	<div role="group" data-sidebar-nav>
 		<h3>Explore</h3>
 		<ul>
 			<li>
-				<a href="/" aria-current={ AriaCurrent(data.ActivePath, "/") }>
+				<a href="/" data-active-match="exact" aria-current={ AriaCurrent(data.ActivePath, "/") }>
 					@IconHome("sidebar-icon")
 					<span>Posture</span>
 				</a>
 			</li>
 			<li>
-				<details open?={ strings.HasPrefix(data.ActivePath, "/discovery") || strings.HasPrefix(data.ActivePath, "/assigned-apps") || strings.HasPrefix(data.ActivePath, "/oauth-apps") }>
+				<details data-active-prefixes="/discovery /assigned-apps /oauth-apps" open?={ strings.HasPrefix(data.ActivePath, "/discovery") || strings.HasPrefix(data.ActivePath, "/assigned-apps") || strings.HasPrefix(data.ActivePath, "/oauth-apps") }>
 					<summary aria-current={ AriaCurrentAppsSurface(data.ActivePath) }>
 						@IconAppWindow("sidebar-icon")
 						<span>Apps &amp; Discovery</span>
@@ -39,7 +39,7 @@ templ Sidebar(data viewmodels.LayoutData) {
 				</a>
 			</li>
 			<li>
-				<details open?={ strings.HasPrefix(data.ActivePath, "/app-assets") || strings.HasPrefix(data.ActivePath, "/credentials") }>
+				<details data-active-prefixes="/app-assets /credentials" open?={ strings.HasPrefix(data.ActivePath, "/app-assets") || strings.HasPrefix(data.ActivePath, "/credentials") }>
 					<summary aria-current={ AriaCurrentInventorySurface(data.ActivePath) }>
 						@IconAppWindow("sidebar-icon")
 						<span>Inventory</span>
@@ -57,13 +57,13 @@ templ Sidebar(data viewmodels.LayoutData) {
 				</a>
 			</li>
 			<li>
-				<details open?={ strings.HasPrefix(data.ActivePath, "/findings") }>
+				<details data-active-prefixes="/findings" open?={ strings.HasPrefix(data.ActivePath, "/findings") }>
 					<summary aria-current={ AriaCurrent(data.ActivePath, "/findings") }>
 						@IconFileWarning("sidebar-icon")
 						<span>Findings</span>
 					</summary>
 						<ul id="sidebar-findings-rulesets">
-							<li><a href="/findings" aria-current={ AriaCurrentExact(data.ActivePath, "/findings") }><span>Overview</span></a></li>
+							<li><a href="/findings" data-active-match="exact" aria-current={ AriaCurrentExact(data.ActivePath, "/findings") }><span>Overview</span></a></li>
 							for _, ruleset := range data.FindingsRulesets {
 								<li><a href={ ruleset.Href } aria-current={ AriaCurrent(data.ActivePath, ruleset.Href) }><span class="truncate" title={ ruleset.Name }>{ ruleset.Name }</span></a></li>
 						}
@@ -72,13 +72,13 @@ templ Sidebar(data viewmodels.LayoutData) {
 			</li>
 			if data.IsAdmin {
 				<li>
-					<details open?={ strings.HasPrefix(data.ActivePath, "/settings") || strings.HasPrefix(data.ActivePath, "/identity-resolution") }>
+					<details data-active-prefixes="/settings /identity-resolution" open?={ strings.HasPrefix(data.ActivePath, "/settings") || strings.HasPrefix(data.ActivePath, "/identity-resolution") }>
 						<summary aria-current={ AriaCurrentBool(strings.HasPrefix(data.ActivePath, "/settings") || strings.HasPrefix(data.ActivePath, "/identity-resolution")) }>
 							@IconSettings("sidebar-icon")
 							<span>Settings</span>
 						</summary>
 						<ul>
-							<li><a href="/settings" aria-current={ AriaCurrentExact(data.ActivePath, "/settings") }><span>Overview</span></a></li>
+							<li><a href="/settings" data-active-match="exact" aria-current={ AriaCurrentExact(data.ActivePath, "/settings") }><span>Overview</span></a></li>
 							<li><a href="/identity-resolution" aria-current={ AriaCurrent(data.ActivePath, "/identity-resolution") }><span>Identity Resolution</span></a></li>
 							<li><a href="/settings/connectors" aria-current={ AriaCurrent(data.ActivePath, "/settings/connectors") }><span>Connectors</span></a></li>
 							<li><a href="/settings/connector-health" aria-current={ AriaCurrent(data.ActivePath, "/settings/connector-health") }><span>Connector health</span></a></li>
@@ -93,7 +93,7 @@ templ Sidebar(data viewmodels.LayoutData) {
 
 templ SidebarFindingsRulesetsOOB(data viewmodels.LayoutData) {
 	<ul id="sidebar-findings-rulesets" hx-swap-oob="morph:outerHTML">
-		<li><a href="/findings" aria-current={ AriaCurrentExact(data.ActivePath, "/findings") }><span>Overview</span></a></li>
+		<li><a href="/findings" data-active-match="exact" aria-current={ AriaCurrentExact(data.ActivePath, "/findings") }><span>Overview</span></a></li>
 		for _, ruleset := range data.FindingsRulesets {
 			<li><a href={ ruleset.Href } aria-current={ AriaCurrent(data.ActivePath, ruleset.Href) }><span class="truncate" title={ ruleset.Name }>{ ruleset.Name }</span></a></li>
 		}

--- a/internal/http/views/sidebar_templ.go
+++ b/internal/http/views/sidebar_templ.go
@@ -32,14 +32,14 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div role=\"group\"><h3>Explore</h3><ul><li><a href=\"/\" aria-current=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div role=\"group\" data-sidebar-nav><h3>Explore</h3><ul><li><a href=\"/\" data-active-match=\"exact\" aria-current=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrent(data.ActivePath, "/"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 11, Col: 64}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 11, Col: 90}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var2)
 		if templ_7745c5c3_Err != nil {
@@ -53,7 +53,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<span>Posture</span></a></li><li><details")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<span>Posture</span></a></li><li><details data-active-prefixes=\"/discovery /assigned-apps /oauth-apps\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -70,7 +70,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrentAppsSurface(data.ActivePath))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 18, Col: 68}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 18, Col: 68}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var3)
 		if templ_7745c5c3_Err != nil {
@@ -91,7 +91,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrent(data.ActivePath, "/discovery/apps"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 23, Col: 98}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 23, Col: 98}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var4)
 		if templ_7745c5c3_Err != nil {
@@ -104,7 +104,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrent(data.ActivePath, "/discovery/hotspots"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 24, Col: 106}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 24, Col: 106}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var5)
 		if templ_7745c5c3_Err != nil {
@@ -117,7 +117,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 		var templ_7745c5c3_Var6 string
 		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrent(data.ActivePath, "/assigned-apps"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 25, Col: 96}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 25, Col: 96}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var6)
 		if templ_7745c5c3_Err != nil {
@@ -130,7 +130,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 		var templ_7745c5c3_Var7 string
 		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrent(data.ActivePath, "/identities"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 30, Col: 84}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 30, Col: 84}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var7)
 		if templ_7745c5c3_Err != nil {
@@ -151,7 +151,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 		var templ_7745c5c3_Var8 string
 		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrent(data.ActivePath, "/non-human-identities"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 36, Col: 104}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 36, Col: 104}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var8)
 		if templ_7745c5c3_Err != nil {
@@ -165,7 +165,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<span>Non-Human Identities</span></a></li><li><details")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<span>Non-Human Identities</span></a></li><li><details data-active-prefixes=\"/app-assets /credentials\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -182,7 +182,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 		var templ_7745c5c3_Var9 string
 		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrentInventorySurface(data.ActivePath))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 43, Col: 73}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 43, Col: 73}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var9)
 		if templ_7745c5c3_Err != nil {
@@ -203,7 +203,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 		var templ_7745c5c3_Var10 string
 		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrent(data.ActivePath, "/app-assets"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 48, Col: 90}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 48, Col: 90}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var10)
 		if templ_7745c5c3_Err != nil {
@@ -216,7 +216,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 		var templ_7745c5c3_Var11 string
 		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrent(data.ActivePath, "/credentials"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 49, Col: 92}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 49, Col: 92}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var11)
 		if templ_7745c5c3_Err != nil {
@@ -229,7 +229,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 		var templ_7745c5c3_Var12 string
 		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrent(data.ActivePath, "/global-view"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 54, Col: 86}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 54, Col: 86}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var12)
 		if templ_7745c5c3_Err != nil {
@@ -243,7 +243,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<span>Sources</span></a></li><li><details")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<span>Sources</span></a></li><li><details data-active-prefixes=\"/findings\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -260,7 +260,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 		var templ_7745c5c3_Var13 string
 		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrent(data.ActivePath, "/findings"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 61, Col: 70}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 61, Col: 70}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var13)
 		if templ_7745c5c3_Err != nil {
@@ -274,14 +274,14 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<span>Findings</span></summary><ul id=\"sidebar-findings-rulesets\"><li><a href=\"/findings\" aria-current=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<span>Findings</span></summary><ul id=\"sidebar-findings-rulesets\"><li><a href=\"/findings\" data-active-match=\"exact\" aria-current=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var14 string
 		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrentExact(data.ActivePath, "/findings"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 66, Col: 92}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 66, Col: 118}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var14)
 		if templ_7745c5c3_Err != nil {
@@ -299,7 +299,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 			var templ_7745c5c3_Var15 templ.SafeURL
 			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinURLErrs(ruleset.Href)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 68, Col: 34}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 68, Col: 34}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 			if templ_7745c5c3_Err != nil {
@@ -312,7 +312,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 			var templ_7745c5c3_Var16 string
 			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrent(data.ActivePath, ruleset.Href))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 68, Col: 94}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 68, Col: 94}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var16)
 			if templ_7745c5c3_Err != nil {
@@ -325,7 +325,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 			var templ_7745c5c3_Var17 string
 			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.ResolveAttributeValue(ruleset.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 68, Col: 140}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 68, Col: 140}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var17)
 			if templ_7745c5c3_Err != nil {
@@ -338,7 +338,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 			var templ_7745c5c3_Var18 string
 			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(ruleset.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 68, Col: 157}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 68, Col: 157}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 			if templ_7745c5c3_Err != nil {
@@ -354,7 +354,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		if data.IsAdmin {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<li><details")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<li><details data-active-prefixes=\"/settings /identity-resolution\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -371,7 +371,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 			var templ_7745c5c3_Var19 string
 			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrentBool(strings.HasPrefix(data.ActivePath, "/settings") || strings.HasPrefix(data.ActivePath, "/identity-resolution")))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 76, Col: 156}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 76, Col: 156}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var19)
 			if templ_7745c5c3_Err != nil {
@@ -385,14 +385,14 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "<span>Settings</span></summary><ul><li><a href=\"/settings\" aria-current=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "<span>Settings</span></summary><ul><li><a href=\"/settings\" data-active-match=\"exact\" aria-current=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var20 string
 			templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrentExact(data.ActivePath, "/settings"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 81, Col: 92}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 81, Col: 118}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var20)
 			if templ_7745c5c3_Err != nil {
@@ -405,7 +405,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 			var templ_7745c5c3_Var21 string
 			templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrent(data.ActivePath, "/identity-resolution"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 82, Col: 109}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 82, Col: 109}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var21)
 			if templ_7745c5c3_Err != nil {
@@ -418,7 +418,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 			var templ_7745c5c3_Var22 string
 			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrent(data.ActivePath, "/settings/connectors"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 83, Col: 109}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 83, Col: 109}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var22)
 			if templ_7745c5c3_Err != nil {
@@ -431,7 +431,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 			var templ_7745c5c3_Var23 string
 			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrent(data.ActivePath, "/settings/connector-health"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 84, Col: 121}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 84, Col: 121}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var23)
 			if templ_7745c5c3_Err != nil {
@@ -444,7 +444,7 @@ func Sidebar(data viewmodels.LayoutData) templ.Component {
 			var templ_7745c5c3_Var24 string
 			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrent(data.ActivePath, "/settings/users"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 85, Col: 99}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 85, Col: 99}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var24)
 			if templ_7745c5c3_Err != nil {
@@ -484,14 +484,14 @@ func SidebarFindingsRulesetsOOB(data viewmodels.LayoutData) templ.Component {
 			templ_7745c5c3_Var25 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "<ul id=\"sidebar-findings-rulesets\" hx-swap-oob=\"morph:outerHTML\"><li><a href=\"/findings\" aria-current=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "<ul id=\"sidebar-findings-rulesets\" hx-swap-oob=\"morph:outerHTML\"><li><a href=\"/findings\" data-active-match=\"exact\" aria-current=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var26 string
 		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrentExact(data.ActivePath, "/findings"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 96, Col: 87}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 96, Col: 113}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var26)
 		if templ_7745c5c3_Err != nil {
@@ -509,7 +509,7 @@ func SidebarFindingsRulesetsOOB(data viewmodels.LayoutData) templ.Component {
 			var templ_7745c5c3_Var27 templ.SafeURL
 			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinURLErrs(ruleset.Href)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 98, Col: 29}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 98, Col: 29}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 			if templ_7745c5c3_Err != nil {
@@ -522,7 +522,7 @@ func SidebarFindingsRulesetsOOB(data viewmodels.LayoutData) templ.Component {
 			var templ_7745c5c3_Var28 string
 			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.ResolveAttributeValue(AriaCurrent(data.ActivePath, ruleset.Href))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 98, Col: 89}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 98, Col: 89}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var28)
 			if templ_7745c5c3_Err != nil {
@@ -535,7 +535,7 @@ func SidebarFindingsRulesetsOOB(data viewmodels.LayoutData) templ.Component {
 			var templ_7745c5c3_Var29 string
 			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.ResolveAttributeValue(ruleset.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 98, Col: 135}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 98, Col: 135}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var29)
 			if templ_7745c5c3_Err != nil {
@@ -548,7 +548,7 @@ func SidebarFindingsRulesetsOOB(data viewmodels.LayoutData) templ.Component {
 			var templ_7745c5c3_Var30 string
 			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(ruleset.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/views/sidebar.templ`, Line: 98, Col: 152}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `sidebar.templ`, Line: 98, Col: 152}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 			if templ_7745c5c3_Err != nil {

--- a/web/static/app.entry.js
+++ b/web/static/app.entry.js
@@ -1,4 +1,6 @@
 import "open-sspm-app/components/sidebar.js";
+import "open-sspm-app/components/sidebar_nav.js";
+import "open-sspm-app/components/page_title.js";
 import "open-sspm-app/components/popover.js";
 import "open-sspm-app/components/command.js";
 import "open-sspm-app/components/toast.js";

--- a/web/static/app/boost.js
+++ b/web/static/app/boost.js
@@ -28,6 +28,7 @@ const BOOST_SWAP = "outerHTML show:window:top";
 
 const HX_OWN_ATTRS = [
   "hx-target",
+  "hx-select",
   "hx-get",
   "hx-post",
   "hx-put",

--- a/web/static/app/boost.js
+++ b/web/static/app/boost.js
@@ -1,0 +1,90 @@
+/**
+ * Boost-link scope.
+ *
+ * The layout's <body> has hx-boost="true" so internal navigation becomes
+ * htmx-driven. We want plain navigation links to swap into #main only — never
+ * the whole body — so the sidebar element persists across page changes.
+ *
+ * Putting hx-target / hx-select / hx-swap on <body> would do that via
+ * inheritance, but htmx inherits those attributes into *every* descendant
+ * request, including filter forms and pagination whose fragment responses
+ * don't contain #main — that breaks them (an empty #main is selected and the
+ * fragment target is blanked).
+ *
+ * Instead we set the boost attributes on the link itself during the capture
+ * phase of the click, just before htmx's own click handler reads them.
+ * Anything htmx-driven that's not a plain navigation link (explicit hx-target,
+ * hx-get, hx-post, etc.) is left alone — it uses its own swap configuration.
+ *
+ * Form submissions are deliberately *not* decorated: a boosted form without
+ * hx-target falls back to htmx's body-swap default, which is what we want for
+ * full-page transitions like logout. Anything that needs fragment swapping
+ * already declares its own hx-target.
+ */
+
+const BOOST_TARGET = "#main";
+const BOOST_SELECT = "#main";
+const BOOST_SWAP = "outerHTML show:window:top";
+
+const HX_OWN_ATTRS = [
+  "hx-target",
+  "hx-get",
+  "hx-post",
+  "hx-put",
+  "hx-patch",
+  "hx-delete",
+];
+
+const isBoostEligible = (link, event) => {
+  if (!(link instanceof HTMLAnchorElement)) return false;
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return false;
+  if (typeof event.button === "number" && event.button !== 0) return false;
+  if (link.getAttribute("hx-boost") === "false") return false;
+  if (HX_OWN_ATTRS.some((attr) => link.hasAttribute(attr))) return false;
+
+  const linkTarget = link.getAttribute("target");
+  if (linkTarget && linkTarget !== "_self") return false;
+  if (link.hasAttribute("download")) return false;
+
+  const href = link.getAttribute("href") || "";
+  if (!href) return false;
+  if (
+    href.startsWith("#") ||
+    href.startsWith("mailto:") ||
+    href.startsWith("tel:") ||
+    href.startsWith("javascript:")
+  ) {
+    return false;
+  }
+
+  try {
+    const url = new URL(href, location.href);
+    if (url.origin !== location.origin) return false;
+  } catch (_) {
+    return false;
+  }
+
+  return true;
+};
+
+const decorateForBoost = (link) => {
+  link.setAttribute("hx-target", BOOST_TARGET);
+  link.setAttribute("hx-select", BOOST_SELECT);
+  link.setAttribute("hx-swap", BOOST_SWAP);
+};
+
+const handleClickCapture = (event) => {
+  if (event.defaultPrevented) return;
+  const target = event.target instanceof Element ? event.target : null;
+  const link = target?.closest("a[href]");
+  if (!link) return;
+  if (!isBoostEligible(link, event)) return;
+  decorateForBoost(link);
+};
+
+export const bindBoostScopeOnce = (root = document) => {
+  const html = root.documentElement || document.documentElement;
+  if (html.dataset.openSspmAppBoostBound === "true") return;
+  html.dataset.openSspmAppBoostBound = "true";
+  document.addEventListener("click", handleClickCapture, true);
+};

--- a/web/static/app/boost.js
+++ b/web/static/app/boost.js
@@ -48,17 +48,11 @@ const isBoostEligible = (link, event) => {
 
   const href = link.getAttribute("href") || "";
   if (!href) return false;
-  if (
-    href.startsWith("#") ||
-    href.startsWith("mailto:") ||
-    href.startsWith("tel:") ||
-    href.startsWith("javascript:")
-  ) {
-    return false;
-  }
+  if (href.startsWith("#")) return false;
 
   try {
     const url = new URL(href, location.href);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return false;
     if (url.origin !== location.origin) return false;
   } catch (_) {
     return false;

--- a/web/static/app/boost.test.js
+++ b/web/static/app/boost.test.js
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { bindBoostScopeOnce } from "open-sspm-app/boost.js";
+
+const fireClick = (target, opts = {}) => {
+  const event = new MouseEvent("click", {
+    bubbles: true,
+    cancelable: true,
+    button: 0,
+    ...opts,
+  });
+  target.dispatchEvent(event);
+  return event;
+};
+
+describe("boost link scope", () => {
+  beforeEach(() => {
+    document.documentElement.dataset.openSspmAppBoostBound = "";
+    document.body.innerHTML = "";
+    bindBoostScopeOnce();
+  });
+
+  afterEach(() => {
+    delete document.documentElement.dataset.openSspmAppBoostBound;
+  });
+
+  it("decorates a plain same-origin link with #main boost attributes", () => {
+    document.body.innerHTML = `<a id="link" href="/identities">Identities</a>`;
+    const link = document.getElementById("link");
+
+    fireClick(link);
+
+    expect(link.getAttribute("hx-target")).toBe("#main");
+    expect(link.getAttribute("hx-select")).toBe("#main");
+    expect(link.getAttribute("hx-swap")).toBe("outerHTML show:window:top");
+  });
+
+  it("does not decorate links that already have their own hx-target", () => {
+    document.body.innerHTML = `<a id="link" href="/x" hx-get="/x" hx-target="#panel">x</a>`;
+    const link = document.getElementById("link");
+
+    fireClick(link);
+
+    expect(link.getAttribute("hx-target")).toBe("#panel");
+    expect(link.getAttribute("hx-select")).toBe(null);
+    expect(link.getAttribute("hx-swap")).toBe(null);
+  });
+
+  it("does not decorate hash links, mailto links, or external links", () => {
+    document.body.innerHTML = `
+      <a id="hash" href="#section">hash</a>
+      <a id="mail" href="mailto:a@b.c">mail</a>
+      <a id="ext" href="https://other.example.com/foo">ext</a>
+    `;
+
+    fireClick(document.getElementById("hash"));
+    fireClick(document.getElementById("mail"));
+    fireClick(document.getElementById("ext"));
+
+    for (const id of ["hash", "mail", "ext"]) {
+      const link = document.getElementById(id);
+      expect(link.getAttribute("hx-target")).toBe(null);
+      expect(link.getAttribute("hx-select")).toBe(null);
+    }
+  });
+
+  it("does not decorate when the user holds a modifier key (open-in-new-tab semantics)", () => {
+    document.body.innerHTML = `<a id="link" href="/foo">foo</a>`;
+    const link = document.getElementById("link");
+
+    fireClick(link, { metaKey: true });
+
+    expect(link.getAttribute("hx-target")).toBe(null);
+  });
+
+  it("does not decorate links opted out via hx-boost=false", () => {
+    document.body.innerHTML = `<a id="link" href="/foo" hx-boost="false">foo</a>`;
+    const link = document.getElementById("link");
+
+    fireClick(link);
+
+    expect(link.getAttribute("hx-target")).toBe(null);
+  });
+
+  it("does not decorate links with target=_blank or download", () => {
+    document.body.innerHTML = `
+      <a id="blank" href="/foo" target="_blank">blank</a>
+      <a id="dl" href="/foo" download>dl</a>
+    `;
+
+    fireClick(document.getElementById("blank"));
+    fireClick(document.getElementById("dl"));
+
+    expect(document.getElementById("blank").getAttribute("hx-target")).toBe(null);
+    expect(document.getElementById("dl").getAttribute("hx-target")).toBe(null);
+  });
+
+  it("decorates links nested inside other elements via event delegation", () => {
+    document.body.innerHTML = `<div><span><a id="link" href="/nested">nested</a></span></div>`;
+    const inner = document.querySelector("span");
+
+    // Click bubbles up through inner, but our capture handler walks via closest()
+    fireClick(inner);
+    // No link clicked directly — verify nothing happens
+    expect(document.getElementById("link").getAttribute("hx-target")).toBe(null);
+
+    // Click the link itself, even if event.target is a descendant
+    fireClick(document.getElementById("link"));
+    expect(document.getElementById("link").getAttribute("hx-target")).toBe("#main");
+  });
+});

--- a/web/static/app/boost.test.js
+++ b/web/static/app/boost.test.js
@@ -46,6 +46,17 @@ describe("boost link scope", () => {
     expect(link.getAttribute("hx-swap")).toBe(null);
   });
 
+  it("does not decorate links that already have their own hx-select", () => {
+    document.body.innerHTML = `<a id="link" href="/x" hx-select="#panel">x</a>`;
+    const link = document.getElementById("link");
+
+    fireClick(link);
+
+    expect(link.getAttribute("hx-select")).toBe("#panel");
+    expect(link.getAttribute("hx-target")).toBe(null);
+    expect(link.getAttribute("hx-swap")).toBe(null);
+  });
+
   it("does not decorate hash links, non-http links, or external links", () => {
     document.body.innerHTML = `
       <a id="hash" href="#section">hash</a>

--- a/web/static/app/boost.test.js
+++ b/web/static/app/boost.test.js
@@ -46,18 +46,22 @@ describe("boost link scope", () => {
     expect(link.getAttribute("hx-swap")).toBe(null);
   });
 
-  it("does not decorate hash links, mailto links, or external links", () => {
+  it("does not decorate hash links, non-http links, or external links", () => {
     document.body.innerHTML = `
       <a id="hash" href="#section">hash</a>
       <a id="mail" href="mailto:a@b.c">mail</a>
+      <a id="data" href="data:text/html,hello">data</a>
+      <a id="vbscript" href="vbscript:msgbox(1)">vbscript</a>
       <a id="ext" href="https://other.example.com/foo">ext</a>
     `;
 
     fireClick(document.getElementById("hash"));
     fireClick(document.getElementById("mail"));
+    fireClick(document.getElementById("data"));
+    fireClick(document.getElementById("vbscript"));
     fireClick(document.getElementById("ext"));
 
-    for (const id of ["hash", "mail", "ext"]) {
+    for (const id of ["hash", "mail", "data", "vbscript", "ext"]) {
       const link = document.getElementById(id);
       expect(link.getAttribute("hx-target")).toBe(null);
       expect(link.getAttribute("hx-select")).toBe(null);

--- a/web/static/app/components/page_title.js
+++ b/web/static/app/components/page_title.js
@@ -1,0 +1,55 @@
+/**
+ * Page title sync component.
+ *
+ * The header h1 (#page-title) is layout chrome that displays the current page
+ * title. Since boosted navigations swap only #main and history restores cache
+ * only the swap target, the h1 must be kept in sync from document.title (which
+ * htmx maintains correctly for both boosted nav and history restore).
+ *
+ * The site title suffix (" · Open-SSPM") is stripped to recover the bare page
+ * title that the server originally rendered into data.Title.
+ */
+import { register } from "./registry.js";
+
+const SITE_SUFFIX = " · Open-SSPM";
+
+const derivePageTitle = (docTitle) => {
+  const trimmed = (docTitle || "").trim();
+  if (trimmed.endsWith(SITE_SUFFIX)) {
+    return trimmed.slice(0, -SITE_SUFFIX.length);
+  }
+  return trimmed;
+};
+
+const init = (el) => {
+  const doc = el.ownerDocument;
+  const view = doc.defaultView;
+  const viewTarget =
+    view &&
+    typeof view.addEventListener === "function" &&
+    typeof view.removeEventListener === "function"
+      ? view
+      : null;
+  const sync = () => {
+    const next = derivePageTitle(doc.title);
+    if (next && next !== el.textContent) el.textContent = next;
+  };
+
+  // Initial render is already correct (server-rendered from data.Title), but
+  // resync defensively in case the server-rendered values drift apart.
+  sync();
+
+  doc.addEventListener("htmx:afterSettle", sync);
+  viewTarget?.addEventListener("popstate", sync);
+
+  return () => {
+    if (typeof doc.removeEventListener === "function") {
+      doc.removeEventListener("htmx:afterSettle", sync);
+    }
+    if (typeof viewTarget?.removeEventListener === "function") {
+      viewTarget.removeEventListener("popstate", sync);
+    }
+  };
+};
+
+register("page-title", "#page-title:not([data-page-title-initialized])", init);

--- a/web/static/app/components/page_title.test.js
+++ b/web/static/app/components/page_title.test.js
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import "open-sspm-app/components/page_title.js";
+import { start, stop } from "open-sspm-app/components/registry.js";
+
+describe("page_title component", () => {
+  beforeEach(() => {
+    stop();
+    document.body.innerHTML = "";
+    document.title = "Posture · Open-SSPM";
+  });
+
+  it("syncs h1 text from document.title on htmx:afterSettle, stripping site suffix", () => {
+    document.body.innerHTML = `<h1 id="page-title">Posture</h1>`;
+    start();
+
+    document.title = "Identities · Open-SSPM";
+    document.dispatchEvent(new CustomEvent("htmx:afterSettle"));
+
+    expect(document.getElementById("page-title").textContent).toBe("Identities");
+  });
+
+  it("syncs h1 text on popstate (history back/forward)", () => {
+    document.body.innerHTML = `<h1 id="page-title">Identities</h1>`;
+    start();
+
+    document.title = "Non-Human Identities · Open-SSPM";
+    window.dispatchEvent(new PopStateEvent("popstate"));
+
+    expect(document.getElementById("page-title").textContent).toBe("Non-Human Identities");
+  });
+
+  it("leaves h1 untouched when document.title lacks the site suffix", () => {
+    document.body.innerHTML = `<h1 id="page-title">Apps</h1>`;
+    start();
+
+    document.title = "Standalone Title";
+    document.dispatchEvent(new CustomEvent("htmx:afterSettle"));
+
+    expect(document.getElementById("page-title").textContent).toBe("Standalone Title");
+  });
+});

--- a/web/static/app/components/page_title.test.js
+++ b/web/static/app/components/page_title.test.js
@@ -30,7 +30,7 @@ describe("page_title component", () => {
     expect(document.getElementById("page-title").textContent).toBe("Non-Human Identities");
   });
 
-  it("leaves h1 untouched when document.title lacks the site suffix", () => {
+  it("uses the full document.title as-is when the site suffix is absent", () => {
     document.body.innerHTML = `<h1 id="page-title">Apps</h1>`;
     start();
 

--- a/web/static/app/components/sidebar_nav.js
+++ b/web/static/app/components/sidebar_nav.js
@@ -1,0 +1,104 @@
+/**
+ * Sidebar nav active-state component.
+ *
+ * The sidebar is application chrome that persists across boosted navigations
+ * (the body's hx-target is #main). Active link/section state is therefore
+ * URL-derived on the client, not re-rendered by the server on each navigation.
+ *
+ * Reads declarative hints from the markup:
+ *   <a href="..." [data-active-match="exact"]>     → link is active when href
+ *                                                    matches location.pathname
+ *                                                    (prefix by default, mirrors
+ *                                                    server IsActivePath)
+ *   <details data-active-prefixes="/a /b">         → details auto-opens and its
+ *                                                    summary is marked active
+ *                                                    when any prefix matches
+ *
+ * Sections auto-open when the user navigates INTO them; user-driven open state
+ * is preserved otherwise (deliberate departure from the prior re-render-each-nav
+ * behavior, which made it impossible to keep a section expanded while browsing
+ * elsewhere).
+ */
+import { register } from "./registry.js";
+
+const trim = (s) => (s || "").trim();
+
+// Mirrors helpers.go IsActivePath: target "/" is exact-match-only; otherwise
+// HasPrefix. The Go side accepts naked prefix matches (e.g. /set would match
+// /settings), so we mirror that for byte-for-byte parity on the initial render.
+const isPrefixActive = (path, target) => {
+  const a = trim(path);
+  const t = trim(target);
+  if (t === "/") return a === "/";
+  return a.startsWith(t);
+};
+
+const isExactActive = (path, target) => trim(path) === trim(target);
+
+const splitPrefixes = (raw) => trim(raw).split(/\s+/).filter(Boolean);
+
+const setAriaCurrent = (el, active) => {
+  if (active) {
+    el.setAttribute("aria-current", "page");
+  } else {
+    el.removeAttribute("aria-current");
+  }
+};
+
+const applyActiveState = (root, path) => {
+  root.querySelectorAll("a[href]").forEach((link) => {
+    const href = link.getAttribute("href") || "";
+    const exact = link.dataset.activeMatch === "exact";
+    const active = exact ? isExactActive(path, href) : isPrefixActive(path, href);
+    setAriaCurrent(link, active);
+  });
+
+  root.querySelectorAll("details[data-active-prefixes]").forEach((details) => {
+    const prefixes = splitPrefixes(details.dataset.activePrefixes);
+    const active = prefixes.some((p) => isPrefixActive(path, p));
+
+    const summary = details.querySelector(":scope > summary");
+    if (summary) setAriaCurrent(summary, active);
+
+    if (active && !details.open) details.open = true;
+  });
+};
+
+const init = (el) => {
+  const doc = el.ownerDocument;
+  const view = doc.defaultView;
+  const viewTarget =
+    view &&
+    typeof view.addEventListener === "function" &&
+    typeof view.removeEventListener === "function"
+      ? view
+      : null;
+  const loc = view?.location || location;
+  let lastPath = loc.pathname;
+  const refresh = () => {
+    lastPath = loc.pathname;
+    applyActiveState(el, lastPath);
+  };
+
+  // Server already rendered correct initial state, but reapply defensively
+  // in case the markup was hydrated outside a fresh page load.
+  refresh();
+
+  const maybeRefresh = () => {
+    if (loc.pathname !== lastPath) refresh();
+  };
+
+  doc.addEventListener("htmx:afterSettle", maybeRefresh);
+  viewTarget?.addEventListener("popstate", maybeRefresh);
+
+  return () => {
+    if (typeof doc.removeEventListener === "function") {
+      doc.removeEventListener("htmx:afterSettle", maybeRefresh);
+    }
+    if (typeof viewTarget?.removeEventListener === "function") {
+      viewTarget.removeEventListener("popstate", maybeRefresh);
+    }
+  };
+};
+
+register("sidebar-nav", "[data-sidebar-nav]:not([data-sidebar-nav-initialized])", init);

--- a/web/static/app/components/sidebar_nav.test.js
+++ b/web/static/app/components/sidebar_nav.test.js
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import "open-sspm-app/components/sidebar_nav.js";
+import { start, stop } from "open-sspm-app/components/registry.js";
+
+const renderNav = (initialOpenSections = []) => {
+  const isOpen = (id) => (initialOpenSections.includes(id) ? "open" : "");
+  document.body.innerHTML = `
+    <div role="group" data-sidebar-nav>
+      <ul>
+        <li><a href="/" data-active-match="exact">Posture</a></li>
+        <li>
+          <details ${isOpen("apps")} data-active-prefixes="/discovery /assigned-apps">
+            <summary>Apps &amp; Discovery</summary>
+            <ul>
+              <li><a href="/discovery/apps">Apps</a></li>
+              <li><a href="/assigned-apps">Okta Assigned Apps</a></li>
+            </ul>
+          </details>
+        </li>
+        <li><a href="/identities">Identities</a></li>
+        <li>
+          <details ${isOpen("findings")} data-active-prefixes="/findings">
+            <summary>Findings</summary>
+            <ul>
+              <li><a href="/findings" data-active-match="exact">Overview</a></li>
+              <li><a href="/findings/leaked-creds">Leaked Creds</a></li>
+            </ul>
+          </details>
+        </li>
+      </ul>
+    </div>
+  `;
+};
+
+const navigate = (path) => {
+  history.pushState({}, "", path);
+  document.dispatchEvent(new CustomEvent("htmx:afterSettle"));
+};
+
+describe("sidebar_nav component", () => {
+  beforeEach(() => {
+    stop();
+    history.replaceState({}, "", "/");
+    document.body.innerHTML = "";
+  });
+
+  it("marks the exact home link active on /", () => {
+    history.replaceState({}, "", "/");
+    renderNav();
+    start();
+
+    const home = document.querySelector('a[href="/"]');
+    const identities = document.querySelector('a[href="/identities"]');
+    expect(home.getAttribute("aria-current")).toBe("page");
+    expect(identities.getAttribute("aria-current")).toBe(null);
+  });
+
+  it("marks prefix-matched links active and opens their containing details", () => {
+    history.replaceState({}, "", "/discovery/apps");
+    renderNav();
+    start();
+
+    const apps = document.querySelector('a[href="/discovery/apps"]');
+    const appsDetails = document.querySelector('details[data-active-prefixes^="/discovery"]');
+    const appsSummary = appsDetails.querySelector("summary");
+
+    expect(apps.getAttribute("aria-current")).toBe("page");
+    expect(appsSummary.getAttribute("aria-current")).toBe("page");
+    expect(appsDetails.open).toBe(true);
+  });
+
+  it("updates active state on htmx:afterSettle without re-rendering markup", () => {
+    history.replaceState({}, "", "/identities");
+    renderNav();
+    start();
+
+    expect(document.querySelector('a[href="/identities"]').getAttribute("aria-current")).toBe("page");
+    expect(document.querySelector('a[href="/discovery/apps"]').getAttribute("aria-current")).toBe(null);
+
+    navigate("/discovery/apps");
+
+    expect(document.querySelector('a[href="/identities"]').getAttribute("aria-current")).toBe(null);
+    expect(document.querySelector('a[href="/discovery/apps"]').getAttribute("aria-current")).toBe("page");
+  });
+
+  it("auto-opens a section when navigating into it but never auto-closes", () => {
+    history.replaceState({}, "", "/identities");
+    renderNav(["apps"]); // user has Apps & Discovery open even though they're elsewhere
+    start();
+
+    const apps = document.querySelector('details[data-active-prefixes^="/discovery"]');
+    const findings = document.querySelector('details[data-active-prefixes="/findings"]');
+    expect(apps.open).toBe(true);
+    expect(findings.open).toBe(false);
+
+    navigate("/findings/leaked-creds");
+
+    // findings auto-opens, apps stays open (user agency preserved)
+    expect(findings.open).toBe(true);
+    expect(apps.open).toBe(true);
+  });
+
+  it("treats exact-match links as exact even when their href is a prefix of the path", () => {
+    history.replaceState({}, "", "/findings/leaked-creds");
+    renderNav();
+    start();
+
+    const overview = document.querySelector('a[href="/findings"][data-active-match="exact"]');
+    const leaked = document.querySelector('a[href="/findings/leaked-creds"]');
+    expect(overview.getAttribute("aria-current")).toBe(null);
+    expect(leaked.getAttribute("aria-current")).toBe("page");
+  });
+});

--- a/web/static/app/main.js
+++ b/web/static/app/main.js
@@ -1,4 +1,5 @@
 import { bindGlobalListenersOnce } from "open-sspm-app/htmx.js";
+import { bindBoostScopeOnce } from "open-sspm-app/boost.js";
 import { openServerDialogs, wireDialogCloseNavigation } from "open-sspm-app/dialogs.js";
 import { initFragment } from "open-sspm-app/fragment.js";
 import { wireSidebarToggle } from "open-sspm-app/sidebar.js";
@@ -24,6 +25,7 @@ export const bootOpenSspmApp = () => {
   if (document.documentElement.dataset.openSspmAppBootstrapped === "true") return;
   document.documentElement.dataset.openSspmAppBootstrapped = "true";
 
+  bindBoostScopeOnce();
   bindGlobalListenersOnce({ initGlobal });
 
   if (document.readyState === "loading") {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes flickering after the htmx changes by scoping history snapshots to `#main` (via `hx-history-elt`), removing the conflicting `globalViewTransitions` flag, and introducing three client-side components to keep persistent layout chrome in sync across boosted navigations.

- **`boost.js`**: decorates plain same-origin navigation links with `hx-target`/`hx-select`/`hx-swap` at click-capture time, preventing the body-level `hx-boost` from swapping the whole page and breaking fragment responses.
- **`sidebar_nav.js`** + template `data-active-*` attributes: re-applies `aria-current` and auto-opens `<details>` sections based on `location.pathname` after each htmx settle or history pop, keeping the persistent sidebar in sync without a server round-trip.
- **`page_title.js`**: keeps the header `<h1 id=\"page-title\">` in sync with `document.title` (stripping the site suffix) after each settle or popstate.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The changes are well-scoped: layout adjustments are backward-compatible, all three new JS components are additive and tested, and the boost decorator is guarded against double-application and external links.

The core logic in boost.js, sidebar_nav.js, and page_title.js is correct and covered by tests. The only finding is a test-only listener leak in boost.test.js that does not affect production behavior or cause test failures in practice.

web/static/app/boost.test.js — afterEach listener cleanup is incomplete.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/static/app/boost.js | New module: decorates plain navigation links with hx-target/hx-select/hx-swap at click-capture time so the body-level hx-boost swaps only #main. Idempotency guard, HX_OWN_ATTRS exclusion list (including hx-select), and modifier-key/external-link guards all look correct. |
| web/static/app/boost.test.js | Tests cover the main eligibility rules and delegation correctly, but afterEach does not remove the document-level capture listener, causing listeners to accumulate across the test suite run. |
| web/static/app/components/sidebar_nav.js | New component: updates aria-current and details[open] state on htmx:afterSettle and popstate using declarative data-active-match/data-active-prefixes attributes. Prefix matching intentionally mirrors the Go server-side IsActivePath helper. |
| web/static/app/components/page_title.js | New component: keeps #page-title h1 in sync with document.title (stripping the site suffix) on htmx:afterSettle and popstate. Cleanup function removes listeners correctly. |
| internal/http/views/layout.templ | Removes globalViewTransitions (was conflicting with partial #main swaps), adds hx-history-elt to main to scope htmx history snapshots, and adds id="page-title" to the h1 for the client-side title sync component. |
| internal/http/views/sidebar.templ | Adds data-sidebar-nav, data-active-match="exact" on exact-match links, and data-active-prefixes on details elements to support the new client-side sidebar_nav.js component. |
| web/static/app/main.js | Calls bindBoostScopeOnce() during app boot, wiring the click-capture decorator before any user interaction. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant BoostJS as boost.js (capture)
    participant HTMX
    participant Server
    participant SidebarNav as sidebar_nav.js
    participant PageTitle as page_title.js

    User->>BoostJS: click on nav link
    BoostJS->>BoostJS: isBoostEligible(link)?
    BoostJS->>BoostJS: "decorateForBoost(link) hx-target=#main hx-select=#main hx-swap=outerHTML"
    BoostJS->>HTMX: event continues (link now has htmx attrs)
    HTMX->>Server: GET /page (hx-request)
    Server-->>HTMX: "HTML fragment with #main content + title"
    HTMX->>HTMX: "swap #main (outerHTML), update document.title"
    HTMX->>SidebarNav: htmx:afterSettle
    HTMX->>PageTitle: htmx:afterSettle
    SidebarNav->>SidebarNav: applyActiveState(root, location.pathname)
    PageTitle->>PageTitle: sync h1 from document.title
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/static/app/boost.test.js:660-668
**Event listener leaks across test runs**

`afterEach` deletes the idempotency flag (`openSspmAppBoostBound`) but never calls `document.removeEventListener` for the capture handler that was added during `beforeEach`. Each test cycle therefore adds an additional capture listener on `document`. After N tests, N listeners fire for each click event. Because `handleClickCapture` is idempotent (setting already-present attributes, or bailing early once `hx-target` is present), tests still pass — but the listeners silently accumulate for the entire test-suite run. Consider exporting an `unbind` helper from `boost.js` and calling it in `afterEach`, or returning a cleanup function from `bindBoostScopeOnce`.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Respect hx-select in boost links and ren..."](https://github.com/open-sspm/open-sspm/commit/3db0636c57aa137e91ae468e08d20dd43a28000f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33770674)</sub>

<!-- /greptile_comment -->