### PR TITLE
refactor: phase one finished

### DIFF
--- a/db/queries/findings.sql
+++ b/db/queries/findings.sql
@@ -340,3 +340,142 @@ LEFT JOIN findings f
 WHERE rs.key = sqlc.arg(key)::text
   AND r.is_active = true
 ORDER BY r.key;
+
+-- name: GetFindingRuleCurrentByRulesetKeyAndRuleKey :one
+WITH selected_sources AS (
+  SELECT
+    css.source_kind,
+    css.source_name
+  FROM connector_source_state css
+  WHERE css.configured
+    AND css.source_kind = sqlc.arg(source_kind)::text
+    AND (
+      sqlc.arg(source_name)::text = ''
+      OR css.source_name = sqlc.arg(source_name)::text
+    )
+),
+rule_current AS (
+  SELECT
+    r.id AS rule_id,
+    count(ss.source_name)::bigint AS source_count,
+    count(*) FILTER (WHERE COALESCE(NULLIF(f.output #>> '{rule_result,status}', ''), 'unknown') = 'fail')::bigint AS fail_count,
+    count(*) FILTER (WHERE COALESCE(NULLIF(f.output #>> '{rule_result,status}', ''), 'unknown') = 'error')::bigint AS error_count,
+    count(*) FILTER (WHERE COALESCE(NULLIF(f.output #>> '{rule_result,status}', ''), 'unknown') = 'unknown')::bigint AS unknown_count,
+    count(*) FILTER (WHERE COALESCE(NULLIF(f.output #>> '{rule_result,status}', ''), 'unknown') = 'not_applicable')::bigint AS not_applicable_count,
+    count(*) FILTER (WHERE COALESCE(NULLIF(f.output #>> '{rule_result,status}', ''), 'unknown') = 'pass')::bigint AS pass_count,
+    max(f.last_seen_at) AS current_evaluated_at,
+    max(COALESCE(NULLIF(f.output #>> '{rule_result,sync_run_id}', '')::bigint, 0))::bigint AS current_sync_run_id,
+    (array_remove(array_agg(NULLIF(f.summary, '') ORDER BY
+      CASE COALESCE(NULLIF(f.output #>> '{rule_result,status}', ''), 'unknown')
+        WHEN 'fail' THEN 1
+        WHEN 'error' THEN 2
+        WHEN 'unknown' THEN 3
+        WHEN 'not_applicable' THEN 4
+        WHEN 'pass' THEN 5
+        ELSE 6
+      END,
+      f.last_seen_at DESC NULLS LAST
+    ), NULL))[1]::text AS first_evidence_summary,
+    (array_remove(array_agg(NULLIF(f.output #>> '{rule_result,error_kind}', '') ORDER BY f.last_seen_at DESC NULLS LAST), NULL))[1]::text AS first_error_kind,
+    (jsonb_agg(f.output -> 'evidence' ORDER BY
+      CASE COALESCE(NULLIF(f.output #>> '{rule_result,status}', ''), 'unknown')
+        WHEN 'fail' THEN 1
+        WHEN 'error' THEN 2
+        WHEN 'unknown' THEN 3
+        WHEN 'not_applicable' THEN 4
+        WHEN 'pass' THEN 5
+        ELSE 6
+      END,
+      f.last_seen_at DESC NULLS LAST
+    ) FILTER (WHERE f.output ? 'evidence'))->0 AS first_evidence_json
+  FROM rules r
+  JOIN rulesets rs ON rs.id = r.ruleset_id
+  LEFT JOIN selected_sources ss ON TRUE
+  LEFT JOIN findings f
+    ON f.ruleset_id = rs.key
+    AND f.rule_id = r.key
+    AND f.scope_kind = sqlc.arg(scope_kind)::text
+    AND f.scope_source_kind = ss.source_kind
+    AND f.scope_source_name = ss.source_name
+  WHERE rs.key = sqlc.arg(ruleset_key)::text
+    AND r.key = sqlc.arg(rule_key)::text
+    AND r.is_active = true
+  GROUP BY r.id
+)
+SELECT
+  r.id,
+  r.ruleset_id,
+  r.key,
+  r.title,
+  r.summary,
+  r.category,
+  r.severity,
+  r.monitoring_status,
+  r.monitoring_reason,
+  r.required_data,
+  r.expected_params,
+  r.rule_version,
+  r.is_active,
+  r.definition_json,
+  r.created_at,
+  r.updated_at,
+  CASE
+    WHEN sqlc.arg(scope_kind)::text = 'connector_instance' THEN
+      CASE
+        WHEN COALESCE(rc.source_count, 0) = 0 THEN 'unknown'
+        WHEN COALESCE(rc.fail_count, 0) > 0 THEN 'fail'
+        WHEN COALESCE(rc.error_count, 0) > 0 THEN 'error'
+        WHEN COALESCE(rc.unknown_count, 0) > 0 THEN 'unknown'
+        WHEN COALESCE(rc.not_applicable_count, 0) = rc.source_count THEN 'not_applicable'
+        WHEN COALESCE(rc.pass_count, 0) = rc.source_count THEN 'pass'
+        ELSE 'unknown'
+      END
+    ELSE COALESCE(NULLIF(f.output #>> '{rule_result,status}', ''), 'unknown')
+  END::text AS current_status,
+  CASE
+    WHEN sqlc.arg(scope_kind)::text = 'connector_instance' THEN rc.current_evaluated_at
+    ELSE f.last_seen_at
+  END::timestamptz AS current_evaluated_at,
+  CASE
+    WHEN sqlc.arg(scope_kind)::text = 'connector_instance' THEN COALESCE(rc.current_sync_run_id, 0)
+    ELSE COALESCE(NULLIF(f.output #>> '{rule_result,sync_run_id}', '')::bigint, 0)
+  END::bigint AS current_sync_run_id,
+  CASE
+    WHEN sqlc.arg(scope_kind)::text = 'connector_instance' THEN
+      CASE
+        WHEN COALESCE(rc.source_count, 0) = 0 THEN ''
+        WHEN rc.source_count = 1 THEN COALESCE(rc.first_evidence_summary, '')
+        ELSE concat(
+          rc.fail_count, ' fail, ',
+          rc.error_count, ' error, ',
+          rc.unknown_count, ' unknown, ',
+          rc.not_applicable_count, ' not applicable, ',
+          rc.pass_count, ' pass'
+        )
+      END
+    ELSE COALESCE(f.summary, '')
+  END::text AS current_evidence_summary,
+  CASE
+    WHEN sqlc.arg(scope_kind)::text = 'connector_instance' THEN
+      CASE
+        WHEN COALESCE(rc.source_count, 0) = 1 THEN COALESCE(rc.first_evidence_json, '{}'::jsonb)
+        ELSE '{}'::jsonb
+      END
+    ELSE COALESCE(f.output -> 'evidence', '{}'::jsonb)
+  END::jsonb AS current_evidence_json,
+  CASE
+    WHEN sqlc.arg(scope_kind)::text = 'connector_instance' THEN COALESCE(rc.first_error_kind, '')
+    ELSE COALESCE(f.output #>> '{rule_result,error_kind}', '')
+  END::text AS current_error_kind
+FROM rules r
+JOIN rulesets rs ON rs.id = r.ruleset_id
+LEFT JOIN rule_current rc ON rc.rule_id = r.id
+LEFT JOIN findings f
+  ON f.ruleset_id = rs.key
+  AND f.rule_id = r.key
+  AND f.scope_kind = sqlc.arg(scope_kind)::text
+  AND f.scope_source_kind = sqlc.arg(source_kind)::text
+  AND f.scope_source_name = sqlc.arg(source_name)::text
+WHERE rs.key = sqlc.arg(ruleset_key)::text
+  AND r.key = sqlc.arg(rule_key)::text
+  AND r.is_active = true;

--- a/db/queries/rules_engine.sql
+++ b/db/queries/rules_engine.sql
@@ -153,7 +153,7 @@ WHERE rs.key = $1
   AND r.is_active = true
 ORDER BY r.key;
 
--- PHASE-TWO-DELETE: rule detail still reads rule_results_current until its finding readmodel is cut over in Phase Two.
+-- PHASE-TWO-DELETE: retained for legacy/parity consumers; findings rule detail reads canonical findings via findings.sql.
 -- name: GetRuleWithCurrentResultByRulesetKeyAndRuleKey :one
 SELECT
   r.*,

--- a/internal/connectors/aws/definition.go
+++ b/internal/connectors/aws/definition.go
@@ -53,26 +53,6 @@ func (d *Definition) SourceName(cfg any) string {
 	return c.Region
 }
 
-func (d *Definition) DefaultSubtitle() string {
-	return "Account assignments via permission sets."
-}
-
-func (d *Definition) ConfiguredSubtitle(cfg any) string {
-	c := cfg.(configstore.AWSIdentityCenterConfig)
-	name := c.Name
-	if name == "" {
-		name = c.Region
-	}
-	if name != "" {
-		return "Instance " + name
-	}
-	return d.DefaultSubtitle()
-}
-
-func (d *Definition) SettingsHref() string {
-	return "/settings/connectors?open=aws_identity_center"
-}
-
 func (d *Definition) MetricsProvider() registry.MetricsProvider {
 	return registry.NewUserSourceMetricsProvider("aws")
 }

--- a/internal/connectors/datadog/definition.go
+++ b/internal/connectors/datadog/definition.go
@@ -42,22 +42,6 @@ func (d *Definition) SourceName(cfg any) string {
 	return cfg.(configstore.DatadogConfig).Site
 }
 
-func (d *Definition) DefaultSubtitle() string {
-	return "Users and roles."
-}
-
-func (d *Definition) ConfiguredSubtitle(cfg any) string {
-	site := cfg.(configstore.DatadogConfig).Site
-	if site != "" {
-		return "Site " + site
-	}
-	return d.DefaultSubtitle()
-}
-
-func (d *Definition) SettingsHref() string {
-	return "/settings/connectors?open=datadog"
-}
-
 func (d *Definition) MetricsProvider() registry.MetricsProvider {
 	return registry.NewUserSourceMetricsProvider(configstore.KindDatadog)
 }

--- a/internal/connectors/entra/definition.go
+++ b/internal/connectors/entra/definition.go
@@ -36,22 +36,6 @@ func (d *Definition) SourceName(cfg any) string {
 	return cfg.(configstore.EntraConfig).TenantID
 }
 
-func (d *Definition) DefaultSubtitle() string {
-	return "Users and access via Microsoft Graph."
-}
-
-func (d *Definition) ConfiguredSubtitle(cfg any) string {
-	tenantID := cfg.(configstore.EntraConfig).TenantID
-	if tenantID != "" {
-		return "Tenant " + tenantID
-	}
-	return d.DefaultSubtitle()
-}
-
-func (d *Definition) SettingsHref() string {
-	return "/settings/connectors?open=entra"
-}
-
 func (d *Definition) MetricsProvider() registry.MetricsProvider {
 	return registry.NewUserSourceMetricsProvider(configstore.KindEntra)
 }

--- a/internal/connectors/github/definition.go
+++ b/internal/connectors/github/definition.go
@@ -42,22 +42,6 @@ func (d *Definition) SourceName(cfg any) string {
 	return cfg.(configstore.GitHubConfig).Org
 }
 
-func (d *Definition) DefaultSubtitle() string {
-	return "Organization members and permissions."
-}
-
-func (d *Definition) ConfiguredSubtitle(cfg any) string {
-	org := cfg.(configstore.GitHubConfig).Org
-	if org != "" {
-		return "Org " + org
-	}
-	return d.DefaultSubtitle()
-}
-
-func (d *Definition) SettingsHref() string {
-	return "/settings/connectors?open=github"
-}
-
 func (d *Definition) MetricsProvider() registry.MetricsProvider {
 	return registry.NewUserSourceMetricsProvider(configstore.KindGitHub)
 }

--- a/internal/connectors/googleworkspace/definition.go
+++ b/internal/connectors/googleworkspace/definition.go
@@ -46,25 +46,6 @@ func (d *Definition) SourceName(cfg any) string {
 	return cfg.(configstore.GoogleWorkspaceConfig).CustomerID
 }
 
-func (d *Definition) DefaultSubtitle() string {
-	return "Users, groups, OAuth grants, and token audits from Google Workspace."
-}
-
-func (d *Definition) ConfiguredSubtitle(cfg any) string {
-	googleCfg := cfg.(configstore.GoogleWorkspaceConfig)
-	if googleCfg.PrimaryDomain != "" {
-		return "Domain " + googleCfg.PrimaryDomain
-	}
-	if googleCfg.CustomerID != "" {
-		return "Customer " + googleCfg.CustomerID
-	}
-	return d.DefaultSubtitle()
-}
-
-func (d *Definition) SettingsHref() string {
-	return "/settings/connectors?open=google_workspace"
-}
-
 func (d *Definition) MetricsProvider() registry.MetricsProvider {
 	return registry.NewUserSourceMetricsProvider(configstore.KindGoogleWorkspace)
 }

--- a/internal/connectors/okta/definition.go
+++ b/internal/connectors/okta/definition.go
@@ -45,22 +45,6 @@ func (d *Definition) SourceName(cfg any) string {
 	return cfg.(configstore.OktaConfig).Domain
 }
 
-func (d *Definition) DefaultSubtitle() string {
-	return "Syncs Okta users and app assignments."
-}
-
-func (d *Definition) ConfiguredSubtitle(cfg any) string {
-	domain := cfg.(configstore.OktaConfig).Domain
-	if domain != "" {
-		return "Domain " + domain
-	}
-	return d.DefaultSubtitle()
-}
-
-func (d *Definition) SettingsHref() string {
-	return "/settings/connectors?open=okta"
-}
-
 func (d *Definition) MetricsProvider() registry.MetricsProvider {
 	return &oktaMetrics{}
 }

--- a/internal/connectors/okta/integration.go
+++ b/internal/connectors/okta/integration.go
@@ -157,7 +157,7 @@ func (i *OktaIntegration) runFull(ctx context.Context, q *gen.Queries, pool *pgx
 		return registry.FailSyncRun(ctx, q, runID, err, registry.SyncErrorKindDB)
 	}
 
-	if err := registry.FinalizeOktaRun(ctx, q, pool, runID, i.sourceName, time.Since(started), false); err != nil {
+	if err := finalizeOktaRecordSnapshots(ctx, q, pool, runID, i.sourceName, time.Since(started)); err != nil {
 		return registry.FailSyncRun(ctx, q, runID, err, registry.SyncErrorKindDB)
 	}
 

--- a/internal/connectors/okta/integration_records.go
+++ b/internal/connectors/okta/integration_records.go
@@ -65,6 +65,10 @@ func finalizeOktaRecordSnapshots(ctx context.Context, q *gen.Queries, pool *pgxp
 	qtx := q.WithTx(tx)
 	projector := recorddispatch.NewOktaStateProjector(qtx, runID)
 	emitter := recorddispatch.NewDispatcher(nil, projector)
+
+	// ResourceEntitlement finalizes Okta assignment tables and the canonical
+	// entitlements derived from them. Expiry queries only touch active rows, so
+	// a prior completion for this run is idempotent.
 	for _, resource := range []records.ResourceName{
 		records.ResourceIdentity,
 		records.ResourceGroup,

--- a/internal/connectors/okta/integration_records.go
+++ b/internal/connectors/okta/integration_records.go
@@ -9,10 +9,12 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/open-sspm/open-sspm/internal/connectors/capabilities"
 	"github.com/open-sspm/open-sspm/internal/connectors/registry"
 	"github.com/open-sspm/open-sspm/internal/db/gen"
 	"github.com/open-sspm/open-sspm/internal/discovery"
+	"github.com/open-sspm/open-sspm/internal/ingest/recorddispatch"
 	"github.com/open-sspm/open-sspm/internal/metrics"
 	"github.com/open-sspm/open-sspm/internal/records"
 )
@@ -44,6 +46,40 @@ func completeOktaSnapshot(ctx context.Context, emitter capabilities.RecordEmitte
 		FinishedAt:     time.Now().UTC(),
 		DedupeKeyValue: fmt.Sprintf("okta:%s:snapshot:%s:complete:%d", strings.TrimSpace(sourceName), resource, runID),
 	})
+}
+
+func finalizeOktaRecordSnapshots(ctx context.Context, q *gen.Queries, pool *pgxpool.Pool, runID int64, sourceName string, duration time.Duration) error {
+	if q == nil {
+		return fmt.Errorf("okta snapshot finalization requires queries")
+	}
+	if pool == nil {
+		return fmt.Errorf("okta snapshot finalization requires database pool")
+	}
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	qtx := q.WithTx(tx)
+	projector := recorddispatch.NewOktaStateProjector(qtx, runID)
+	emitter := recorddispatch.NewDispatcher(nil, projector)
+	for _, resource := range []records.ResourceName{
+		records.ResourceIdentity,
+		records.ResourceGroup,
+		records.ResourceApplication,
+		records.ResourceEntitlement,
+	} {
+		if err := completeOktaSnapshot(ctx, emitter, sourceName, resource, runID, true); err != nil {
+			return err
+		}
+	}
+
+	if err := registry.FinalizeRunCountsInTx(ctx, qtx, runID, projector.Counts(), duration, "okta", sourceName); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
 }
 
 func (i *OktaIntegration) syncOktaAccountsRecords(ctx context.Context, emitter capabilities.RecordEmitter, report func(registry.Event), runID int64, users []User) error {

--- a/internal/connectors/okta/integration_records_test.go
+++ b/internal/connectors/okta/integration_records_test.go
@@ -1,0 +1,174 @@
+package okta
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/open-sspm/open-sspm/internal/connectors/registry"
+	"github.com/open-sspm/open-sspm/internal/db/gen"
+	"github.com/open-sspm/open-sspm/internal/ingest/recorddispatch"
+	"github.com/open-sspm/open-sspm/internal/records"
+	"github.com/open-sspm/open-sspm/internal/testdb"
+)
+
+func TestFinalizeOktaRecordSnapshotsCompletesAndExpiresThroughProjector(t *testing.T) {
+	testdb.WithDatabase(t, testdb.Options{NamePrefix: "okta_record_finalize"}, func(ctx context.Context, pool *pgxpool.Pool, migrator *migrate.Migrate) {
+		testdb.MigrateUp(t, migrator)
+		q := gen.New(pool)
+		sourceName := "example.okta.com"
+		source := records.SourceRef{Kind: "okta", Name: sourceName}
+
+		runID1, err := registry.StartSyncRun(ctx, q, "okta", sourceName)
+		if err != nil {
+			t.Fatalf("StartSyncRun(run1) err = %v", err)
+		}
+		dispatcher1 := recorddispatch.NewDispatcher(nil, recorddispatch.NewOktaStateProjector(q, runID1))
+		for _, record := range []records.StateUpsert{
+			{
+				Source:         source,
+				Resource:       records.ResourceIdentity,
+				Key:            "00u-old",
+				DedupeKeyValue: "state:identity:00u-old",
+				Payload: records.IdentityPayload{
+					ExternalID:  "00u-old",
+					Email:       "old@example.com",
+					DisplayName: "Old User",
+					Status:      "ACTIVE",
+					ProviderAttrs: map[string]any{
+						"account_kind":    registry.AccountKindHuman,
+						"entity_category": registry.EntityCategoryUser,
+					},
+				},
+			},
+			groupStateRecord(sourceName, Group{ID: "00g-old", Name: "Old Group", Type: "OKTA_GROUP"}),
+			appStateRecord(sourceName, App{ID: "0oa-old", Label: "Old App", Status: "ACTIVE"}),
+			appUserAssignmentRecord(sourceName, App{ID: "0oa-old", Label: "Old App"}, AppAccountAssignment{AccountID: "00u-old", Scope: "USER"}),
+		} {
+			if err := dispatcher1.UpsertState(ctx, record); err != nil {
+				t.Fatalf("run1 UpsertState(%s/%s) err = %v", record.Resource, record.Key, err)
+			}
+		}
+		if err := finalizeOktaRecordSnapshots(ctx, q, pool, runID1, sourceName, time.Second); err != nil {
+			t.Fatalf("finalizeOktaRecordSnapshots(run1) err = %v", err)
+		}
+		assertRecordFinalizeCounts(t, ctx, pool, sourceName, 2, 1, 1, 1, 1)
+
+		runID2, err := registry.StartSyncRun(ctx, q, "okta", sourceName)
+		if err != nil {
+			t.Fatalf("StartSyncRun(run2) err = %v", err)
+		}
+		dispatcher2 := recorddispatch.NewDispatcher(nil, recorddispatch.NewOktaStateProjector(q, runID2))
+		if err := dispatcher2.UpsertState(ctx, records.StateUpsert{
+			Source:         source,
+			Resource:       records.ResourceIdentity,
+			Key:            "00u-new",
+			DedupeKeyValue: "state:identity:00u-new",
+			Payload: records.IdentityPayload{
+				ExternalID:  "00u-new",
+				Email:       "new@example.com",
+				DisplayName: "New User",
+				Status:      "ACTIVE",
+				ProviderAttrs: map[string]any{
+					"account_kind":    registry.AccountKindHuman,
+					"entity_category": registry.EntityCategoryUser,
+				},
+			},
+		}); err != nil {
+			t.Fatalf("run2 UpsertState(identity) err = %v", err)
+		}
+		if err := finalizeOktaRecordSnapshots(ctx, q, pool, runID2, sourceName, time.Second); err != nil {
+			t.Fatalf("finalizeOktaRecordSnapshots(run2) err = %v", err)
+		}
+		assertRecordFinalizeCounts(t, ctx, pool, sourceName, 1, 0, 0, 0, 0)
+
+		var status string
+		var stats []byte
+		if err := pool.QueryRow(ctx, `SELECT status, stats FROM sync_runs WHERE id = $1`, runID2).Scan(&status, &stats); err != nil {
+			t.Fatalf("query sync run err = %v", err)
+		}
+		if status != "success" {
+			t.Fatalf("sync run status = %q, want success", status)
+		}
+		var payload struct {
+			Counts map[string]int64 `json:"counts"`
+		}
+		if err := json.Unmarshal(stats, &payload); err != nil {
+			t.Fatalf("unmarshal sync run stats err = %v", err)
+		}
+		if payload.Counts["okta_accounts_observed"] != 1 || payload.Counts["okta_accounts_expired"] != 2 {
+			t.Fatalf("account counts = %+v, want observed=1 expired=2", payload.Counts)
+		}
+		if payload.Counts["okta_groups_expired"] != 1 || payload.Counts["okta_apps_expired"] != 1 || payload.Counts["okta_app_assignments_expired"] != 1 {
+			t.Fatalf("expiration counts = %+v, want group/app/assignment expiration through snapshot complete", payload.Counts)
+		}
+		if payload.Counts["entitlements_observed"] != 0 || payload.Counts["entitlements_expired"] != 1 {
+			t.Fatalf("entitlement counts = %+v, want observed=0 expired=1", payload.Counts)
+		}
+
+		if err := finalizeOktaRecordSnapshots(ctx, q, pool, runID2, sourceName, time.Second); err != nil {
+			t.Fatalf("finalizeOktaRecordSnapshots(run2 repeat) err = %v", err)
+		}
+		assertRecordFinalizeCounts(t, ctx, pool, sourceName, 1, 0, 0, 0, 0)
+	})
+}
+
+func assertRecordFinalizeCounts(t *testing.T, ctx context.Context, pool *pgxpool.Pool, sourceName string, accounts, groups, apps, assignments, entitlements int) {
+	t.Helper()
+	assertRecordFinalizeCount(t, ctx, pool, "active okta accounts", `
+		SELECT count(*)
+		FROM accounts
+		WHERE source_kind = 'okta'
+		  AND source_name = $1
+		  AND expired_at IS NULL
+		  AND last_observed_run_id IS NOT NULL
+	`, accounts, sourceName)
+	assertRecordFinalizeCount(t, ctx, pool, "active okta groups", `
+		SELECT count(*)
+		FROM okta_groups
+		WHERE source_kind = 'okta'
+		  AND source_name = $1
+		  AND expired_at IS NULL
+		  AND last_observed_run_id IS NOT NULL
+	`, groups, sourceName)
+	assertRecordFinalizeCount(t, ctx, pool, "active okta apps", `
+		SELECT count(*)
+		FROM okta_apps
+		WHERE source_kind = 'okta'
+		  AND source_name = $1
+		  AND expired_at IS NULL
+		  AND last_observed_run_id IS NOT NULL
+	`, apps, sourceName)
+	assertRecordFinalizeCount(t, ctx, pool, "active okta app assignments", `
+		SELECT count(*)
+		FROM okta_user_app_assignments ua
+		JOIN accounts a ON a.id = ua.okta_user_account_id
+		WHERE a.source_kind = 'okta'
+		  AND a.source_name = $1
+		  AND ua.expired_at IS NULL
+		  AND ua.last_observed_run_id IS NOT NULL
+	`, assignments, sourceName)
+	assertRecordFinalizeCount(t, ctx, pool, "active entitlements", `
+		SELECT count(*)
+		FROM entitlements e
+		JOIN accounts a ON a.id = e.app_user_id
+		WHERE a.source_kind = 'okta'
+		  AND a.source_name = $1
+		  AND e.expired_at IS NULL
+		  AND e.last_observed_run_id IS NOT NULL
+	`, entitlements, sourceName)
+}
+
+func assertRecordFinalizeCount(t *testing.T, ctx context.Context, pool *pgxpool.Pool, label, query string, want int, args ...any) {
+	t.Helper()
+	var got int
+	if err := pool.QueryRow(ctx, query, args...).Scan(&got); err != nil {
+		t.Fatalf("%s query err = %v", label, err)
+	}
+	if got != want {
+		t.Fatalf("%s count = %d, want %d", label, got, want)
+	}
+}

--- a/internal/connectors/okta/integration_records_test.go
+++ b/internal/connectors/okta/integration_records_test.go
@@ -93,9 +93,10 @@ func TestFinalizeOktaRecordSnapshotsCompletesAndExpiresThroughProjector(t *testi
 		if status != "success" {
 			t.Fatalf("sync run status = %q, want success", status)
 		}
-		var payload struct {
+		type statsPayload struct {
 			Counts map[string]int64 `json:"counts"`
 		}
+		var payload statsPayload
 		if err := json.Unmarshal(stats, &payload); err != nil {
 			t.Fatalf("unmarshal sync run stats err = %v", err)
 		}
@@ -113,6 +114,27 @@ func TestFinalizeOktaRecordSnapshotsCompletesAndExpiresThroughProjector(t *testi
 			t.Fatalf("finalizeOktaRecordSnapshots(run2 repeat) err = %v", err)
 		}
 		assertRecordFinalizeCounts(t, ctx, pool, sourceName, 1, 0, 0, 0, 0)
+		if err := pool.QueryRow(ctx, `SELECT status, stats FROM sync_runs WHERE id = $1`, runID2).Scan(&status, &stats); err != nil {
+			t.Fatalf("query repeated sync run err = %v", err)
+		}
+		if status != "success" {
+			t.Fatalf("repeated sync run status = %q, want success", status)
+		}
+		payload = statsPayload{}
+		if err := json.Unmarshal(stats, &payload); err != nil {
+			t.Fatalf("unmarshal repeated sync run stats err = %v", err)
+		}
+		for _, key := range []string{
+			"okta_accounts_expired",
+			"okta_groups_expired",
+			"okta_apps_expired",
+			"okta_app_assignments_expired",
+			"entitlements_expired",
+		} {
+			if payload.Counts[key] != 0 {
+				t.Fatalf("repeated finalization count %s = %d, want 0; counts = %+v", key, payload.Counts[key], payload.Counts)
+			}
+		}
 	})
 }
 

--- a/internal/connectors/registry/definition.go
+++ b/internal/connectors/registry/definition.go
@@ -13,11 +13,6 @@ type ConnectorDefinition interface {
 	IsConfigured(cfg any) bool
 	SourceName(cfg any) string // e.g., org name, domain
 
-	// UI Metadata
-	DefaultSubtitle() string
-	ConfiguredSubtitle(cfg any) string
-	SettingsHref() string
-
 	// Metrics (optional - returns nil if not applicable)
 	MetricsProvider() MetricsProvider
 

--- a/internal/connectors/registry/helpers.go
+++ b/internal/connectors/registry/helpers.go
@@ -139,6 +139,8 @@ func ReportAndFailSyncRun(ctx context.Context, q *gen.Queries, runID int64, repo
 	return FailSyncRun(ctx, q, runID, err, errorKind)
 }
 
+// PHASE-TWO-DELETE: retained for legacy direct finalization callers; Okta full
+// sync finalizes production state through records.SnapshotComplete.
 func FinalizeOktaRun(ctx context.Context, q *gen.Queries, pool *pgxpool.Pool, runID int64, sourceName string, duration time.Duration, finalizeDiscovery bool) error {
 	tx, err := pool.Begin(ctx)
 	if err != nil {
@@ -811,6 +813,10 @@ func finalizeRunCountsInTx(ctx context.Context, q *gen.Queries, runID int64, cou
 		"duration_ms": duration.Milliseconds(),
 	})
 	return finalizeSuccessfulRunInTx(ctx, q, runID, stats, sourceKind, sourceName)
+}
+
+func FinalizeRunCountsInTx(ctx context.Context, q *gen.Queries, runID int64, counts map[string]int64, duration time.Duration, sourceKind, sourceName string) error {
+	return finalizeRunCountsInTx(ctx, q, runID, counts, duration, sourceKind, sourceName)
 }
 
 func finalizeSuccessfulRunInTx(ctx context.Context, q *gen.Queries, runID int64, stats []byte, sourceKind, sourceName string) error {

--- a/internal/connectors/vault/definition.go
+++ b/internal/connectors/vault/definition.go
@@ -1,8 +1,6 @@
 package vault
 
 import (
-	"strings"
-
 	"github.com/open-sspm/open-sspm/internal/connectors/configstore"
 	"github.com/open-sspm/open-sspm/internal/connectors/registry"
 )
@@ -46,23 +44,6 @@ func (d *Definition) IsConfigured(cfg any) bool {
 
 func (d *Definition) SourceName(cfg any) string {
 	return cfg.(configstore.VaultConfig).SourceName()
-}
-
-func (d *Definition) DefaultSubtitle() string {
-	return "Identity entities, policies, mounts, and auth roles."
-}
-
-func (d *Definition) ConfiguredSubtitle(cfg any) string {
-	c := cfg.(configstore.VaultConfig).Normalized()
-	source := strings.TrimSpace(c.SourceName())
-	if source == "" {
-		return d.DefaultSubtitle()
-	}
-	return "Source " + source
-}
-
-func (d *Definition) SettingsHref() string {
-	return "/settings/connectors?open=vault"
 }
 
 func (d *Definition) MetricsProvider() registry.MetricsProvider {

--- a/internal/db/gen/findings.sql.go
+++ b/internal/db/gen/findings.sql.go
@@ -63,6 +63,215 @@ func (q *Queries) GetFindingByKey(ctx context.Context, findingKey string) (Findi
 	return i, err
 }
 
+const getFindingRuleCurrentByRulesetKeyAndRuleKey = `-- name: GetFindingRuleCurrentByRulesetKeyAndRuleKey :one
+WITH selected_sources AS (
+  SELECT
+    css.source_kind,
+    css.source_name
+  FROM connector_source_state css
+  WHERE css.configured
+    AND css.source_kind = $2::text
+    AND (
+      $3::text = ''
+      OR css.source_name = $3::text
+    )
+),
+rule_current AS (
+  SELECT
+    r.id AS rule_id,
+    count(ss.source_name)::bigint AS source_count,
+    count(*) FILTER (WHERE COALESCE(NULLIF(f.output #>> '{rule_result,status}', ''), 'unknown') = 'fail')::bigint AS fail_count,
+    count(*) FILTER (WHERE COALESCE(NULLIF(f.output #>> '{rule_result,status}', ''), 'unknown') = 'error')::bigint AS error_count,
+    count(*) FILTER (WHERE COALESCE(NULLIF(f.output #>> '{rule_result,status}', ''), 'unknown') = 'unknown')::bigint AS unknown_count,
+    count(*) FILTER (WHERE COALESCE(NULLIF(f.output #>> '{rule_result,status}', ''), 'unknown') = 'not_applicable')::bigint AS not_applicable_count,
+    count(*) FILTER (WHERE COALESCE(NULLIF(f.output #>> '{rule_result,status}', ''), 'unknown') = 'pass')::bigint AS pass_count,
+    max(f.last_seen_at) AS current_evaluated_at,
+    max(COALESCE(NULLIF(f.output #>> '{rule_result,sync_run_id}', '')::bigint, 0))::bigint AS current_sync_run_id,
+    (array_remove(array_agg(NULLIF(f.summary, '') ORDER BY
+      CASE COALESCE(NULLIF(f.output #>> '{rule_result,status}', ''), 'unknown')
+        WHEN 'fail' THEN 1
+        WHEN 'error' THEN 2
+        WHEN 'unknown' THEN 3
+        WHEN 'not_applicable' THEN 4
+        WHEN 'pass' THEN 5
+        ELSE 6
+      END,
+      f.last_seen_at DESC NULLS LAST
+    ), NULL))[1]::text AS first_evidence_summary,
+    (array_remove(array_agg(NULLIF(f.output #>> '{rule_result,error_kind}', '') ORDER BY f.last_seen_at DESC NULLS LAST), NULL))[1]::text AS first_error_kind,
+    (jsonb_agg(f.output -> 'evidence' ORDER BY
+      CASE COALESCE(NULLIF(f.output #>> '{rule_result,status}', ''), 'unknown')
+        WHEN 'fail' THEN 1
+        WHEN 'error' THEN 2
+        WHEN 'unknown' THEN 3
+        WHEN 'not_applicable' THEN 4
+        WHEN 'pass' THEN 5
+        ELSE 6
+      END,
+      f.last_seen_at DESC NULLS LAST
+    ) FILTER (WHERE f.output ? 'evidence'))->0 AS first_evidence_json
+  FROM rules r
+  JOIN rulesets rs ON rs.id = r.ruleset_id
+  LEFT JOIN selected_sources ss ON TRUE
+  LEFT JOIN findings f
+    ON f.ruleset_id = rs.key
+    AND f.rule_id = r.key
+    AND f.scope_kind = $1::text
+    AND f.scope_source_kind = ss.source_kind
+    AND f.scope_source_name = ss.source_name
+  WHERE rs.key = $4::text
+    AND r.key = $5::text
+    AND r.is_active = true
+  GROUP BY r.id
+)
+SELECT
+  r.id,
+  r.ruleset_id,
+  r.key,
+  r.title,
+  r.summary,
+  r.category,
+  r.severity,
+  r.monitoring_status,
+  r.monitoring_reason,
+  r.required_data,
+  r.expected_params,
+  r.rule_version,
+  r.is_active,
+  r.definition_json,
+  r.created_at,
+  r.updated_at,
+  CASE
+    WHEN $1::text = 'connector_instance' THEN
+      CASE
+        WHEN COALESCE(rc.source_count, 0) = 0 THEN 'unknown'
+        WHEN COALESCE(rc.fail_count, 0) > 0 THEN 'fail'
+        WHEN COALESCE(rc.error_count, 0) > 0 THEN 'error'
+        WHEN COALESCE(rc.unknown_count, 0) > 0 THEN 'unknown'
+        WHEN COALESCE(rc.not_applicable_count, 0) = rc.source_count THEN 'not_applicable'
+        WHEN COALESCE(rc.pass_count, 0) = rc.source_count THEN 'pass'
+        ELSE 'unknown'
+      END
+    ELSE COALESCE(NULLIF(f.output #>> '{rule_result,status}', ''), 'unknown')
+  END::text AS current_status,
+  CASE
+    WHEN $1::text = 'connector_instance' THEN rc.current_evaluated_at
+    ELSE f.last_seen_at
+  END::timestamptz AS current_evaluated_at,
+  CASE
+    WHEN $1::text = 'connector_instance' THEN COALESCE(rc.current_sync_run_id, 0)
+    ELSE COALESCE(NULLIF(f.output #>> '{rule_result,sync_run_id}', '')::bigint, 0)
+  END::bigint AS current_sync_run_id,
+  CASE
+    WHEN $1::text = 'connector_instance' THEN
+      CASE
+        WHEN COALESCE(rc.source_count, 0) = 0 THEN ''
+        WHEN rc.source_count = 1 THEN COALESCE(rc.first_evidence_summary, '')
+        ELSE concat(
+          rc.fail_count, ' fail, ',
+          rc.error_count, ' error, ',
+          rc.unknown_count, ' unknown, ',
+          rc.not_applicable_count, ' not applicable, ',
+          rc.pass_count, ' pass'
+        )
+      END
+    ELSE COALESCE(f.summary, '')
+  END::text AS current_evidence_summary,
+  CASE
+    WHEN $1::text = 'connector_instance' THEN
+      CASE
+        WHEN COALESCE(rc.source_count, 0) = 1 THEN COALESCE(rc.first_evidence_json, '{}'::jsonb)
+        ELSE '{}'::jsonb
+      END
+    ELSE COALESCE(f.output -> 'evidence', '{}'::jsonb)
+  END::jsonb AS current_evidence_json,
+  CASE
+    WHEN $1::text = 'connector_instance' THEN COALESCE(rc.first_error_kind, '')
+    ELSE COALESCE(f.output #>> '{rule_result,error_kind}', '')
+  END::text AS current_error_kind
+FROM rules r
+JOIN rulesets rs ON rs.id = r.ruleset_id
+LEFT JOIN rule_current rc ON rc.rule_id = r.id
+LEFT JOIN findings f
+  ON f.ruleset_id = rs.key
+  AND f.rule_id = r.key
+  AND f.scope_kind = $1::text
+  AND f.scope_source_kind = $2::text
+  AND f.scope_source_name = $3::text
+WHERE rs.key = $4::text
+  AND r.key = $5::text
+  AND r.is_active = true
+`
+
+type GetFindingRuleCurrentByRulesetKeyAndRuleKeyParams struct {
+	ScopeKind  string `json:"scope_kind"`
+	SourceKind string `json:"source_kind"`
+	SourceName string `json:"source_name"`
+	RulesetKey string `json:"ruleset_key"`
+	RuleKey    string `json:"rule_key"`
+}
+
+type GetFindingRuleCurrentByRulesetKeyAndRuleKeyRow struct {
+	ID                     int64              `json:"id"`
+	RulesetID              int64              `json:"ruleset_id"`
+	Key                    string             `json:"key"`
+	Title                  string             `json:"title"`
+	Summary                string             `json:"summary"`
+	Category               string             `json:"category"`
+	Severity               string             `json:"severity"`
+	MonitoringStatus       string             `json:"monitoring_status"`
+	MonitoringReason       string             `json:"monitoring_reason"`
+	RequiredData           []byte             `json:"required_data"`
+	ExpectedParams         []byte             `json:"expected_params"`
+	RuleVersion            string             `json:"rule_version"`
+	IsActive               bool               `json:"is_active"`
+	DefinitionJson         []byte             `json:"definition_json"`
+	CreatedAt              pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt              pgtype.Timestamptz `json:"updated_at"`
+	CurrentStatus          string             `json:"current_status"`
+	CurrentEvaluatedAt     pgtype.Timestamptz `json:"current_evaluated_at"`
+	CurrentSyncRunID       int64              `json:"current_sync_run_id"`
+	CurrentEvidenceSummary string             `json:"current_evidence_summary"`
+	CurrentEvidenceJson    []byte             `json:"current_evidence_json"`
+	CurrentErrorKind       string             `json:"current_error_kind"`
+}
+
+func (q *Queries) GetFindingRuleCurrentByRulesetKeyAndRuleKey(ctx context.Context, arg GetFindingRuleCurrentByRulesetKeyAndRuleKeyParams) (GetFindingRuleCurrentByRulesetKeyAndRuleKeyRow, error) {
+	row := q.db.QueryRow(ctx, getFindingRuleCurrentByRulesetKeyAndRuleKey,
+		arg.ScopeKind,
+		arg.SourceKind,
+		arg.SourceName,
+		arg.RulesetKey,
+		arg.RuleKey,
+	)
+	var i GetFindingRuleCurrentByRulesetKeyAndRuleKeyRow
+	err := row.Scan(
+		&i.ID,
+		&i.RulesetID,
+		&i.Key,
+		&i.Title,
+		&i.Summary,
+		&i.Category,
+		&i.Severity,
+		&i.MonitoringStatus,
+		&i.MonitoringReason,
+		&i.RequiredData,
+		&i.ExpectedParams,
+		&i.RuleVersion,
+		&i.IsActive,
+		&i.DefinitionJson,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.CurrentStatus,
+		&i.CurrentEvaluatedAt,
+		&i.CurrentSyncRunID,
+		&i.CurrentEvidenceSummary,
+		&i.CurrentEvidenceJson,
+		&i.CurrentErrorKind,
+	)
+	return i, err
+}
+
 const insertFindingEvent = `-- name: InsertFindingEvent :exec
 INSERT INTO finding_events (
   finding_key,

--- a/internal/db/gen/rules_engine.sql.go
+++ b/internal/db/gen/rules_engine.sql.go
@@ -169,7 +169,7 @@ type GetRuleWithCurrentResultByRulesetKeyAndRuleKeyRow struct {
 	CurrentErrorKind       string             `json:"current_error_kind"`
 }
 
-// PHASE-TWO-DELETE: rule detail still reads rule_results_current until its finding readmodel is cut over in Phase Two.
+// PHASE-TWO-DELETE: retained for legacy/parity consumers; findings rule detail reads canonical findings via findings.sql.
 func (q *Queries) GetRuleWithCurrentResultByRulesetKeyAndRuleKey(ctx context.Context, arg GetRuleWithCurrentResultByRulesetKeyAndRuleKeyParams) (GetRuleWithCurrentResultByRulesetKeyAndRuleKeyRow, error) {
 	row := q.db.QueryRow(ctx, getRuleWithCurrentResultByRulesetKeyAndRuleKey,
 		arg.Key,

--- a/internal/http/connectorui/state.go
+++ b/internal/http/connectorui/state.go
@@ -213,7 +213,7 @@ func defaultSubtitle(kind string) string {
 	case configstore.KindVault:
 		return "Identity entities, policies, mounts, and auth roles."
 	default:
-		return "Configure connector."
+		return ""
 	}
 }
 

--- a/internal/http/connectorui/state.go
+++ b/internal/http/connectorui/state.go
@@ -2,8 +2,10 @@ package connectorui
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
+	"github.com/open-sspm/open-sspm/internal/connectors/configstore"
 	"github.com/open-sspm/open-sspm/internal/connectors/registry"
 	"github.com/open-sspm/open-sspm/internal/http/viewmodels"
 	"github.com/open-sspm/open-sspm/internal/http/views"
@@ -18,10 +20,7 @@ func NewStatePresenter(state registry.ConnectorState) StatePresenter {
 }
 
 func (p StatePresenter) Subtitle() string {
-	if p.state.Configured {
-		return p.state.Definition.ConfiguredSubtitle(p.state.Config)
-	}
-	return p.state.Definition.DefaultSubtitle()
+	return connectorSubtitle(p.kind(), p.state.Config, p.state.Configured)
 }
 
 func (p StatePresenter) StatusClass() string {
@@ -46,7 +45,7 @@ func (p StatePresenter) MetricsKV() []viewmodels.GlobalViewKV {
 		}
 	}
 
-	if p.state.Definition.Role() == registry.RoleIdP {
+	if p.role() == registry.RoleIdP {
 		return []viewmodels.GlobalViewKV{
 			{Label: "Users", Value: views.FormatInt64(p.state.Metrics.Total)},
 			{Label: "Apps", Value: views.FormatInt64(p.state.Metrics.Extras["apps"])},
@@ -69,7 +68,7 @@ func (p StatePresenter) HighlightsKV() []viewmodels.GlobalViewKV {
 		}
 	}
 
-	if p.state.Definition.Role() == registry.RoleIdP {
+	if p.role() == registry.RoleIdP {
 		domain := strings.TrimSpace(p.state.SourceName)
 		if domain == "" {
 			domain = "—"
@@ -90,11 +89,11 @@ func (p StatePresenter) HighlightsKV() []viewmodels.GlobalViewKV {
 
 func (p StatePresenter) PrimaryHref() string {
 	if p.state.Configured && p.state.Enabled {
-		if href := connectorBrowseUsersHref(p.state.Definition.Kind()); href != "" {
+		if href := connectorBrowseUsersHref(p.kind()); href != "" {
 			return href
 		}
 	}
-	return p.state.Definition.SettingsHref()
+	return SettingsHrefForKind(p.kind())
 }
 
 func (p StatePresenter) PrimaryLabel() string {
@@ -106,16 +105,116 @@ func (p StatePresenter) PrimaryLabel() string {
 
 func (p StatePresenter) SecondaryHref() string {
 	if p.state.Configured && p.state.Enabled {
-		return connectorNeedsAnchorHref(p.state.Definition.Kind(), p.state.SourceName)
+		return connectorNeedsAnchorHref(p.kind(), p.state.SourceName)
 	}
 	return ""
 }
 
 func (p StatePresenter) SecondaryLabel() string {
 	if p.state.Configured && p.state.Enabled {
-		return connectorSecondaryLabel(p.state.Definition.Kind())
+		return connectorSecondaryLabel(p.kind())
 	}
 	return ""
+}
+
+func (p StatePresenter) kind() string {
+	if p.state.Definition == nil {
+		return ""
+	}
+	return strings.TrimSpace(p.state.Definition.Kind())
+}
+
+func (p StatePresenter) role() registry.IntegrationRole {
+	if p.state.Definition == nil {
+		return ""
+	}
+	return p.state.Definition.Role()
+}
+
+func SettingsHrefForKind(kind string) string {
+	kind = strings.TrimSpace(kind)
+	if kind == "" {
+		return "/settings/connectors"
+	}
+	return "/settings/connectors?open=" + url.QueryEscape(kind)
+}
+
+func connectorSubtitle(kind string, cfg any, configured bool) string {
+	if configured {
+		if subtitle := configuredSubtitle(kind, cfg); subtitle != "" {
+			return subtitle
+		}
+	}
+	return defaultSubtitle(kind)
+}
+
+func configuredSubtitle(kind string, cfg any) string {
+	switch strings.TrimSpace(kind) {
+	case configstore.KindOkta:
+		if c, ok := cfg.(configstore.OktaConfig); ok && strings.TrimSpace(c.Domain) != "" {
+			return "Domain " + strings.TrimSpace(c.Domain)
+		}
+	case configstore.KindGoogleWorkspace:
+		if c, ok := cfg.(configstore.GoogleWorkspaceConfig); ok {
+			if strings.TrimSpace(c.PrimaryDomain) != "" {
+				return "Domain " + strings.TrimSpace(c.PrimaryDomain)
+			}
+			if strings.TrimSpace(c.CustomerID) != "" {
+				return "Customer " + strings.TrimSpace(c.CustomerID)
+			}
+		}
+	case configstore.KindEntra:
+		if c, ok := cfg.(configstore.EntraConfig); ok && strings.TrimSpace(c.TenantID) != "" {
+			return "Tenant " + strings.TrimSpace(c.TenantID)
+		}
+	case configstore.KindGitHub:
+		if c, ok := cfg.(configstore.GitHubConfig); ok && strings.TrimSpace(c.Org) != "" {
+			return "Org " + strings.TrimSpace(c.Org)
+		}
+	case configstore.KindDatadog:
+		if c, ok := cfg.(configstore.DatadogConfig); ok && strings.TrimSpace(c.Site) != "" {
+			return "Site " + strings.TrimSpace(c.Site)
+		}
+	case configstore.KindAWSIdentityCenter:
+		if c, ok := cfg.(configstore.AWSIdentityCenterConfig); ok {
+			name := strings.TrimSpace(c.Name)
+			if name == "" {
+				name = strings.TrimSpace(c.Region)
+			}
+			if name != "" {
+				return "Instance " + name
+			}
+		}
+	case configstore.KindVault:
+		if c, ok := cfg.(configstore.VaultConfig); ok {
+			source := strings.TrimSpace(c.Normalized().SourceName())
+			if source != "" {
+				return "Source " + source
+			}
+		}
+	}
+	return ""
+}
+
+func defaultSubtitle(kind string) string {
+	switch strings.TrimSpace(kind) {
+	case configstore.KindOkta:
+		return "Syncs Okta users and app assignments."
+	case configstore.KindGoogleWorkspace:
+		return "Users, groups, OAuth grants, and token audits from Google Workspace."
+	case configstore.KindEntra:
+		return "Users and access via Microsoft Graph."
+	case configstore.KindGitHub:
+		return "Organization members and permissions."
+	case configstore.KindDatadog:
+		return "Users and roles."
+	case configstore.KindAWSIdentityCenter:
+		return "Account assignments via permission sets."
+	case configstore.KindVault:
+		return "Identity entities, policies, mounts, and auth roles."
+	default:
+		return "Configure connector."
+	}
 }
 
 func connectorBrowseUsersHref(kind string) string {

--- a/internal/http/connectorui/state_test.go
+++ b/internal/http/connectorui/state_test.go
@@ -3,6 +3,7 @@ package connectorui
 import (
 	"testing"
 
+	"github.com/open-sspm/open-sspm/internal/connectors/configstore"
 	"github.com/open-sspm/open-sspm/internal/connectors/registry"
 )
 
@@ -18,9 +19,6 @@ func (d testDefinition) DecodeConfig([]byte) (any, error)                 { retu
 func (d testDefinition) ValidateConfig(any) error                         { return nil }
 func (d testDefinition) IsConfigured(any) bool                            { return false }
 func (d testDefinition) SourceName(any) string                            { return "" }
-func (d testDefinition) DefaultSubtitle() string                          { return "default subtitle" }
-func (d testDefinition) ConfiguredSubtitle(any) string                    { return "configured subtitle" }
-func (d testDefinition) SettingsHref() string                             { return "/settings/connectors/" + d.kind + "/dialog" }
 func (d testDefinition) MetricsProvider() registry.MetricsProvider        { return nil }
 func (d testDefinition) NewIntegration(any) (registry.Integration, error) { return nil, nil }
 
@@ -29,6 +27,7 @@ func TestStatePresenterActionsForConfiguredOkta(t *testing.T) {
 		Definition: testDefinition{kind: "okta", role: registry.RoleIdP},
 		Configured: true,
 		Enabled:    true,
+		Config:     configstore.OktaConfig{Domain: "example.okta.com"},
 		SourceName: "example.okta.com",
 		Metrics: &registry.ConnectorMetrics{
 			Total: 42,
@@ -47,13 +46,26 @@ func TestStatePresenterActionsForConfiguredOkta(t *testing.T) {
 	if got := p.SecondaryLabel(); got != "Browse apps" {
 		t.Fatalf("SecondaryLabel() = %q, want Browse apps", got)
 	}
-	if got := p.Subtitle(); got != "configured subtitle" {
-		t.Fatalf("Subtitle() = %q, want configured subtitle", got)
+	if got := p.Subtitle(); got != "Domain example.okta.com" {
+		t.Fatalf("Subtitle() = %q, want Domain example.okta.com", got)
 	}
 
 	metrics := p.MetricsKV()
 	if len(metrics) != 3 || metrics[0].Label != "Users" || metrics[0].Value != "42" || metrics[1].Label != "Apps" || metrics[1].Value != "7" {
 		t.Fatalf("MetricsKV() = %+v", metrics)
+	}
+}
+
+func TestStatePresenterSettingsHrefForUnconfiguredConnector(t *testing.T) {
+	p := NewStatePresenter(registry.ConnectorState{
+		Definition: testDefinition{kind: "google_workspace", role: registry.RoleApp},
+	})
+
+	if got := p.PrimaryHref(); got != "/settings/connectors?open=google_workspace" {
+		t.Fatalf("PrimaryHref() = %q, want settings connector href", got)
+	}
+	if got := p.Subtitle(); got != "Users, groups, OAuth grants, and token audits from Google Workspace." {
+		t.Fatalf("Subtitle() = %q, want Google Workspace default subtitle", got)
 	}
 }
 

--- a/internal/http/handlers/command_integration_test.go
+++ b/internal/http/handlers/command_integration_test.go
@@ -41,9 +41,6 @@ func (d commandSearchTestDefinition) Kind() string                       { retur
 func (d commandSearchTestDefinition) DisplayName() string                { return d.displayName }
 func (d commandSearchTestDefinition) Role() connregistry.IntegrationRole { return d.role }
 func (d commandSearchTestDefinition) ValidateConfig(any) error           { return nil }
-func (d commandSearchTestDefinition) DefaultSubtitle() string            { return "" }
-func (d commandSearchTestDefinition) ConfiguredSubtitle(any) string      { return "" }
-func (d commandSearchTestDefinition) SettingsHref() string               { return "/settings/connectors" }
 func (d commandSearchTestDefinition) MetricsProvider() connregistry.MetricsProvider {
 	return nil
 }

--- a/internal/http/handlers/connector_state_view_test.go
+++ b/internal/http/handlers/connector_state_view_test.go
@@ -54,12 +54,6 @@ func (d testConnectorDefinition) IsConfigured(any) bool { return false }
 
 func (d testConnectorDefinition) SourceName(any) string { return "" }
 
-func (d testConnectorDefinition) DefaultSubtitle() string { return "" }
-
-func (d testConnectorDefinition) ConfiguredSubtitle(any) string { return "" }
-
-func (d testConnectorDefinition) SettingsHref() string { return "" }
-
 func (d testConnectorDefinition) MetricsProvider() registry.MetricsProvider { return nil }
 
 func (d testConnectorDefinition) NewIntegration(any) (registry.Integration, error) { return nil, nil }

--- a/internal/http/handlers/findings.go
+++ b/internal/http/handlers/findings.go
@@ -16,6 +16,7 @@ import (
 	"github.com/labstack/echo/v5"
 	osspecv2 "github.com/open-sspm/open-sspm-spec/gen/go/opensspm/spec/v2"
 	"github.com/open-sspm/open-sspm/internal/db/gen"
+	"github.com/open-sspm/open-sspm/internal/http/connectorui"
 	"github.com/open-sspm/open-sspm/internal/http/events"
 	"github.com/open-sspm/open-sspm/internal/http/viewmodels"
 	"github.com/open-sspm/open-sspm/internal/http/views"
@@ -262,7 +263,7 @@ func (h *Handlers) findingsScopeForRulesetMode(ctx context.Context, rs gen.Rules
 			return findingsScope{ScopeKind: "connector_instance"}, nil
 		}
 
-		hintHref := ""
+		hintHref := connectorui.SettingsHrefForKind(connectorKind)
 		sourceName := ""
 
 		if h.Registry != nil {
@@ -272,7 +273,6 @@ func (h *Handlers) findingsScopeForRulesetMode(ctx context.Context, rs gen.Rules
 			}
 			for _, st := range states {
 				if strings.EqualFold(strings.TrimSpace(st.Definition.Kind()), connectorKind) {
-					hintHref = strings.TrimSpace(st.Definition.SettingsHref())
 					if concreteSource {
 						sourceName = strings.TrimSpace(st.SourceName)
 					}
@@ -401,9 +401,9 @@ func (h *Handlers) HandleFindingsRule(c *echo.Context) error {
 		return h.RenderError(c, err)
 	}
 
-	r, err := h.Q.GetRuleWithCurrentResultByRulesetKeyAndRuleKey(ctx, gen.GetRuleWithCurrentResultByRulesetKeyAndRuleKeyParams{
-		Key:        rulesetKey,
-		Key_2:      ruleKey,
+	r, err := h.Q.GetFindingRuleCurrentByRulesetKeyAndRuleKey(ctx, gen.GetFindingRuleCurrentByRulesetKeyAndRuleKeyParams{
+		RulesetKey: rulesetKey,
+		RuleKey:    ruleKey,
 		ScopeKind:  scope.ScopeKind,
 		SourceKind: scope.SourceKind,
 		SourceName: scope.SourceName,
@@ -430,9 +430,9 @@ func (h *Handlers) renderFindingsRuleMutationResponse(c *echo.Context, rs gen.Ru
 		return RenderNotFound(c)
 	}
 
-	r, err := h.Q.GetRuleWithCurrentResultByRulesetKeyAndRuleKey(ctx, gen.GetRuleWithCurrentResultByRulesetKeyAndRuleKeyParams{
-		Key:        rulesetKey,
-		Key_2:      ruleKey,
+	r, err := h.Q.GetFindingRuleCurrentByRulesetKeyAndRuleKey(ctx, gen.GetFindingRuleCurrentByRulesetKeyAndRuleKeyParams{
+		RulesetKey: rulesetKey,
+		RuleKey:    ruleKey,
 		ScopeKind:  scope.ScopeKind,
 		SourceKind: scope.SourceKind,
 		SourceName: scope.SourceName,
@@ -473,9 +473,9 @@ func (h *Handlers) HandleFindingsRuleOverride(c *echo.Context) error {
 		return h.RenderError(c, err)
 	}
 
-	r, err := h.Q.GetRuleWithCurrentResultByRulesetKeyAndRuleKey(ctx, gen.GetRuleWithCurrentResultByRulesetKeyAndRuleKeyParams{
-		Key:        rulesetKey,
-		Key_2:      ruleKey,
+	r, err := h.Q.GetFindingRuleCurrentByRulesetKeyAndRuleKey(ctx, gen.GetFindingRuleCurrentByRulesetKeyAndRuleKeyParams{
+		RulesetKey: rulesetKey,
+		RuleKey:    ruleKey,
 		ScopeKind:  scope.ScopeKind,
 		SourceKind: scope.SourceKind,
 		SourceName: scope.SourceName,
@@ -552,9 +552,9 @@ func (h *Handlers) HandleFindingsRuleAttestation(c *echo.Context) error {
 		return h.RenderError(c, err)
 	}
 
-	r, err := h.Q.GetRuleWithCurrentResultByRulesetKeyAndRuleKey(ctx, gen.GetRuleWithCurrentResultByRulesetKeyAndRuleKeyParams{
-		Key:        rulesetKey,
-		Key_2:      ruleKey,
+	r, err := h.Q.GetFindingRuleCurrentByRulesetKeyAndRuleKey(ctx, gen.GetFindingRuleCurrentByRulesetKeyAndRuleKeyParams{
+		RulesetKey: rulesetKey,
+		RuleKey:    ruleKey,
 		ScopeKind:  scope.ScopeKind,
 		SourceKind: scope.SourceKind,
 		SourceName: scope.SourceName,
@@ -969,7 +969,7 @@ func parseDatetimeLocal(v string) (pgtype.Timestamptz, error) {
 	return pgtype.Timestamptz{Time: t, Valid: true}, nil
 }
 
-func (h *Handlers) buildFindingsRuleViewData(ctx context.Context, c *echo.Context, rs gen.Ruleset, r gen.GetRuleWithCurrentResultByRulesetKeyAndRuleKeyRow, scope findingsScope, alert *viewmodels.AlertViewData) (viewmodels.FindingsRuleViewData, error) {
+func (h *Handlers) buildFindingsRuleViewData(ctx context.Context, c *echo.Context, rs gen.Ruleset, r gen.GetFindingRuleCurrentByRulesetKeyAndRuleKeyRow, scope findingsScope, alert *viewmodels.AlertViewData) (viewmodels.FindingsRuleViewData, error) {
 	layout, _, err := h.LayoutData(ctx, c, strings.TrimSpace(rs.Name))
 	if err != nil {
 		return viewmodels.FindingsRuleViewData{}, err
@@ -1033,7 +1033,7 @@ func (h *Handlers) buildFindingsRuleViewData(ctx context.Context, c *echo.Contex
 	}, nil
 }
 
-func (h *Handlers) renderRuleWithAlert(c *echo.Context, rs gen.Ruleset, r gen.GetRuleWithCurrentResultByRulesetKeyAndRuleKeyRow, scope findingsScope, alert viewmodels.AlertViewData) error {
+func (h *Handlers) renderRuleWithAlert(c *echo.Context, rs gen.Ruleset, r gen.GetFindingRuleCurrentByRulesetKeyAndRuleKeyRow, scope findingsScope, alert viewmodels.AlertViewData) error {
 	ctx := c.Request().Context()
 
 	data, err := h.buildFindingsRuleViewData(ctx, c, rs, r, scope, &alert)

--- a/internal/http/handlers/findings_integration_test.go
+++ b/internal/http/handlers/findings_integration_test.go
@@ -154,15 +154,25 @@ func TestHandleFindingsRuleUsesConcreteConnectorSourceScope(t *testing.T) {
 		rule := seedRuleForFindingsHandler(t, ctx, q, ruleset.ID, "001-detail")
 
 		evaluatedAt := time.Date(2026, time.May, 21, 9, 0, 0, 0, time.UTC)
+		canonical := canonicalRuleFindingForHandler(ruleset.Key, rule, "fail", findings.StatusOpen, evaluatedAt)
+		canonical.Output["evidence"] = map[string]any{
+			"schema_version": 1,
+			"check": map[string]any{
+				"type": "manual",
+			},
+		}
+		if err := findings.NewWriter(q).Write(ctx, canonical); err != nil {
+			t.Fatalf("Write(canonical detail) err = %v", err)
+		}
 		if _, err := q.UpsertRuleResultCurrent(ctx, gen.UpsertRuleResultCurrentParams{
 			RuleID:              rule.ID,
 			ScopeKind:           "connector_instance",
 			SourceKind:          "okta",
 			SourceName:          "example.okta.com",
-			Status:              "fail",
-			EvaluatedAt:         pgtype.Timestamptz{Time: evaluatedAt, Valid: true},
-			EvidenceSummary:     "source-specific current result",
-			EvidenceJson:        []byte(`{"schema_version":1,"check":{"type":"manual"}}`),
+			Status:              "pass",
+			EvaluatedAt:         pgtype.Timestamptz{Time: evaluatedAt.Add(time.Hour), Valid: true},
+			EvidenceSummary:     "legacy current result should be ignored",
+			EvidenceJson:        []byte(`{"legacy":true}`),
 			AffectedResourceIds: []string{},
 		}); err != nil {
 			t.Fatalf("UpsertRuleResultCurrent() err = %v", err)
@@ -203,10 +213,13 @@ func TestHandleFindingsRuleUsesConcreteConnectorSourceScope(t *testing.T) {
 		}
 
 		body := rec.Body.String()
-		for _, want := range []string{"example.okta.com", "source-specific current result", "source-specific attestation"} {
+		for _, want := range []string{"example.okta.com", "canonical fail", "source-specific attestation"} {
 			if !strings.Contains(body, want) {
 				t.Fatalf("body missing %q:\n%s", want, body)
 			}
+		}
+		if strings.Contains(body, "legacy current result should be ignored") {
+			t.Fatalf("rule detail used rule_results_current evidence:\n%s", body)
 		}
 		if strings.Contains(body, "Unknown") {
 			t.Fatalf("rule detail fell back to unknown status:\n%s", body)
@@ -220,15 +233,15 @@ func TestHandleFindingsRuleUsesConcreteConnectorSourceScope(t *testing.T) {
 			t.Fatalf("concrete SourceName = %q, want example.okta.com", scope.SourceName)
 		}
 
-		row, err := q.GetRuleWithCurrentResultByRulesetKeyAndRuleKey(ctx, gen.GetRuleWithCurrentResultByRulesetKeyAndRuleKeyParams{
-			Key:        ruleset.Key,
-			Key_2:      rule.Key,
+		row, err := q.GetFindingRuleCurrentByRulesetKeyAndRuleKey(ctx, gen.GetFindingRuleCurrentByRulesetKeyAndRuleKeyParams{
+			RulesetKey: ruleset.Key,
+			RuleKey:    rule.Key,
 			ScopeKind:  scope.ScopeKind,
 			SourceKind: scope.SourceKind,
 			SourceName: scope.SourceName,
 		})
 		if err != nil {
-			t.Fatalf("GetRuleWithCurrentResultByRulesetKeyAndRuleKey() err = %v", err)
+			t.Fatalf("GetFindingRuleCurrentByRulesetKeyAndRuleKey() err = %v", err)
 		}
 		data, err := h.buildFindingsRuleViewData(ctx, c, ruleset, row, scope, nil)
 		if err != nil {
@@ -236,6 +249,9 @@ func TestHandleFindingsRuleUsesConcreteConnectorSourceScope(t *testing.T) {
 		}
 		if data.CurrentStatus != "fail" {
 			t.Fatalf("CurrentStatus = %q, want fail", data.CurrentStatus)
+		}
+		if data.Evidence.CheckType != "manual" {
+			t.Fatalf("Evidence.CheckType = %q, want manual", data.Evidence.CheckType)
 		}
 		if data.RuleOverride.Enabled {
 			t.Fatalf("RuleOverride.Enabled = true, want false")

--- a/internal/http/handlers/settings_connector_health_test.go
+++ b/internal/http/handlers/settings_connector_health_test.go
@@ -32,9 +32,6 @@ func (d connectorHealthTestDefinition) DecodeConfig([]byte) (any, error)        
 func (d connectorHealthTestDefinition) ValidateConfig(any) error                      { return nil }
 func (d connectorHealthTestDefinition) IsConfigured(any) bool                         { return true }
 func (d connectorHealthTestDefinition) SourceName(any) string                         { return "" }
-func (d connectorHealthTestDefinition) DefaultSubtitle() string                       { return "" }
-func (d connectorHealthTestDefinition) ConfiguredSubtitle(any) string                 { return "" }
-func (d connectorHealthTestDefinition) SettingsHref() string                          { return "/settings/connectors" }
 func (d connectorHealthTestDefinition) MetricsProvider() connregistry.MetricsProvider { return nil }
 func (d connectorHealthTestDefinition) NewIntegration(any) (connregistry.Integration, error) {
 	return nil, nil

--- a/internal/http/routes_api.go
+++ b/internal/http/routes_api.go
@@ -7,7 +7,7 @@ import (
 
 func (es *EchoServer) registerAPIRoutes() {
 	api := es.e.Group("/api")
-	api.Use(es.sessionMiddleware()...)
+	api.Use(es.browserMiddleware()...)
 	api.Use(authn.RequireAuth(es.h.Sessions, es.h.Q))
 	api.Use(authn.RequireRole(auth.RoleAdmin))
 

--- a/internal/http/routes_api.go
+++ b/internal/http/routes_api.go
@@ -7,7 +7,7 @@ import (
 
 func (es *EchoServer) registerAPIRoutes() {
 	api := es.e.Group("/api")
-	api.Use(es.browserMiddleware()...)
+	api.Use(es.sessionMiddleware()...)
 	api.Use(authn.RequireAuth(es.h.Sessions, es.h.Q))
 	api.Use(authn.RequireRole(auth.RoleAdmin))
 

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -281,6 +281,12 @@ func (es *EchoServer) browserMiddleware() []echo.MiddlewareFunc {
 	}
 }
 
+func (es *EchoServer) sessionMiddleware() []echo.MiddlewareFunc {
+	return []echo.MiddlewareFunc{
+		echo.WrapMiddleware(es.h.Sessions.LoadAndSave),
+	}
+}
+
 func (es *EchoServer) browserCSRFMiddleware() echo.MiddlewareFunc {
 	return middleware.CSRFWithConfig(middleware.CSRFConfig{
 		TokenLookup:    "header:" + echo.HeaderXCSRFToken + ",form:csrf",

--- a/internal/http/server_test.go
+++ b/internal/http/server_test.go
@@ -305,17 +305,14 @@ func TestRouteSurfacesOwnBrowserMiddleware(t *testing.T) {
 		}
 	})
 
-	t.Run("api post is not blocked by browser csrf", func(t *testing.T) {
+	t.Run("api post keeps browser csrf protection", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "http://example.com/api/identity-resolution/candidates/123/accept", nil)
 		rec := httptest.NewRecorder()
 
 		e.ServeHTTP(rec, req)
 
-		if rec.Code != http.StatusUnauthorized {
-			t.Fatalf("api POST status = %d, want %d", rec.Code, http.StatusUnauthorized)
-		}
-		if !strings.Contains(rec.Header().Get(echo.HeaderContentType), echo.MIMEApplicationJSON) {
-			t.Fatalf("api POST content-type = %q, want JSON", rec.Header().Get(echo.HeaderContentType))
+		if rec.Code != http.StatusBadRequest && rec.Code != http.StatusForbidden {
+			t.Fatalf("api POST status = %d, want CSRF rejection", rec.Code)
 		}
 	})
 

--- a/internal/http/server_test.go
+++ b/internal/http/server_test.go
@@ -305,6 +305,20 @@ func TestRouteSurfacesOwnBrowserMiddleware(t *testing.T) {
 		}
 	})
 
+	t.Run("api post is not blocked by browser csrf", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "http://example.com/api/identity-resolution/candidates/123/accept", nil)
+		rec := httptest.NewRecorder()
+
+		e.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("api POST status = %d, want %d", rec.Code, http.StatusUnauthorized)
+		}
+		if !strings.Contains(rec.Header().Get(echo.HeaderContentType), echo.MIMEApplicationJSON) {
+			t.Fatalf("api POST content-type = %q, want JSON", rec.Header().Get(echo.HeaderContentType))
+		}
+	})
+
 	t.Run("web gets browser login redirect", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "http://example.com/global-view", nil)
 		rec := httptest.NewRecorder()

--- a/internal/ingest/recorddispatch/okta_state_projector.go
+++ b/internal/ingest/recorddispatch/okta_state_projector.go
@@ -17,12 +17,31 @@ import (
 )
 
 type OktaStateProjector struct {
-	q     *gen.Queries
-	runID int64
+	q      *gen.Queries
+	runID  int64
+	counts map[string]int64
 }
 
 func NewOktaStateProjector(q *gen.Queries, runID int64) *OktaStateProjector {
-	return &OktaStateProjector{q: q, runID: runID}
+	return &OktaStateProjector{q: q, runID: runID, counts: make(map[string]int64)}
+}
+
+func (p *OktaStateProjector) Counts() map[string]int64 {
+	out := make(map[string]int64)
+	if p == nil {
+		return out
+	}
+	for key, value := range p.counts {
+		out[key] = value
+	}
+	return out
+}
+
+func (p *OktaStateProjector) addCount(key string, value int64) {
+	if p.counts == nil {
+		p.counts = make(map[string]int64)
+	}
+	p.counts[key] += value
 }
 
 func (p *OktaStateProjector) UpsertState(ctx context.Context, record records.StateUpsert) error {
@@ -97,139 +116,170 @@ func (p *OktaStateProjector) CompleteSnapshot(ctx context.Context, record record
 	runID := registry.PgInt8(p.runID)
 	switch record.Resource {
 	case records.ResourceIdentity:
-		if _, err := p.q.PromoteSourceAccountsSeenInRun(ctx, gen.PromoteSourceAccountsSeenInRunParams{
+		observed, err := p.q.PromoteSourceAccountsSeenInRun(ctx, gen.PromoteSourceAccountsSeenInRunParams{
 			LastObservedRunID: runID,
 			SourceKind:        "okta",
 			SourceName:        record.SourceName(),
-		}); err != nil {
+		})
+		if err != nil {
 			return err
 		}
+		p.addCount("okta_accounts_observed", observed)
 		if record.ExpireAbsent {
-			_, err := p.q.ExpireSourceAccountsNotSeenInRun(ctx, gen.ExpireSourceAccountsNotSeenInRunParams{
+			expired, err := p.q.ExpireSourceAccountsNotSeenInRun(ctx, gen.ExpireSourceAccountsNotSeenInRunParams{
 				ExpiredRunID: runID,
 				SourceKind:   "okta",
 				SourceName:   record.SourceName(),
 			})
+			p.addCount("okta_accounts_expired", expired)
 			return err
 		}
 	case records.ResourceGroup:
-		if _, err := p.q.PromoteOktaGroupsSeenInRunBySource(ctx, gen.PromoteOktaGroupsSeenInRunBySourceParams{
+		observed, err := p.q.PromoteOktaGroupsSeenInRunBySource(ctx, gen.PromoteOktaGroupsSeenInRunBySourceParams{
 			LastObservedRunID: p.runID,
 			SourceKind:        "okta",
 			SourceName:        record.SourceName(),
-		}); err != nil {
+		})
+		if err != nil {
 			return err
 		}
-		if _, err := p.q.PromoteOktaGroupMembershipsSeenInRunBySource(ctx, gen.PromoteOktaGroupMembershipsSeenInRunBySourceParams{
+		p.addCount("okta_groups_observed", observed)
+		observed, err = p.q.PromoteOktaGroupMembershipsSeenInRunBySource(ctx, gen.PromoteOktaGroupMembershipsSeenInRunBySourceParams{
 			LastObservedRunID: p.runID,
 			SourceKind:        "okta",
 			SourceName:        record.SourceName(),
-		}); err != nil {
+		})
+		if err != nil {
 			return err
 		}
+		p.addCount("okta_group_memberships_observed", observed)
 		if record.ExpireAbsent {
-			if _, err := p.q.ExpireOktaGroupsNotSeenInRunBySource(ctx, gen.ExpireOktaGroupsNotSeenInRunBySourceParams{
-				ExpiredRunID: p.runID,
-				SourceKind:   "okta",
-				SourceName:   record.SourceName(),
-			}); err != nil {
-				return err
-			}
-			_, err := p.q.ExpireOktaGroupMembershipsNotSeenInRunBySource(ctx, gen.ExpireOktaGroupMembershipsNotSeenInRunBySourceParams{
+			expired, err := p.q.ExpireOktaGroupsNotSeenInRunBySource(ctx, gen.ExpireOktaGroupsNotSeenInRunBySourceParams{
 				ExpiredRunID: p.runID,
 				SourceKind:   "okta",
 				SourceName:   record.SourceName(),
 			})
+			if err != nil {
+				return err
+			}
+			p.addCount("okta_groups_expired", expired)
+			expired, err = p.q.ExpireOktaGroupMembershipsNotSeenInRunBySource(ctx, gen.ExpireOktaGroupMembershipsNotSeenInRunBySourceParams{
+				ExpiredRunID: p.runID,
+				SourceKind:   "okta",
+				SourceName:   record.SourceName(),
+			})
+			p.addCount("okta_group_memberships_expired", expired)
 			return err
 		}
 	case records.ResourceApplication:
-		if _, err := p.q.PromoteOktaAppsSeenInRunBySource(ctx, gen.PromoteOktaAppsSeenInRunBySourceParams{
+		observed, err := p.q.PromoteOktaAppsSeenInRunBySource(ctx, gen.PromoteOktaAppsSeenInRunBySourceParams{
 			LastObservedRunID: p.runID,
 			SourceKind:        "okta",
 			SourceName:        record.SourceName(),
-		}); err != nil {
+		})
+		if err != nil {
 			return err
 		}
+		p.addCount("okta_apps_observed", observed)
 		if record.ExpireAbsent {
-			_, err := p.q.ExpireOktaAppsNotSeenInRunBySource(ctx, gen.ExpireOktaAppsNotSeenInRunBySourceParams{
+			expired, err := p.q.ExpireOktaAppsNotSeenInRunBySource(ctx, gen.ExpireOktaAppsNotSeenInRunBySourceParams{
 				ExpiredRunID: p.runID,
 				SourceKind:   "okta",
 				SourceName:   record.SourceName(),
 			})
+			p.addCount("okta_apps_expired", expired)
 			return err
 		}
 	case records.ResourceEntitlement:
-		if _, err := p.q.PromoteOktaAppAssignmentsSeenInRunBySource(ctx, gen.PromoteOktaAppAssignmentsSeenInRunBySourceParams{
+		observed, err := p.q.PromoteOktaAppAssignmentsSeenInRunBySource(ctx, gen.PromoteOktaAppAssignmentsSeenInRunBySourceParams{
 			LastObservedRunID: p.runID,
 			SourceKind:        "okta",
 			SourceName:        record.SourceName(),
-		}); err != nil {
+		})
+		if err != nil {
 			return err
 		}
-		if _, err := p.q.PromoteOktaAppGroupAssignmentsSeenInRunBySource(ctx, gen.PromoteOktaAppGroupAssignmentsSeenInRunBySourceParams{
+		p.addCount("okta_app_assignments_observed", observed)
+		observed, err = p.q.PromoteOktaAppGroupAssignmentsSeenInRunBySource(ctx, gen.PromoteOktaAppGroupAssignmentsSeenInRunBySourceParams{
 			LastObservedRunID: p.runID,
 			SourceKind:        "okta",
 			SourceName:        record.SourceName(),
-		}); err != nil {
+		})
+		if err != nil {
 			return err
 		}
-		if _, err := p.q.PromoteEntitlementsSeenInRunBySource(ctx, gen.PromoteEntitlementsSeenInRunBySourceParams{
+		p.addCount("okta_app_group_assignments_observed", observed)
+		observed, err = p.q.PromoteEntitlementsSeenInRunBySource(ctx, gen.PromoteEntitlementsSeenInRunBySourceParams{
 			LastObservedRunID: runID,
 			SourceKind:        "okta",
 			SourceName:        record.SourceName(),
-		}); err != nil {
+		})
+		if err != nil {
 			return err
 		}
+		p.addCount("entitlements_observed", observed)
 		if record.ExpireAbsent {
-			if _, err := p.q.ExpireOktaAppAssignmentsNotSeenInRunBySource(ctx, gen.ExpireOktaAppAssignmentsNotSeenInRunBySourceParams{
+			expired, err := p.q.ExpireOktaAppAssignmentsNotSeenInRunBySource(ctx, gen.ExpireOktaAppAssignmentsNotSeenInRunBySourceParams{
 				ExpiredRunID: p.runID,
 				SourceKind:   "okta",
 				SourceName:   record.SourceName(),
-			}); err != nil {
+			})
+			if err != nil {
 				return err
 			}
-			if _, err := p.q.ExpireOktaAppGroupAssignmentsNotSeenInRunBySource(ctx, gen.ExpireOktaAppGroupAssignmentsNotSeenInRunBySourceParams{
+			p.addCount("okta_app_assignments_expired", expired)
+			expired, err = p.q.ExpireOktaAppGroupAssignmentsNotSeenInRunBySource(ctx, gen.ExpireOktaAppGroupAssignmentsNotSeenInRunBySourceParams{
 				ExpiredRunID: p.runID,
 				SourceKind:   "okta",
 				SourceName:   record.SourceName(),
-			}); err != nil {
+			})
+			if err != nil {
 				return err
 			}
-			_, err := p.q.ExpireEntitlementsNotSeenInRunBySource(ctx, gen.ExpireEntitlementsNotSeenInRunBySourceParams{
+			p.addCount("okta_app_group_assignments_expired", expired)
+			expired, err = p.q.ExpireEntitlementsNotSeenInRunBySource(ctx, gen.ExpireEntitlementsNotSeenInRunBySourceParams{
 				ExpiredRunID: runID,
 				SourceKind:   "okta",
 				SourceName:   record.SourceName(),
 			})
+			p.addCount("entitlements_expired", expired)
 			return err
 		}
 	case records.ResourceDiscoveryEvidence:
-		if _, err := p.q.PromoteSaaSAppSourcesSeenInRunBySource(ctx, gen.PromoteSaaSAppSourcesSeenInRunBySourceParams{
+		observed, err := p.q.PromoteSaaSAppSourcesSeenInRunBySource(ctx, gen.PromoteSaaSAppSourcesSeenInRunBySourceParams{
 			LastObservedRunID: p.runID,
 			SourceKind:        "okta",
 			SourceName:        record.SourceName(),
-		}); err != nil {
+		})
+		if err != nil {
 			return err
 		}
-		if _, err := p.q.PromoteSaaSAppEventsSeenInRunBySource(ctx, gen.PromoteSaaSAppEventsSeenInRunBySourceParams{
+		p.addCount("saas_app_sources_observed", observed)
+		observed, err = p.q.PromoteSaaSAppEventsSeenInRunBySource(ctx, gen.PromoteSaaSAppEventsSeenInRunBySourceParams{
 			LastObservedRunID: p.runID,
 			SourceKind:        "okta",
 			SourceName:        record.SourceName(),
-		}); err != nil {
+		})
+		if err != nil {
 			return err
 		}
+		p.addCount("saas_app_events_observed", observed)
 		if record.ExpireAbsent {
-			if _, err := p.q.ExpireSaaSAppSourcesNotSeenInRunBySource(ctx, gen.ExpireSaaSAppSourcesNotSeenInRunBySourceParams{
-				ExpiredRunID: p.runID,
-				SourceKind:   "okta",
-				SourceName:   record.SourceName(),
-			}); err != nil {
-				return err
-			}
-			_, err := p.q.ExpireSaaSAppEventsNotSeenInRunBySource(ctx, gen.ExpireSaaSAppEventsNotSeenInRunBySourceParams{
+			expired, err := p.q.ExpireSaaSAppSourcesNotSeenInRunBySource(ctx, gen.ExpireSaaSAppSourcesNotSeenInRunBySourceParams{
 				ExpiredRunID: p.runID,
 				SourceKind:   "okta",
 				SourceName:   record.SourceName(),
 			})
+			if err != nil {
+				return err
+			}
+			p.addCount("saas_app_sources_expired", expired)
+			expired, err = p.q.ExpireSaaSAppEventsNotSeenInRunBySource(ctx, gen.ExpireSaaSAppEventsNotSeenInRunBySourceParams{
+				ExpiredRunID: p.runID,
+				SourceKind:   "okta",
+				SourceName:   record.SourceName(),
+			})
+			p.addCount("saas_app_events_expired", expired)
 			return err
 		}
 	default:


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes phase one of a refactor that cuts over rule-detail views from the legacy `rule_results_current` read model to the canonical `findings` table, and moves Okta full-sync finalization from `FinalizeOktaRun` to a new transactional `finalizeOktaRecordSnapshots` path that drives all resource snapshot completions through `OktaStateProjector`.

- **Findings query cutover**: `GetFindingRuleCurrentByRulesetKeyAndRuleKey` is introduced with dual-mode aggregation — `connector_instance` scope aggregates counts across all configured sources while other scopes resolve a single direct finding; four handler call sites and integration tests are updated to verify the legacy `rule_results_current` evidence is ignored.
- **Okta finalization refactor**: `finalizeOktaRecordSnapshots` wraps Identity/Group/Application/Entitlement snapshot completions in a single transaction, tracks per-resource observed/expired counts via `OktaStateProjector.Counts()`, and replaces the `FinalizeOktaRun(…, finalizeDiscovery=false)` call; a new integration test verifies run-to-run expiry and idempotent repeat finalization.
- **Interface slimming**: `DefaultSubtitle`, `ConfiguredSubtitle`, and `SettingsHref` are removed from `ConnectorDefinition`; their logic is centralised into package-level switch functions in `connectorui`, with `SettingsHrefForKind` also used directly by the findings handler.

<h3>Confidence Score: 4/5</h3>

Safe to merge with the noted entitlement double-expiry concern from the previous review still open; the new finalization path is well-tested and idempotency is verified.

The entitlement promote/expire side-effect added to full-run finalization remains unresolved: any entitlement rows not seen in the current full run are now expired during finalization, whereas the old FinalizeOktaRun(finalizeDiscovery=false) path did not do this. If entitlements were intentionally left to the incremental sync phase for expiry, this change could silently over-expire rows in production. The rest of the PR — SQL cutover, interface slimming, count tracking — is clean and covered by tests.

internal/connectors/okta/integration_records.go and internal/ingest/recorddispatch/okta_state_projector.go warrant a second look to confirm entitlement expiry during full-run finalization is intentional and safe.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| db/queries/findings.sql | Adds GetFindingRuleCurrentByRulesetKeyAndRuleKey query reading from canonical findings table with dual-mode aggregation for connector_instance vs single-source scopes. |
| internal/connectors/okta/integration_records.go | Adds finalizeOktaRecordSnapshots, replacing FinalizeOktaRun for full-sync finalization; wraps all resource snapshot completions in a single transaction via OktaStateProjector. |
| internal/ingest/recorddispatch/okta_state_projector.go | Adds per-operation count tracking (observed/expired) to CompleteSnapshot; exposes Counts() with defensive nil-receiver guard and copy-on-read semantics. |
| internal/http/connectorui/state.go | Removes DefaultSubtitle/ConfiguredSubtitle/SettingsHref from ConnectorDefinition interface; centralises subtitle and href logic into package-level switch functions. |
| internal/http/handlers/findings.go | Switches four rule-detail query call sites from legacy GetRuleWithCurrentResultByRulesetKeyAndRuleKey to the new GetFindingRuleCurrentByRulesetKeyAndRuleKey; hintHref now derived directly from SettingsHrefForKind. |
| internal/http/server.go | Adds sessionMiddleware() helper wrapping Sessions.LoadAndSave without CSRF, but the method is not wired to any route group in this PR. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant OktaIntegration
    participant finalizeOktaRecordSnapshots
    participant OktaStateProjector
    participant DB

    OktaIntegration->>finalizeOktaRecordSnapshots: runFull() complete
    finalizeOktaRecordSnapshots->>DB: pool.Begin()
    loop Each resource: Identity, Group, Application, Entitlement
        finalizeOktaRecordSnapshots->>OktaStateProjector: "CompleteSnapshot(expireAbsent=true)"
        OktaStateProjector->>DB: PromoteXxxSeenInRun
        OktaStateProjector->>DB: ExpireXxxNotSeenInRun
        OktaStateProjector-->>finalizeOktaRecordSnapshots: addCount(observed/expired)
    end
    finalizeOktaRecordSnapshots->>DB: FinalizeRunCountsInTx(projector.Counts())
    finalizeOktaRecordSnapshots->>DB: tx.Commit()

    note over OktaIntegration,DB: Rule detail handler (findings.go)
    participant Handler
    participant FindingsQuery
    Handler->>FindingsQuery: GetFindingRuleCurrentByRulesetKeyAndRuleKey
    FindingsQuery->>DB: selected_sources CTE + rule_current CTE (findings table)
    DB-->>Handler: aggregated status / evidence (connector_instance or single-source)
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/connectors/okta/integration_records.go`, line 64-96 ([link](https://github.com/open-sspm/open-sspm/blob/5d08235ac370fd894acf0d6c6f7226abb39c84c1/internal/connectors/okta/integration_records.go#L64-L96)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Entitlement promote/expire now runs in `runFull` finalization — new behavior vs old path**

   `finalizeOktaRecordSnapshots` calls `completeOktaSnapshot(... ResourceEntitlement ... expireAbsent=true)`, which routes to `OktaStateProjector.CompleteSnapshot` and executes `PromoteEntitlementsSeenInRunBySource` + `ExpireEntitlementsNotSeenInRunBySource`. The old `FinalizeOktaRun` path (called with `finalizeDiscovery=false`) never called these queries — it stopped at `okta_app_group_assignments`. This adds a new expiry side-effect to full-run finalization: any entitlement rows not seen in the current run will now be expired by `runFull`. If entitlements were previously promoted/expired only during the incremental sync phase and this finalization path was intentionally left out, running the expiry a second time during finalization could produce unexpected row deletions or double-expire records. Confirm this expiry is safe to run at finalization time and is idempotent with any mid-sync expiry that may have already fired.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/connectors/okta/integration_records.go
   Line: 64-96

   Comment:
   **Entitlement promote/expire now runs in `runFull` finalization — new behavior vs old path**

   `finalizeOktaRecordSnapshots` calls `completeOktaSnapshot(... ResourceEntitlement ... expireAbsent=true)`, which routes to `OktaStateProjector.CompleteSnapshot` and executes `PromoteEntitlementsSeenInRunBySource` + `ExpireEntitlementsNotSeenInRunBySource`. The old `FinalizeOktaRun` path (called with `finalizeDiscovery=false`) never called these queries — it stopped at `okta_app_group_assignments`. This adds a new expiry side-effect to full-run finalization: any entitlement rows not seen in the current run will now be expired by `runFull`. If entitlements were previously promoted/expired only during the incremental sync phase and this finalization path was intentionally left out, running the expiry a second time during finalization could produce unexpected row deletions or double-expire records. Confirm this expiry is safe to run at finalization time and is idempotent with any mid-sync expiry that may have already fired.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/http/server.go:284-288
**Unexported method defined but never called**

`sessionMiddleware()` is added here but has no call sites anywhere in the codebase — grep confirms it is only defined, never invoked. It duplicates the session-load half of `browserMiddleware()` without the CSRF wrapper, which suggests it's scaffolding for API routes that need sessions but not CSRF (phase two work). Until it's wired in, it's dead code that could cause confusion about which middleware stack API routes actually use.


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Clarify Okta finalization entitlement ex..."](https://github.com/open-sspm/open-sspm/commit/f6d018dc99e4ae09708a303914d70e48b67b561e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33812798)</sub>

<!-- /greptile_comment -->